### PR TITLE
Loading class is not removed if no url is provided on the Post page

### DIFF
--- a/client/views/posts/post_submit.js
+++ b/client/views/posts/post_submit.js
@@ -88,10 +88,11 @@ Template.post_submit.events = {
           }else{
               alert("Sorry, couldn't find a title...");
           }
-       });  
+          $(".get-title-link").removeClass("loading");
+       });
     }else{
       alert("Please fill in an URL first!");
+      $(".get-title-link").removeClass("loading");
     }
-    $(".get-title-link").removeClass("loading");
   }
 };


### PR DESCRIPTION
Hi there,

first pull request here, not sure if I'm doing it properly :)

This is a small fix for a bug I found on the Submit Post page, if no URL is provided and you click on the Suggest Title link, an alert shows up but once you close the alert the loading class is still there.

If I did something wrong, please let me know.

Ever daniel
