### PR TITLE
Adjust Logout button size for consistency

### DIFF
--- a/client/css/screen.css
+++ b/client/css/screen.css
@@ -769,7 +769,6 @@ body.pageslide-open {
       font-size: inherit;
       padding: 0;
       height: 26px;
-      margin-right: 10px;
       text-shadow: none; }
 
 /* line 134, ../sass/modules/_header.scss */

--- a/client/sass/modules/_header.scss
+++ b/client/sass/modules/_header.scss
@@ -126,7 +126,6 @@
 			font-size:inherit;
 			padding:0;
 			height:26px;
-			margin-right:10px;
 			text-shadow:none;
 		}
 	}


### PR DESCRIPTION
The Logout button is slightly smaller than the other buttons in the login widget (see pic). Not sure if this is desired, but here is a change that will normalize the width.

![logout](https://f.cloud.github.com/assets/1295565/309389/3a582960-96ff-11e2-928c-f6780ac5703a.png)
