### PR TITLE
update google+ share button style

### DIFF
--- a/client/helpers/config.js
+++ b/client/helpers/config.js
@@ -20,7 +20,7 @@ SharrreOptions={
 	  twitter: true,
 	},
 	buttons: {
-	  googlePlus: {size: 'tall'},
+	  googlePlus: {size: 'tall', annotation:'bubble'},
 	  // facebook: {layout: 'box_count'},
 	  twitter: {
 	    count: 'vertical',


### PR DESCRIPTION
Add "annotation:'bubble'" to googlePlus buttons config to make it behave normally
