### PR TITLE
Set document title to post headline

### DIFF
--- a/client/views/posts/post_page.js
+++ b/client/views/posts/post_page.js
@@ -22,4 +22,6 @@ Template.post_page.rendered = function(){
 		Session.set('scrollToCommentId', null);
 		this.rendered=true;
 	}
+
+	document.title = Posts.findOne(Session.get('selectedPostId')).headline;
 }


### PR DESCRIPTION
Especially on comments pages, it would be useful to have the post headline as the document title. This was done via document.title = ... since the header is not reactive per se in Meteor as I was told.
