### PR TITLE
Make upvote cleanup prior downvote and vice-versa

### DIFF
--- a/lib/vote.js
+++ b/lib/vote.js
@@ -28,11 +28,18 @@
 
     var votePower=getVotePower(user);
     var votedItem = collection.findOne(id);
+    var vote = 1;
+
+    if (hasDownvotedItem(user, collection, id)) {
+      vote += 1;
+      votePower *= 2;
+    }
 
     // Votes & Score
     collection.update({_id: id},{
       $addToSet: {upvoters: user._id},
-      $inc: {votes: 1, baseScore: votePower},
+      $pull: {downvoters: user._id},
+      $inc: {votes: vote, baseScore: votePower},
       $set: {inactive: false}
     });
     if(!this.isSimulation)
@@ -56,11 +63,18 @@
     
     var votePower=getVotePower(user);
     var votedItem = collection.findOne(id);
+    var vote = -1;
+
+    if (hasUpvotedItem(user, collection, id)) {
+      vote -= 1;
+      votePower *= 2;
+    }
 
     // Votes & Score
     collection.update({_id: id},{
       $addToSet: {downvoters: user._id},
-      $inc: {votes: -1, baseScore: -votePower},
+      $pull: {upvoters: user._id},
+      $inc: {votes: vote, baseScore: -votePower},
       $set: {inactive: false}
     });
     if(!this.isSimulation)  


### PR DESCRIPTION
Currently if a user upvotes and then downvotes the same post (or vice-versa), her original vote isn’t cleaned up properly. She will end up being in both the `upvoters` and `downvoters` sets and the score from her votes will total 0.

This commit checks during `upvotePost` and `downvotePost` if the user has performed the opposing action and it updates the Post accordingly, e.g., double the vote strength and cleanup the voters sets.

Note: when I tested it out on localhost, I didn’t see a way to actually downvote within the app, so I tested by manually calling the `upvotePost`, `cancelUpvotePost`, `downvotePost`, and `cancelDownvotePost` methods from my browser’s JS console.
