### PR TITLE
Update epic-light.css to set a minimum height for the 'Message' text ent...

### DIFF
--- a/public/editor/themes/editor/epic-light.css
+++ b/public/editor/themes/editor/epic-light.css
@@ -16,6 +16,8 @@ body {
 	-moz-transition: border-color 500ms;
 	-o-transition: border-color 500ms;
 	transition: border-color 500ms;
+	min-height: 80px;
+
 }
 body:focus{
 	outline: none;


### PR DESCRIPTION
Update epic-light.css to set a minimum height for the 'Message' text entry box

When submitting a post, the 'Message' text entry field starts off smaller than the height of one line. To help make it clear that users can write things in this box I propose setting a min-height for this field.
