### PR TITLE
Prevent weird deploy problem on some versions of node

### DIFF
--- a/smart.json
+++ b/smart.json
@@ -2,6 +2,7 @@
   "meteor": {},
   "packages": {
     "momentjs": {},
+    "crypto-base": {},
     "database-forms": {
       "git": "git://github.com/SachaG/database-forms.git"
     },


### PR DESCRIPTION
Some versions of node have an issue with meteorite. The issue is with the dependencies, for some reason the folders come out blank.

`crypto-base` is a dependency of `crypto-md5` putting it in the packages seems to fix it.

Related: https://github.com/DiscoverMeteor/Microscope/issues/11
