### PR TITLE
Have no title if there isn't a title set instead of undefined

### DIFF
--- a/client/views/common/layout.js
+++ b/client/views/common/layout.js
@@ -32,5 +32,5 @@ Template.layout.rendered = function(){
     // set title
     var title = getSetting("title");
     var tagline = getSetting("tagline");
-    document.title = tagline ? title+': '+tagline : title;
+    document.title = (tagline ? title+': '+tagline : title) || "";
 }


### PR DESCRIPTION
Usually the title is `undefined`. This way it shows the URL instead if nothing is set in settings.
