### PR TITLE
For for #209: createNotifications() is a server-side function now

### DIFF
--- a/collections/comments.js
+++ b/collections/comments.js
@@ -81,41 +81,44 @@ Meteor.methods({
         properties.parentAuthorId = parentComment.userId;
         properties.parentAuthorName = getDisplayName(parentUser);
 
-        // reply notification
-        // do not notify users of their own actions (i.e. they're replying to themselves)
-        if(parentUser._id != user._id){
-          Meteor.call('createNotification', {
-            event: 'newReply', 
-            properties: properties, 
-            userToNotify: parentUser, 
-            userDoingAction: user, 
-            sendEmail: getUserSetting('notifications.replies', false, parentUser)
-          });
-        }
+        if(!this.isSimulation){
+          // reply notification
+          // do not notify users of their own actions (i.e. they're replying to themselves)
+          if(parentUser._id != user._id){
+            createNotification({
+              event: 'newReply',
+              properties: properties,
+              userToNotify: parentUser,
+              userDoingAction: user,
+              sendEmail: getUserSetting('notifications.replies', false, parentUser)
+            });
+          }
 
-        // comment notification
-        // if the original poster is different from the author of the parent comment, notify them too
-        if(postUser._id != user._id && parentComment.userId != post.userId){
-          Meteor.call('createNotification', {
-            event: 'newComment',
-            properties: properties,
-            userToNotify: postUser,
-            userDoingAction: user,
-            sendEmail: getUserSetting('notifications.comments', false, postUser)
-          });
+          // comment notification
+          // if the original poster is different from the author of the parent comment, notify them too
+          if(postUser._id != user._id && parentComment.userId != post.userId){
+            createNotification({
+              event: 'newComment',
+              properties: properties,
+              userToNotify: postUser,
+              userDoingAction: user,
+              sendEmail: getUserSetting('notifications.comments', false, postUser)
+            });
+          }
         }
-
       }else{
-        // root comment
-        // don't notify users of their own comments
-        if(postUser._id != user._id){
-          Meteor.call('createNotification', {
-            event: 'newComment',
-            properties: properties,
-            userToNotify: postUser,
-            userDoingAction: Meteor.user(),
-            sendEmail: getUserSetting('notifications.comments', false, postUser)
-          });
+        if(!this.isSimulation){
+          // root comment
+          // don't notify users of their own comments
+          if(postUser._id != user._id){
+            createNotification({
+              event: 'newComment',
+              properties: properties,
+              userToNotify: postUser,
+              userDoingAction: Meteor.user(),
+              sendEmail: getUserSetting('notifications.comments', false, postUser)
+            });
+          }
         }
       }
     }

--- a/server/invites.js
+++ b/server/invites.js
@@ -24,7 +24,7 @@ Meteor.methods({
       }});
       console.log(a)
 
-      Meteor.call('createNotification', {
+      createNotification({
         event: 'accountApproved', 
         properties: {}, 
         userToNotify: invitedUser, 

--- a/server/notifications.js
+++ b/server/notifications.js
@@ -2,35 +2,36 @@ getUnsubscribeLink = function(user){
   return Meteor.absoluteUrl()+'unsubscribe/'+user.email_hash;
 };
 
-Meteor.methods({
-  createNotification: function(options){
-    var event = options.event,
-        properties = options.properties,
-        userToNotify = options.userToNotify,
-        userDoingAction = options.userDoingAction,
-        sendEmail = options.sendEmail;
-    // console.log('adding new notification for:'+getDisplayName(userToNotify)+', for event:'+event);
-    // console.log(userToNotify);
-    // console.log(userDoingAction);
-    // console.log(properties);
-    // console.log(sendEmail);
-    var notification = {
-      timestamp: new Date().getTime(),
-      userId: userToNotify._id,
-      event: event,
-      properties: properties,
-      read: false
-    }
-    var newNotificationId=Notifications.insert(notification);
+createNotification = function(options) {
+  var event = options.event,
+      properties = options.properties,
+      userToNotify = options.userToNotify,
+      userDoingAction = options.userDoingAction,
+      sendEmail = options.sendEmail;
+  // console.log('adding new notification for:'+getDisplayName(userToNotify)+', for event:'+event);
+  // console.log(userToNotify);
+  // console.log(userDoingAction);
+  // console.log(properties);
+  // console.log(sendEmail);
+  var notification = {
+    timestamp: new Date().getTime(),
+    userId: userToNotify._id,
+    event: event,
+    properties: properties,
+    read: false
+  }
+  var newNotificationId=Notifications.insert(notification);
 
-    // send the notification if notifications are activated,
-    // the notificationsFrequency is set to 1, or if it's undefined (legacy compatibility)
-    if(sendEmail){
-      // get specific notification content for "email" context
-      var contents = getNotificationContents(notification, 'email');     
-      sendNotification(contents);
-    }
-  },
+  // send the notification if notifications are activated,
+  // the notificationsFrequency is set to 1, or if it's undefined (legacy compatibility)
+  if(sendEmail){
+    // get specific notification content for "email" context
+    var contents = getNotificationContents(notification, 'email');     
+    sendNotification(contents);
+  }
+}
+
+Meteor.methods({
   unsubscribeUser : function(hash){
     // TO-DO: currently, if you have somebody's email you can unsubscribe them
     // A user-specific salt should be added to the hashing method to prevent this


### PR DESCRIPTION
See #209 . I've made `createNotifications()` a server-side method, which can be called from server versions of `comment` and `inviteUser` only. Therefore, noone can send a notification to user on behalf of Telescope without actually doing some action.

No latency compensation was available for `createNotifications`, so there was nothing to change in it.

You may find `git diff -w` command useful (it ignores space characters).
