### PR TITLE
User profile edit form: now it's prevented from submit and windows is scrolled to display error/success message

### DIFF
--- a/client/views/users/user_edit.js
+++ b/client/views/users/user_edit.js
@@ -33,7 +33,9 @@ Template.user_edit.helpers({
 
 Template.user_edit.events({
   'submit form': function(e){
+    e.preventDefault();
 
+    clearSeenErrors();
     if(!Meteor.user())
       throwError(i18n.t('You must be logged in.'));
 
@@ -74,6 +76,10 @@ Template.user_edit.events({
       } else {
         throwError(i18n.t('Profile updated'));
       }
+      Deps.afterFlush(function() {
+        var element = $('.grid > .error');
+        $('html, body').animate({scrollTop: element.offset().top});
+      });
     });
   }
 


### PR DESCRIPTION
This should probably fix #196, because if form is submitted, there may be not enough time for changes to be submitted, which may cause absence of changes.

I've added `e.preventDefault()` call to submit handler (such line is presented in every handler except this one) and added scrolling for better UX.
