### PR TITLE
#184: fixed subscription to Notifications collection

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -32,8 +32,14 @@ Meteor.subscribe('currentUser');
 Meteor.subscribe('allUsersAdmin');
 
 // Notifications - only load if user is logged in
-if(Meteor.user() != null)
-  Meteor.subscribe('notifications');
+// Not mandatory, because server won't publish anything even if we try to load.
+// Remember about Deps.autorun - user can log in and log out several times
+Deps.autorun(function() {
+  // userId() can be changed before user(), because loading profile takes time
+  if(Meteor.userId()) {
+    Meteor.subscribe('notifications');
+  }
+})
 
 STATUS_PENDING=1;
 STATUS_APPROVED=2;


### PR DESCRIPTION
This fixes #184 . Somewhy in 9c4f030b909111df0b9acfc7e22b94049a3ff0a8 `Meteor.userId()` was changed by `Meteor.user()` check, which may be null until profile is loaded. That's why notifications broke.

One more problem that I've fixed: if user wasn't logged in and the he signed in, we should notice that and subscribe to notifications. That's why I wrapped this call into `Deps.autorun`
