### PR TITLE
#217: fixed bug with 'You have to be an admin' message displayed to admins

### DIFF
--- a/client/helpers/router.js
+++ b/client/helpers/router.js
@@ -131,6 +131,8 @@ var filters = {
   },
 
   isAdmin: function() {
+    this.subscribe('currentUser').wait();
+    if(!this.ready()) return;
     if(!Meteor.loggingIn() && Session.get('settingsLoaded') && !isAdmin()){
       throwError(i18n.t("Sorry, you  have to be an admin to view this page."))
       this.render('no_rights');


### PR DESCRIPTION
Fixes #217

Bug: router may perform access check before user profile is fully loaded.

Solution: make pages which require user to be admin depend on `currentUser` subscription. AFAIK, router will wait for this subscription and then will reactively re-run `before` callback.
