### PR TITLE
#220: now all pages are waitOn('categories')

### DIFF
--- a/client/helpers/router.js
+++ b/client/helpers/router.js
@@ -92,6 +92,7 @@ Router.configure({
   layoutTemplate: 'layout',
   loadingTemplate: 'loading',
   notFoundTemplate: 'not_found',
+  waitOn: Meteor.subscribe('categories')
 });
 
 //--------------------------------------------------------------------------------------------------//


### PR DESCRIPTION
Fix for #220 . I've added `Categories` to `Router.configure({waitOn: ...})` - now all pages should wait for it before render.
