### PR TITLE
Only show category list on post submit/edit if there are categories

### DIFF
--- a/client/views/posts/post_edit.html
+++ b/client/views/posts/post_edit.html
@@ -24,6 +24,7 @@
           <label class="control-label post-form-body">{{i18n "Body"}}</label>
           <div class="controls" id="editor"><textarea id="body" value="" class="input-xlarge">{{body}}</textarea></div>
         </div>
+        {{#if categoriesEnabled}}
         <div class="control-group post-form-category">
           <label class="control-label">{{i18n "Categories"}}</label>
           <div class="controls">
@@ -34,6 +35,7 @@
             {{/each}}
           </div>
         </div>
+        {{/if}}
         {{#if isAdmin}}
           <div class="control-group post-form-sticky">
             <label class="control-label">{{i18n "Inactive?"}}</label>

--- a/client/views/posts/post_edit.js
+++ b/client/views/posts/post_edit.js
@@ -23,6 +23,9 @@ Template.post_edit.helpers({
       return category;
     });
   },
+  categoriesEnabled: function(){
+    return Categories.find().count();
+  },
   isApproved: function(){
     return this.status == STATUS_APPROVED;
   },

--- a/client/views/posts/post_submit.html
+++ b/client/views/posts/post_submit.html
@@ -14,6 +14,7 @@
         <label class="control-label">{{i18n "Body"}}</label>
         <div class="controls" id="editor"><textarea id="body" value="" class="input-xlarge"/></div>
       </div>
+      {{#if categoriesEnabled}}
       <div class="control-group">
         <label class="control-label">{{i18n "Category"}}</label>
         <div class="controls">
@@ -24,6 +25,7 @@
           {{/each}}
         </div>
       </div>
+      {{/if}}
       {{/constant}}
       {{#if isAdmin}}
         {{#constant}}

--- a/client/views/posts/post_submit.js
+++ b/client/views/posts/post_submit.js
@@ -1,4 +1,7 @@
 Template.post_submit.helpers({
+  categoriesEnabled: function(){
+    return Categories.find().count();
+  },
   categories: function(){
     return Categories.find();
   },


### PR DESCRIPTION
Hey,

Not a big issue but if there have been no categories added to the overall site then don't show the empty categories section in the post submit / edit.

Cheers.
