### PR TITLE
categories are sorted by name

### DIFF
--- a/client/views/admin/categories.js
+++ b/client/views/admin/categories.js
@@ -1,6 +1,6 @@
 Template.categories.helpers({
   categories: function(){
-    return Categories.find();
+    return Categories.find({}, {sort: {name: 1}});
   }
 });
 

--- a/client/views/common/nav.js
+++ b/client/views/common/nav.js
@@ -30,7 +30,7 @@ Template.nav.helpers({
     return Categories.find().count();
   },
   categories: function(){
-    return Categories.find();
+    return Categories.find({}, {sort: {name: 1}});
   },
   categoryLink: function () {
     return getCategoryUrl(this.slug);


### PR DESCRIPTION
Simple change to sort categories in the admin and nav header alphabetically. Makes it easier to quickly parse through longer lists.
