### PR TITLE
fixed issue for broken redirection to template after commment deletion

### DIFF
--- a/client/views/comments/comment_edit.js
+++ b/client/views/comments/comment_edit.js
@@ -36,7 +36,9 @@ Template.comment_edit.events({
     
     if(confirm(i18n.t("Are you sure?"))){
       Meteor.call('removeComment', comment._id);
-      Router.go("/comments/deleted");
+      Router.go("/posts/"+comment.post)
+      throwError("Your comment has been deleted.");
+//      Router.go("/comments/deleted");
     }
   }
 });


### PR DESCRIPTION
When you delete a comment , you are not redirected to 'comment/deleted' template instead get following error in browser console-

`Exception from Deps recompute: TypeError: Cannot read property 'post' of undefined
    at Object.Template.comment_page.helpers.post (http://localhost:3000/client/views/comments/comment_page.js?d4b21efd672dd1d21b9818946769287a3e5cf8c2:3:38)
    at apply (http://localhost:3000/packages/handlebars.js?c2b75d49875b4cfcc7544447aad117fd81fccf3b:276:24)
    at invoke (http://localhost:3000/packages/handlebars.js?c2b75d49875b4cfcc7544447aad117fd81fccf3b:293:18)
    at http://localhost:3000/packages/handlebars.js?c2b75d49875b4cfcc7544447aad117fd81fccf3b:385:27
    at Object.Spark.labelBranch (http://localhost:3000/packages/spark.js?3a050592ceb34d6c585c70f1df11e353610be0ab:1171:14)
    at branch (http://localhost:3000/packages/handlebars.js?c2b75d49875b4cfcc7544447aad117fd81fccf3b:355:20)
    at http://localhost:3000/packages/handlebars.js?c2b75d49875b4cfcc7544447aad117fd81fccf3b:384:20
    at Array.forEach (native)
    at Function._.each._.forEach (http://localhost:3000/packages/underscore.js?13ab483e8a3c795d9991577e65e811cd0b827997:130:11)
    at template (http://localhost:3000/packages/handlebars.js?c2b75d49875b4cfcc7544447aad117fd81fccf3b:358:7)`

Now, what i did redirected to original post message with error msg.
