### PR TITLE
Translations variable change to object

### DIFF
--- a/packages/telescope-i18n/i18n.js
+++ b/packages/telescope-i18n/i18n.js
@@ -1,6 +1,6 @@
 i18n = {
 
-  translations: [],
+  translations: {},
 
   t: function (str) {
     var lang = getSetting('language', 'en');


### PR DESCRIPTION
Translations is referenced with i18n.translations[lang][str],
so it should be changed to be an object.

I think it should be used something like below.

e.g.
translations: {
    kr:{
      'Please fill in a headline': '빈칸 채우라고'
    }
  }
