### PR TITLE
Changed the default sign-in route from /signin to /sign-in

### DIFF
--- a/client/views/posts/modules/post_upvote.js
+++ b/client/views/posts/modules/post_upvote.js
@@ -15,7 +15,7 @@ Template[getTemplate('postUpvote')].events({
     var post = this;
     e.preventDefault();
     if(!Meteor.user()){
-      Router.go('/signin');
+      Router.go('/sign-in');
       throwError(i18n.t("Please log in first"));
     }
     Meteor.call('upvotePost', post, function(error, result){


### PR DESCRIPTION
When the user is not logged in, and clicks "up-vote", the user experience should be consistent. Not sure if /signin is even needed.
