### PR TITLE
changed data.commentsCount to commentCount

### DIFF
--- a/collections/comments.js
+++ b/collections/comments.js
@@ -135,7 +135,7 @@ Meteor.methods({
 
     // increment comment count
     Meteor.users.update({_id: user._id}, {
-      $inc:       {'data.commentsCount': 1}
+      $inc:       {'commentCount': 1}
     });
 
     // extend comment with newly created _id
@@ -192,7 +192,7 @@ Meteor.methods({
 
       // decrement user comment count and remove comment ID from user
       Meteor.users.update({_id: comment.userId}, {
-        $inc:   {'data.commentsCount': -1}
+        $inc:   {'commentCount': -1}
       });
 
       // note: should we also decrease user's comment karma ?

--- a/server/migrations.js
+++ b/server/migrations.js
@@ -364,5 +364,16 @@ var migrationsList = {
       console.log("---------------------");
     });
     return i;
+  },
+  userDataCommentsCountToCommentCount: function(){
+    var i = 0;
+    Meteor.users.find({'data.commentsCount': {$exists: true}}).forEach(function(user){
+      i++;
+      var commentCount = Comments.find({userId: user._id}).count();
+      console.log("User: "+user._id);
+      Meteor.users.update(user._id, {$unset: {data: ""}, $set: {'commentCount': commentCount}});
+      console.log("---------------------");
+    });
+    return i;
   }
 }


### PR DESCRIPTION
posting comments currently increase a data.commentsCount property on the user which does not exist (or is displayed anywhere). So currently the commentcount of a user is not being properly tracked. 

I changed it to the proper commentCount and performed a migration to remove the entire data key (because i couldnt find any other place it was used) and updates the comment count on the users which had the 'data.commentCount' key set (with the assumption that all the others are fine)
