### PR TITLE
Fix header logo position

### DIFF
--- a/packages/telescope-theme-base/lib/client/css/screen.css
+++ b/packages/telescope-theme-base/lib/client/css/screen.css
@@ -616,7 +616,7 @@ li {
       .logo a {
         font-size: 24px;
         display: block;
-        position: absolute;
+        position: static;
         width: 100%;
         height: 50px;
         line-height: 50px;

--- a/packages/telescope-theme-base/lib/client/scss/specific/_header.scss
+++ b/packages/telescope-theme-base/lib/client/scss/specific/_header.scss
@@ -44,7 +44,7 @@ $mobile-header-height: 50px;
     a{
       font-size: 24px;
       display: block;
-      position: absolute;
+      position: static;
       width: 100%;
       height: $mobile-header-height;
       line-height: $mobile-header-height;


### PR DESCRIPTION
logo position was wonky between 30em and 40em screen widths -- noticed it on my phone in landscape orientation

Here's what it looks like on crater.io (where I also submitted a PR)
![](https://cloud.githubusercontent.com/assets/5376785/4122718/65c739b4-32c7-11e4-9534-40b46a946483.png)

Also, it seems kind of weird to have the source scss files and the resulting CodeKit-generated css files all in source control. I guess there weren't any good Sass packages for Meteor back when Sacha first wrote Telescope? Since this was such a small change, I just manually edited both the source _header.scss and resulting screen.css files. I don't have CodeKit (running Linux here), and I didn't want to regenerate the css with a different Sass preprocessor and introduce a bunch of trivial changes.

Cheers!
Ben
