### PR TITLE
fix email hash of gravatar

### DIFF
--- a/lib/gravatar.js
+++ b/lib/gravatar.js
@@ -6,7 +6,7 @@ Gravatar = {
 
       var protocol = options.secure ? 'https' : 'http';
       delete options.secure;
-      var hash = user.email_hash;
+      var hash = CryptoJS.MD5(getEmail(Meteor.user()).trim().toLowerCase()).toString();
       var url = protocol + '://www.gravatar.com/avatar/' + hash;
 
       var params = _.map(options, function(val, key) { return key + "=" + val;}).join('&');


### PR DESCRIPTION
currently `email_hash` is generated from `getEmail(user).trim().toLowerCase() + user.createdAt`. 
I didnt change email_hash logic because it was used in some other places as well.
