### PR TITLE
Corrected path to /forgot-password

### DIFF
--- a/client/views/users/user_edit.html
+++ b/client/views/users/user_edit.html
@@ -95,7 +95,7 @@
       </div>
       {{/if}}
       <div class="form-actions">
-        <a href="/forgot_password">{{i18n "Forgot password?"}}</a>
+        <a href="/forgot-password">{{i18n "Forgot password?"}}</a>
         <input type="submit" class="button" value="{{i18n "Submit"}}" />
       </div>
     </form>


### PR DESCRIPTION
needed to be hyphenated rather than underscored
