### PR TITLE
Fixes #415: prevent invalid up/downvotes when concurrent requests

### DIFF
--- a/lib/vote.js
+++ b/lib/vote.js
@@ -49,36 +49,38 @@
     cancelDownvote(collection, item, user);
 
     // Votes & Score
-    var result = collection.update({_id: item && item._id},{
+    var result = collection.update({_id: item && item._id, upvoters: {$not: {$in: [user._id]}}},{
       $addToSet: {upvoters: user._id},
       $inc: {upvotes: 1, baseScore: votePower},
       $set: {inactive: false}
     });
 
-    // Add item to list of upvoted items
-    var vote = {
-      itemId: item._id,
-      votedAt: new Date(),
-      power: votePower
-    };
-    addVote(user._id, vote, collectionName, 'up');
+    if (result > 0) {
+      // Add item to list of upvoted items
+      var vote = {
+        itemId: item._id,
+        votedAt: new Date(),
+        power: votePower
+      };
+      addVote(user._id, vote, collectionName, 'up');
 
-    // extend item with baseScore to help calculate newScore
-    item = _.extend(item, {baseScore: (item.baseScore + votePower)});
-    updateScore({collection: collection, item: item, forceUpdate: true});
+      // extend item with baseScore to help calculate newScore
+      item = _.extend(item, {baseScore: (item.baseScore + votePower)});
+      updateScore({collection: collection, item: item, forceUpdate: true});
 
-    // if the item is being upvoted by its own author, don't give karma
-    if (item.userId != user._id){
-      modifyKarma(item.userId, votePower);
+      // if the item is being upvoted by its own author, don't give karma
+      if (item.userId != user._id){
+        modifyKarma(item.userId, votePower);
       
-      // if karma redistribution is enabled, give karma to all previous upvoters of the post 
-      // (but not to the person doing the upvoting)
-      if(getSetting('redistributeKarma', false)){
-        _.each(item.upvoters, function(upvoterId){
-          // share the karma equally among all upvoters, but cap the value at 0.1
-          var karmaIncrease = Math.min(0.1, votePower/item.upvoters.length);
-          modifyKarma(upvoterId, 0.1);
-        });
+        // if karma redistribution is enabled, give karma to all previous upvoters of the post 
+        // (but not to the person doing the upvoting)
+        if(getSetting('redistributeKarma', false)){
+          _.each(item.upvoters, function(upvoterId){
+            // share the karma equally among all upvoters, but cap the value at 0.1
+            var karmaIncrease = Math.min(0.1, votePower/item.upvoters.length);
+            modifyKarma(upvoterId, 0.1);
+          });
+        }
       }
     }
     // console.log(collection.findOne(item._id));
@@ -98,28 +100,29 @@
     cancelUpvote(collection, item, user);
 
     // Votes & Score
-    collection.update({_id: item && item._id},{
+    var result = collection.update({_id: item && item._id, downvoters: {$not: {$in: [user._id]}}},{
       $addToSet: {downvoters: user._id},
       $inc: {downvotes: 1, baseScore: -votePower},
       $set: {inactive: false}
     });
 
-    // Add item to list of downvoted items
-    var vote = {
-      itemId: item._id,
-      votedAt: new Date(),
-      power: votePower
-    };
-    addVote(user._id, vote, collectionName, 'down');
+    if (result > 0) {
+      // Add item to list of downvoted items
+      var vote = {
+        itemId: item._id,
+        votedAt: new Date(),
+        power: votePower
+      };
+      addVote(user._id, vote, collectionName, 'down');
 
-    // extend item with baseScore to help calculate newScore
-    item = _.extend(item, {baseScore: (item.baseScore + votePower)});
-    updateScore({collection: collection, item: item, forceUpdate: true});
+      // extend item with baseScore to help calculate newScore
+      item = _.extend(item, {baseScore: (item.baseScore + votePower)});
+      updateScore({collection: collection, item: item, forceUpdate: true});
 
-    // if the item is being upvoted by its own author, don't give karma
-    if (item.userId != user._id)
-      modifyKarma(item.userId, votePower);
-
+      // if the item is being upvoted by its own author, don't give karma
+      if (item.userId != user._id)
+        modifyKarma(item.userId, votePower);
+    }
     // console.log(collection.findOne(item._id));
     return true;
   };
@@ -134,23 +137,24 @@
       return false;
 
     // Votes & Score
-    collection.update({_id: item && item._id},{
+    var result = collection.update({_id: item && item._id, upvoters: { $in: [user._id]}},{
       $pull: {upvoters: user._id},
       $inc: {upvotes: -1, baseScore: -votePower},
       $set: {inactive: false}
     });
 
-    // Remove item from list of upvoted items
-    removeVote(user._id, item._id, collectionName, 'up');
+    if (result > 0) {
+      // Remove item from list of upvoted items
+      removeVote(user._id, item._id, collectionName, 'up');
 
-    // extend item with baseScore to help calculate newScore
-    item = _.extend(item, {baseScore: (item.baseScore + votePower)});
-    updateScore({collection: collection, item: item, forceUpdate: true});
+      // extend item with baseScore to help calculate newScore
+      item = _.extend(item, {baseScore: (item.baseScore + votePower)});
+      updateScore({collection: collection, item: item, forceUpdate: true});
 
-    // if the item is being upvoted by its own author, don't give karma
-    if (item.userId != user._id)
-      modifyKarma(item.userId, votePower);
-    
+      // if the item is being upvoted by its own author, don't give karma
+      if (item.userId != user._id)
+        modifyKarma(item.userId, votePower);
+    }
     // console.log(collection.findOne(item._id));
     return true;
   };
@@ -165,23 +169,24 @@
       return false;
     
     // Votes & Score
-    collection.update({_id: item && item._id},{
+    var result = collection.update({_id: item && item._id, downvoters: {$in: [user._id]}},{
       $pull: {downvoters: user._id},
       $inc: {downvotes: 1, baseScore: votePower},
       $set: {inactive: false}
     });
     
-    // Remove item from list of downvoted items
-    removeVote(user._id, item._id, collectionName, 'down');
+    if (result > 0) {
+      // Remove item from list of downvoted items
+      removeVote(user._id, item._id, collectionName, 'down');
 
-    // extend item with baseScore to help calculate newScore
-    item = _.extend(item, {baseScore: (item.baseScore + votePower)});
-    updateScore({collection: collection, item: item, forceUpdate: true});
+      // extend item with baseScore to help calculate newScore
+      item = _.extend(item, {baseScore: (item.baseScore + votePower)});
+      updateScore({collection: collection, item: item, forceUpdate: true});
 
-    // if the item is being upvoted by its own author, don't give karma
-    if (item.userId != user._id)
-      modifyKarma(item.userId, votePower);
-    
+      // if the item is being upvoted by its own author, don't give karma
+      if (item.userId != user._id)
+        modifyKarma(item.userId, votePower);
+    }
     // console.log(collection.findOne(item._id));
     return true;
   };


### PR DESCRIPTION
Fixes #415 : do not update up/downvotes counters server-side when up/downvoters have been modified in the meantime. Ex: concurrent upvote and cancelUpvote HTTP requests at once, when the user clicks button several times in a row.

Please review this fix.
