### PR TITLE
fix #401 profile url collisions

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -71,9 +71,8 @@ getPostCommentUrl = function(postId, commentId){
 };
 slugify = function(text) {
   if(text){
-    text = text.replace(/[^-a-zA-Z0-9,&\s]+/ig, '');
-    text = text.replace(/-/gi, "_");
-    text = text.replace(/\s/gi, "-");
+    text = text.replace(/[^-_a-zA-Z0-9,&\s]+/ig, '');
+    text = text.replace(/\s/gi, "+");
     text = text.toLowerCase();
   }
   return text;


### PR DESCRIPTION
Added the underscore. Keeping -'s and _'s as is, replacing \s's with +'s. Won't result in collisions if inputs are limited to the whitelisted character ranges.
