### PR TITLE
Fully abstract isAdmin

### DIFF
--- a/client/views/comments/comment_item.html
+++ b/client/views/comments/comment_item.html
@@ -25,7 +25,7 @@
             {{#if can_edit}}
               | <a class="edit-link" href="/comments/{{_id}}/edit">{{i18n "Edit"}}</a>
             {{/if}}
-            {{#if currentUser.isAdmin}}
+            {{#if isAdmin}}
               | <span>{{full_date}}</span>
             {{/if}}
           </div>

--- a/client/views/comments/comment_item.js
+++ b/client/views/comments/comment_item.js
@@ -81,7 +81,7 @@ Template[getTemplate('comment_item')].helpers({
   },
   can_edit: function(){
     if(this.userId && Meteor.userId())
-      return Meteor.user().isAdmin || (Meteor.userId() === this.userId);
+      return isAdmin(Meteor.user()) || (Meteor.userId() === this.userId);
     else
       return false;
   },

--- a/client/views/posts/modules/post_admin.html
+++ b/client/views/posts/modules/post_admin.html
@@ -1,5 +1,5 @@
 <template name="postAdmin">
-  {{#if currentUser.isAdmin}}
+  {{#if isAdmin}}
     <div class="post-meta-item">
       {{#if postsMustBeApproved}}
         |

--- a/client/views/users/user_item.js
+++ b/client/views/users/user_item.js
@@ -44,19 +44,11 @@ Template[getTemplate('user_item')].events({
   },
   'click .admin-link': function(e, instance){
     e.preventDefault();
-    Meteor.users.update(instance.data._id,{
-      $set:{
-        isAdmin: true
-      }
-    });
+    updateAdmin(instance.data._id, true);
   },
   'click .unadmin-link': function(e, instance){
     e.preventDefault();
-    Meteor.users.update(instance.data._id,{
-      $set:{
-        isAdmin: false
-      }
-    });
+    updateAdmin(instance.data._id, false);
   },
   'click .delete-link': function(e, instance){
     e.preventDefault();

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -41,13 +41,13 @@ getUsersParameters = function(filterBy, sortBy, limit) {
   switch(filterBy){
     case 'invited':
       // consider admins as invited
-      find = {$or: [{isInvited: true}, {isAdmin: true}]};
+      find = {$or: [{isInvited: true}, adminMongoQuery]};
       break;
     case 'uninvited':
-      find = {$and: [{isInvited: false}, {isAdmin: false}]};
+      find = {$and: [{isInvited: false}, notAdminMongoQuery]};
       break;
     case 'admin':
-      find = {isAdmin: true};
+      find = adminMongoQuery;
       break;
   }
 

--- a/lib/users.js
+++ b/lib/users.js
@@ -6,6 +6,13 @@ isAdmin=function(user){
   user = (typeof user === 'undefined') ? Meteor.user() : user;
   return !!user && !!user.isAdmin;
 };
+setAdmin = function(user, admin){
+  user = (typeof user === 'undefined') ? Meteor.user() : user;
+  user.isAdmin = !!admin;
+};
+updateAdmin = function(userId, admin) {
+  Meteor.users.update(userId, {$set: {isAdmin: admin}});
+};
 isInvited=function(user){
   if(!user || typeof user === 'undefined')
     return false;

--- a/lib/vote.js
+++ b/lib/vote.js
@@ -1,7 +1,7 @@
 
   // returns how much "power" a user's votes have
   var getVotePower = function(user){
-    // return (user && user.isAdmin) ? 5 : 1;
+    // return isAdmin(user) ? 5 : 1;
     return 1; // for now, leave everybody at 1 including admins; 5 is too unbalanced
   };
 

--- a/packages/telescope-search/lib/search.js
+++ b/packages/telescope-search/lib/search.js
@@ -16,18 +16,12 @@ Searches = new Meteor.Collection("searches", {
   })
 });
 
-Searches.allow({
-  update: isAdminById
-, remove: isAdminById
+Meteor.startup(function() {
+  Searches.allow({
+    update: isAdminById
+  , remove: isAdminById
+  });
 });
-
-// XXX
-// TODO: find a way to make the package use the same isAdminById as the rest of the app
-isAdminById=function(userId){
-  var user = Meteor.users.findOne(userId);
-  return !!(user && isAdmin(user));
-};
-
 
 // search post list parameters
 viewParameters.search = function (terms, baseParameters) {

--- a/server/users.js
+++ b/server/users.js
@@ -3,7 +3,6 @@ Accounts.onCreateUser(function(options, user){
     profile: options.profile || {},
     karma: 0,
     isInvited: false,
-    isAdmin: false,
     postCount: 0,
     commentCount: 0,
     invitedCount: 0,
@@ -37,8 +36,11 @@ Accounts.onCreateUser(function(options, user){
   user.slug = slugify(getUserName(user));
 
   // if this is the first user ever, make them an admin
-  if (!Meteor.users.find().count() )
-    user.isAdmin = true;
+  if (!Meteor.users.find().count() ) {
+    setAdmin(user, true);
+  } else {
+    setAdmin(user, false);
+  }
 
   // give new users a few invites (default to 3)
   user.inviteCount = getSetting('startInvitesCount', 3);
@@ -73,7 +75,7 @@ Accounts.onCreateUser(function(options, user){
   }
 
   // send notifications to admins
-  var admins = Meteor.users.find({isAdmin: true});
+  var admins = adminUsers();
   admins.forEach(function(admin){
     if(getUserSetting('notifications.users', false, admin)){
       var emailProperties = {


### PR DESCRIPTION
We're using a fork with a different definition of "isAdmin" (using
`meteor-roles` rather than the boolean user.isAdmin).  `lib/user.js`
provides abstracted methods for reading admin state, which makes it very
easy to change our definition -- except that the abstractions weren't
used universally.

This commit finishes the job of using the abstractions, and adds a few
new parts to also allow abstracting setting and updating admin-ness:
- setAdmin: sets admin status directly on a user object.
- updateAdmin: executes a mongo update to set admin status.
- adminMongoQuery: the query parameter for admin-ness, for composing
  user queries with other fields.
- notAdminMongoQuery: the query parameter for not-admin-ness.
