### PR TITLE
use author name if user not avalible

### DIFF
--- a/packages/telescope-notifications/lib/herald.js
+++ b/packages/telescope-notifications/lib/herald.js
@@ -53,6 +53,8 @@ Herald.addCourier('newComment', {
       var user = Meteor.users.findOne(this.data.comment.userId);
       if(user)
         return getUserName(user);
+      else
+        return this.data.comment.author;
     },
     postTitle: function () {
       return this.data.post.title;
@@ -90,6 +92,8 @@ Herald.addCourier('newReply', {
       var user = Meteor.users.findOne(this.data.comment.userId);
       if(user)
         return getUserName(user);
+      else
+        return this.data.comment.author;
     },
     postTitle: function () {
       return this.data.post.title;


### PR DESCRIPTION
I just realized I never pushed this fix. Server use up-to-date name and client is able to get the name if user data is available. Change lets client default back to static author name.
