### PR TITLE
[Editing Post] Show the message error when the Title field is left blank

### DIFF
--- a/client/views/posts/post_edit.js
+++ b/client/views/posts/post_edit.js
@@ -90,6 +90,14 @@ Template[getTemplate('post_edit')].events({
       return false;
     }
 
+    var title = $('#title').val();
+
+    if(!title){
+      throwError(i18n.t('Please fill in a title'));
+      $(e.target).removeClass('disabled');
+      return false;
+    }
+
     // ------------------------------ Properties ------------------------------ //
 
     // Basic Properties
@@ -98,7 +106,7 @@ Template[getTemplate('post_edit')].events({
       body = instance.editor.exportFile();
 
     var properties = {
-      title:            $('#title').val(),
+      title:            title,
       url:              url,
       body:             body,
       categories:       []
@@ -182,7 +190,7 @@ Template[getTemplate('post_edit')].events({
       }, function(error){
         if(error){
           console.log(error);
-          throwError(error.reason);
+          throwError(error.message);
           clearSeenErrors();
           $(e.target).removeClass('disabled');
         }else{

--- a/lib/locales/de.js
+++ b/lib/locales/de.js
@@ -79,6 +79,7 @@ i18n.translations.de = {
       "Delete Post": "Link löschen",
       "Thanks, your post is awaiting approval.": "Vielen Dank, Dein Beitrag wartet auf Freischaltung.",
       "Sorry, couldn't find a title...": "Du hast vergessen einen Titel anzugeben...",
+      "Please fill in a title": "Please fill in a title",
       "Please fill in an URL first!": "Du musst eine URL/einen Link angeben!",
 
       // Post item

--- a/lib/locales/en.js
+++ b/lib/locales/en.js
@@ -79,6 +79,7 @@ i18n.translations.en = {
       "Delete Post": "Delete Post",
       "Thanks, your post is awaiting approval.": "Thanks, your post is awaiting approval.",
       "Sorry, couldn't find a title...": "Sorry, couldn't find a title...",
+      "Please fill in a title": "Please fill in a title",
       "Please fill in an URL first!": "Please fill in an URL first!",
 
       // Post item

--- a/lib/locales/es.js
+++ b/lib/locales/es.js
@@ -79,6 +79,7 @@ i18n.translations.es = {
   "Delete Post": "Borrar este post",
   "Thanks, your post is awaiting approval.": "Gracias, su post esta esperando validación.",
   "Sorry, couldn't find a title...": "Lo sentimos, impossible de encontrar este título.",
+  "Please fill in a title": "Please fill in a title",
   "Please fill in an URL first!": "Tienes que poner una URL.",
 
   // Post item

--- a/lib/locales/fr.js
+++ b/lib/locales/fr.js
@@ -79,6 +79,7 @@ i18n.translations.fr = {
   "Delete Post": "Supprimer le post",
   "Thanks, your post is awaiting approval.": "Merci, votre post est en cours de validation",
   "Sorry, couldn't find a title...": "Désolé, impossible de trouver un titre...",
+  "Please fill in a title": "Please fill in a title",
   "Please fill in an URL first!": "Vous devez saisir une URL.",
 
   // Post item

--- a/lib/locales/it.js
+++ b/lib/locales/it.js
@@ -79,6 +79,7 @@ i18n.translations.it = {
       "Delete Post": "Elimina Post",
       "Thanks, your post is awaiting approval.": "Grazie, il tuo post è in attesa di approvazione.",
       "Sorry, couldn't find a title...": "Ci spiace, non riusciamo a trovare un titolo...",
+      "Please fill in a title": "Per favore riempi prima il titolo",
       "Please fill in an URL first!": "Per favore riempi prima l'URL!",
 
       // Post item

--- a/lib/locales/zh.js
+++ b/lib/locales/zh.js
@@ -79,6 +79,7 @@ i18n.translations.zh = {
   "Delete Post": "删除帖子",
   "Thanks, your post is awaiting approval.": "感谢, 你的帖子正在等待批准.",
   "Sorry, couldn't find a title...": "抱歉找不相关话题",
+  "Please fill in a title": "Please fill in a title",
   "Please fill in an URL first!": "请在第一栏填写链接",
 
   // Post item


### PR DESCRIPTION
When editing a post, if the title field is left blank, now show the right alert, actually nothing is shown.

Please translate the message `Please fill in a title` also for these languages: `de.js`, `es.js`, `fr.js`, `zh.js`. Line 82.
