### PR TITLE
Update to use bengott:avatar 0.1.2

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -12,7 +12,7 @@ application-configuration@1.0.2
 autoupdate@1.1.1
 backbone@1.0.0
 base64@1.0.0
-bengott:avatar@0.1.1
+bengott:avatar@0.1.2
 binary-heap@1.0.0
 blaze-tools@1.0.0
 blaze@2.0.1

--- a/client/views/comments/comment_item.html
+++ b/client/views/comments/comment_item.html
@@ -15,7 +15,7 @@
             <span>{{i18n "downvote"}}</span>
           </a>
         </div>
-        <div class="user-avatar">{{>avatar userId=userId cssClass="avatar circle"}}</div>
+        <div class="user-avatar">{{>avatar userId=userId class="circle"}}</div>
         <div class="comment-main">
           <div class="comment-meta">
             <a class="comment-username" href="{{profileUrl}}">{{authorName}}</a>

--- a/client/views/users/user_item.html
+++ b/client/views/users/user_item.html
@@ -1,6 +1,6 @@
 <template name="user_item">
 <tr class="user">
-	<td>{{>avatar user=this cssClass="avatar circle"}}</td>
+	<td>{{>avatar user=this class="circle"}}</td>
 	<td>
 		<a href="{{getProfileUrl}}">{{displayName}}</a>
 		<br/>

--- a/client/views/users/user_profile.html
+++ b/client/views/users/user_profile.html
@@ -3,7 +3,7 @@
 		<div class="user-profile grid grid-module">
 			<table>
 				<tr>
-					<td colspan="2">{{>avatar user=this cssClass="avatar large circle"}}</td>
+					<td colspan="2">{{>avatar user=this class="large circle"}}</td>
 				</tr>
 				{{#if isAdmin}}
 					<tr>

--- a/lib/users.js
+++ b/lib/users.js
@@ -86,7 +86,7 @@ getEmailHash = function(user){
   return CryptoJS.MD5(getEmail(user).trim().toLowerCase()).toString()
 };
 getAvatarUrl = function(user) {
-  console.log('FUNCTION getAvatarUrl() IS DEPRECATED -- package bengott:avatar is used instead.')
+  console.warn('FUNCTION getAvatarUrl() IS DEPRECATED -- package bengott:avatar is used instead.')
   return Avatar.getUrl(user);
 };
 getCurrentUserEmail = function(){


### PR DESCRIPTION
Changes in bengott:avatar 0.1.2
- Merged in PRs adding support for Google, GitHub, and Instagram, also default avatar URL override
- Added support for Gravatar's default (d:) option
