### PR TITLE
Update to bengott:avatar 0.2.1

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -12,7 +12,7 @@ application-configuration@1.0.2
 autoupdate@1.1.1
 backbone@1.0.0
 base64@1.0.0
-bengott:avatar@0.1.4
+bengott:avatar@0.2.1
 binary-heap@1.0.0
 blaze-tools@1.0.0
 blaze@2.0.1


### PR DESCRIPTION
Adds gravatarDefault option, better handling of relative paths on defaultAvatarUrl option
