### PR TITLE
Upgrade to bengott:avatar 0.6.0

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -13,7 +13,7 @@ artwells:queue@0.0.3
 autoupdate@1.1.3
 backbone@1.0.0
 base64@1.0.1
-bengott:avatar@0.5.1
+bengott:avatar@0.6.0
 binary-heap@1.0.1
 blaze-tools@1.0.1
 blaze@2.0.3

--- a/client/helpers/config.js
+++ b/client/helpers/config.js
@@ -40,8 +40,3 @@ Statuses={
 	approved: 2,
 	rejected: 3
 };
-
-Avatar.options = {
-	emailHashProperty: 'email_hash',
-  defaultAvatarUrl: '/img/default-avatar.png',
-};

--- a/client/views/comments/comment_item.html
+++ b/client/views/comments/comment_item.html
@@ -15,7 +15,7 @@
             <span>{{i18n "downvote"}}</span>
           </a>
         </div>
-        <div class="user-avatar">{{>avatar userId=userId class="circle"}}</div>
+        <div class="user-avatar">{{> avatar userId=userId shape="circle"}}</div>
         <div class="comment-main">
           <div class="comment-meta">
             <a class="comment-username" href="{{profileUrl}}">{{authorName}}</a>

--- a/client/views/users/user_item.html
+++ b/client/views/users/user_item.html
@@ -1,6 +1,6 @@
 <template name="user_item">
 <tr class="user">
-	<td>{{>avatar user=this class="circle"}}</td>
+	<td>{{> avatar user=this shape="circle"}}</td>
 	<td>
 		<a href="{{getProfileUrl}}">{{displayName}}</a>
 		<br/>

--- a/client/views/users/user_profile.html
+++ b/client/views/users/user_profile.html
@@ -3,7 +3,7 @@
 		<div class="user-profile grid grid-module">
 			<table>
 				<tr>
-					<td colspan="2">{{>avatar user=this class="large circle"}}</td>
+					<td colspan="2">{{> avatar user=this size="large" shape="circle"}}</td>
 				</tr>
 				{{#if isAdmin}}
 					<tr>

--- a/lib/config/avatar.js
+++ b/lib/config/avatar.js
@@ -1,0 +1,3 @@
+Avatar.options = {
+  emailHashProperty: 'email_hash'
+};

--- a/packages/telescope-theme-hubble/lib/client/css/screen.css
+++ b/packages/telescope-theme-hubble/lib/client/css/screen.css
@@ -1013,10 +1013,10 @@ em {
     position: block;
     float: left; }
     /* line 141, ../scss/modules/_comments.scss */
-    .comment-content .user-avatar img {
+    /*.comment-content .user-avatar img {
       height: 40px;
       width: 40px;
-      display: block; }
+      display: block; }*/
 
 /* line 148, ../scss/modules/_comments.scss */
 .comment-meta {

--- a/packages/telescope-theme-hubble/lib/client/scss/modules/_comments.scss
+++ b/packages/telescope-theme-hubble/lib/client/scss/modules/_comments.scss
@@ -1,7 +1,7 @@
 .queue-container{
 	position:relative;
 	height:0px;
-	@include single-transition(ease-out, opacity, 400ms, 0ms);	
+	@include single-transition(ease-out, opacity, 400ms, 0ms);
 	ul{
 		position:absolute;
 		// right:0;
@@ -60,7 +60,7 @@
 			// @extend .grid-block;
 			// display:block;
 			// padding:3px 8px;
-			
+
 			// white-space:nowrap;
 
 			// font-size:14px;
@@ -138,11 +138,11 @@
 		overflow:hidden;
 		position:block;
 		float:left;
-		img{
-			height:40px;
-			width:40px;
-			display:block;
-		}
+		// img{
+		//	height:40px;
+		//	width:40px;
+		//	display:block;
+		// }
 	}
 }
 .comment-meta{


### PR DESCRIPTION
I created a new config file in lib/config/avatar.js (accessible to both client and server) and moved Avatar.options from client/helpers/config.js to the new file. I also configured Avatar to use user initials when none of the linked services can find an avatar (the default behavior). You can change this back to use your default image by editing the config to read:

```
Avatar.options = {
  emailHashProperty: 'email_hash',
  defaultType: 'image',
  defaultImageUrl: 'img/default-avatar.png'
};
```

@SachaG: I also commented out some outdated SCSS/CSS. Like we discussed in the past, I don't wanna rock the boat too much with your Sass compilation workflow, so I'll let you clean that up if you want to.

Whew! This was a big one...
