### PR TITLE
Fix telescope-search route for iron:router 1.0

### DIFF
--- a/packages/telescope-search/lib/client/routes.js
+++ b/packages/telescope-search/lib/client/routes.js
@@ -12,6 +12,7 @@ Meteor.startup(function () {
       if ("q" in this.params) {
         Session.set("searchQuery", this.params.q);
       }
+      this.next();
     }
   });
 


### PR DESCRIPTION
The `onBeforeAction` in `PostsSearchController` isn't calling `this.next()`, and so is never dispatching.
