### PR TITLE
Minor tweaks

### DIFF
--- a/lib/vote.js
+++ b/lib/vote.js
@@ -1,19 +1,19 @@
 
   // returns how much "power" a user's votes have
-  var getVotePower = function(user){
+  var getVotePower = function (user) {
     // return isAdmin(user) ? 5 : 1;
     return 1; // for now, leave everybody at 1 including admins; 5 is too unbalanced
   };
 
-  var modifyKarma = function(userId, karma){
+  var modifyKarma = function (userId, karma) {
     Meteor.users.update({_id: userId}, {$inc: {karma: karma}});
   };
 
-  var hasUpvotedItem= function(item, user){
+  var hasUpvotedItem = function (item, user) {
     return item.upvoters && item.upvoters.indexOf(user._id) != -1;
   };
 
-  var hasDownvotedItem= function(item, user){
+  var hasDownvotedItem = function (item, user) {
     return item.downvoters && item.downvoters.indexOf(user._id) != -1;
   };
 
@@ -35,7 +35,7 @@
     });
   };
 
-  var upvoteItem = function(collection, item) {
+  var upvoteItem = function (collection, item) {
     var user = Meteor.user(),
         votePower = getVotePower(user),
         collectionName = collection._name.slice(0,1).toUpperCase()+collection._name.slice(1);
@@ -49,7 +49,7 @@
     cancelDownvote(collection, item, user);
 
     // Votes & Score
-    var result = collection.update({_id: item && item._id, upvoters: {$not: {$in: [user._id]}}},{
+    var result = collection.update({_id: item && item._id, upvoters: { $ne: user._id }},{
       $addToSet: {upvoters: user._id},
       $inc: {upvotes: 1, baseScore: votePower},
       $set: {inactive: false}
@@ -69,13 +69,13 @@
       updateScore({collection: collection, item: item, forceUpdate: true});
 
       // if the item is being upvoted by its own author, don't give karma
-      if (item.userId != user._id){
+      if (item.userId != user._id) {
         modifyKarma(item.userId, votePower);
       
         // if karma redistribution is enabled, give karma to all previous upvoters of the post 
         // (but not to the person doing the upvoting)
-        if(getSetting('redistributeKarma', false)){
-          _.each(item.upvoters, function(upvoterId){
+        if (getSetting('redistributeKarma', false)) {
+          _.each(item.upvoters, function (upvoterId) {
             // share the karma equally among all upvoters, but cap the value at 0.1
             var karmaIncrease = Math.min(0.1, votePower/item.upvoters.length);
             modifyKarma(upvoterId, 0.1);
@@ -87,7 +87,7 @@
     return true;
   };
 
-  var downvoteItem = function(collection, item) {
+  var downvoteItem = function (collection, item) {
     var user = Meteor.user(),
         votePower = getVotePower(user),
         collectionName = collection._name.slice(0,1).toUpperCase()+collection._name.slice(1);
@@ -100,7 +100,7 @@
     cancelUpvote(collection, item, user);
 
     // Votes & Score
-    var result = collection.update({_id: item && item._id, downvoters: {$not: {$in: [user._id]}}},{
+    var result = collection.update({_id: item && item._id, downvoters: { $ne: user._id }},{
       $addToSet: {downvoters: user._id},
       $inc: {downvotes: 1, baseScore: -votePower},
       $set: {inactive: false}
@@ -127,17 +127,17 @@
     return true;
   };
 
-  var cancelUpvote = function(collection, item) {
-    var user = Meteor.user();
+  var cancelUpvote = function (collection, item) {
+    var user = Meteor.user(),
         votePower = getVotePower(user),
         collectionName = collection._name.slice(0,1).toUpperCase()+collection._name.slice(1);
 
     // if user isn't among the upvoters, abort
-    if(!hasUpvotedItem(item, user))
+    if (!hasUpvotedItem(item, user))
       return false;
 
     // Votes & Score
-    var result = collection.update({_id: item && item._id, upvoters: { $in: [user._id]}},{
+    var result = collection.update({_id: item && item._id, upvoters: user._id},{
       $pull: {upvoters: user._id},
       $inc: {upvotes: -1, baseScore: -votePower},
       $set: {inactive: false}
@@ -159,17 +159,17 @@
     return true;
   };
 
-  var cancelDownvote = function(collection, item) {
+  var cancelDownvote = function (collection, item) {
     var user = Meteor.user(),
         votePower = getVotePower(user),
         collectionName = collection._name.slice(0,1).toUpperCase()+collection._name.slice(1);
 
     // if user isn't among the downvoters, abort
-    if(!hasDownvotedItem(item, user))
+    if (!hasDownvotedItem(item, user))
       return false;
     
     // Votes & Score
-    var result = collection.update({_id: item && item._id, downvoters: {$in: [user._id]}},{
+    var result = collection.update({_id: item && item._id, downvoters: user._id},{
       $pull: {downvoters: user._id},
       $inc: {downvotes: 1, baseScore: votePower},
       $set: {inactive: false}
@@ -192,35 +192,35 @@
   };
 
   // note: doesn't actually seem very useful to enable admins to vote for other users. Remove this?
-  var getUser = function(user){
+  var getUser = function (user) {
     // only let admins specify different users for voting
     // if no user is specified, use current user by default
     return (isAdmin(Meteor.user()) && typeof user !== 'undefined') ? user : Meteor.user();
   };
   
   Meteor.methods({
-    upvotePost: function(post, user){
+    upvotePost: function (post, user) {
       return upvoteItem.call(this, Posts, post);
     },
-    downvotePost: function(post, user){
+    downvotePost: function (post, user) {
       return downvoteItem.call(this, Posts, post);
     },
-    cancelUpvotePost: function(post, user){
+    cancelUpvotePost: function (post, user) {
       return cancelUpvote.call(this, Posts, post);
     },
-    cancelDownvotePost: function(post, user){
+    cancelDownvotePost: function (post, user) {
       return cancelDownvote.call(this, Posts, post);
     },
-    upvoteComment: function(comment, user){
+    upvoteComment: function (comment, user) {
       return upvoteItem.call(this, Comments, comment);
     },
-    downvoteComment: function(comment, user){
+    downvoteComment: function (comment, user) {
       return downvoteItem.call(this, Comments, comment);
     },
-    cancelUpvoteComment: function(comment, user){
+    cancelUpvoteComment: function (comment, user) {
       return cancelUpvote.call(this, Comments, comment);
     },
-    cancelDownvoteComment: function(comment, user){
+    cancelDownvoteComment: function (comment, user) {
       return cancelDownvote.call(this, Comments, comment);
     }
   });


### PR DESCRIPTION
Removed a stray semicolon on L131. Also, is there any particular reason `{ $not: { $in: [user._id] } }` and `{ $in: [user._id] }` were being used? Seems like both are just restatements of `{ $ne: user._id}` and just `user._id`.
