### PR TITLE
Update to bengott:avatar@0.7.2

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -13,7 +13,7 @@ artwells:queue@0.0.3
 autoupdate@1.1.3
 backbone@1.0.0
 base64@1.0.1
-bengott:avatar@0.7.1
+bengott:avatar@0.7.2
 binary-heap@1.0.1
 blaze-tools@1.0.1
 blaze@2.0.3


### PR DESCRIPTION
fixes jparker:gravatar version update that got missed in 0.7.1
