### PR TITLE
Couple of small Newsletter fixes

### DIFF
--- a/packages/telescope-newsletter/lib/server/routes.js
+++ b/packages/telescope-newsletter/lib/server/routes.js
@@ -6,7 +6,7 @@ Meteor.startup(function () {
     action: function() {
       var campaign = buildCampaign(getCampaignPosts(getSetting('postsPerNewsletter', 5)));
       var campaignSubject = '<div class="campaign-subject"><strong>Subject:</strong> '+campaign.subject+' (note: contents might change)</div>';
-      var campaignSchedule = '<div class="campaign-schedule"><strong>Scheduled for:</strong> '+getNextCampaignSchedule()+'</div>';
+      var campaignSchedule = '<div class="campaign-schedule"><strong>Scheduled for:</strong> '+ Meteor.call('getNextJob') +'</div>';
 
       this.response.write(campaignSubject+campaignSchedule+campaign.html);
       this.response.end();

--- a/packages/telescope-newsletter/lib/server/templates/emailPostItem.handlebars
+++ b/packages/telescope-newsletter/lib/server/templates/emailPostItem.handlebars
@@ -17,7 +17,7 @@
   <span class="post-submitted">Submitted by <a href="{{profileUrl}}" class="comment-link" target="_blank">{{authorName}}</a></span>
   <span class="post-date">on {{date}}</span>
   |
-  <a href="{{postPageLink}}" class="comment-link" target="_blank">{{comments}} Comments</a>
+  <a href="{{postPageLink}}" class="comment-link" target="_blank">{{commentCount}} Comments</a>
 </div>
 
 


### PR DESCRIPTION
1) The route /email/campaign was broken in ceeb7bf5317d7133bf8726b779584fb0a26daafe.  the method getNextCampaignSchedule() was removed e.g. http://meta.telesc.pe/email/campaign
2) The wrong comment count helper was used in the newsletter template resulting in it being undefined and so you wouldn’t see a count. I’m guessing this was broken when the post schema was changed as it comes from a post’s document.
