### PR TITLE
fix bug where All Categories didn't clear the category filter

### DIFF
--- a/packages/vulcan-base-components/lib/categories/CategoriesList.jsx
+++ b/packages/vulcan-base-components/lib/categories/CategoriesList.jsx
@@ -33,7 +33,8 @@ class CategoriesList extends Component {
 
   render() {
 
-    const currentQuery = _.clone(this.props.router.location.query);
+    const allCategoriesQuery = _.clone(this.props.router.location.query);
+    delete allCategoriesQuery.cat;
     const nestedCategories = this.getNestedCategories();
 
     return (
@@ -45,7 +46,7 @@ class CategoriesList extends Component {
           id="categories-dropdown"
         >
           <div className="category-menu-item category-menu-item-all dropdown-item">
-            <LinkContainer className="category-menu-item-title" to={{pathname:"/", query: currentQuery}}>
+            <LinkContainer className="category-menu-item-title" to={{pathname:"/", query: allCategoriesQuery}}>
               <MenuItem eventKey={0}>
                 <FormattedMessage id="categories.all"/>
               </MenuItem>


### PR DESCRIPTION
The "All Categories" link in the category option used to set the user's query to whatever it already was. With this change, the query is set to a modified copy of the current query that has category filters removed from it.