### PR TITLE
Add embedly and forms dependencies to vulcan-base-components

### DIFF
--- a/packages/vulcan-base-components/package.js
+++ b/packages/vulcan-base-components/package.js
@@ -17,6 +17,7 @@ Package.onUse(function (api) {
     'vulcan:voting@1.3.2',
     'vulcan:accounts@1.3.2',
     'vulcan:categories@1.3.2',
+    'vulcan:embedly@1.3.2'
   ]);
 
   api.mainModule("lib/server.js", "server");

--- a/packages/vulcan-base-components/package.js
+++ b/packages/vulcan-base-components/package.js
@@ -17,7 +17,8 @@ Package.onUse(function (api) {
     'vulcan:voting@1.3.2',
     'vulcan:accounts@1.3.2',
     'vulcan:categories@1.3.2',
-    'vulcan:embedly@1.3.2'
+    'vulcan:embedly@1.3.2',
+    'vulcan:forms@1.3.2',
   ]);
 
   api.mainModule("lib/server.js", "server");


### PR DESCRIPTION
The vulcan-base-components package assumes that Posts have a `thumbnailUrl` field. This field is provided by vulcan-embedly, so if you include the base components in a project without including embedly, you get a GraphQL error:

    Error: GraphQL error: Cannot query field "thumbnailUrl" on type "Post".

Similarly, base-components rely on the SmartForm component from vulcan-forms.