### PR TITLE
Use Boostrap V 3.3.7!

### DIFF
--- a/packages/vulcan-base-components/lib/common/HeadTags.jsx
+++ b/packages/vulcan-base-components/lib/common/HeadTags.jsx
@@ -45,7 +45,7 @@ class HeadTags extends Component {
 		const link = Headtags.link.concat([
 			{ rel: "canonical", href: url },
 			{ rel: "shortcut icon", href: getSetting("faviconUrl", "/img/favicon.ico") },
-		  { rel: 'stylesheet', type: 'text/css', href: 'https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css' },
+		  { rel: 'stylesheet', type: 'text/css', href: 'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css' },
 		  { rel: 'stylesheet', type: 'text/css', href: 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css' },
 		]);
 


### PR DESCRIPTION
Please I already have asked this many times

Use Boostrap V 3.3.7  which is the only supported version on React bootstrap otherwise everything looks weird and doesn't work properly!