### PR TITLE
use correct code for Mailchimp "already subscribed" state

### DIFF
--- a/packages/vulcan-newsletter/lib/server/integrations/mailchimp.js
+++ b/packages/vulcan-newsletter/lib/server/integrations/mailchimp.js
@@ -47,7 +47,7 @@ if (settings) {
         return {result: 'subscribed', ...subscribe};
       } catch (error) {
         // if the email is already in the Mailchimp list, no need to throw an error
-        if (error.message === "214") {
+        if (error.code === 214) {
           return {result: 'already-subscribed'};
         }
         throw new Error("subscription-failed", error.message);


### PR DESCRIPTION
If the user is already subscribed, the return code is numeric `214`, returned as `code` rather than `message`.