### PR TITLE
Fix remove permission strings

### DIFF
--- a/packages/vulcan-core/lib/modules/default_mutations.js
+++ b/packages/vulcan-core/lib/modules/default_mutations.js
@@ -89,7 +89,7 @@ export const getDefaultMutations = collectionName => ({
     
     check(user, document) {
       if (!user || !document) return false;
-      return Users.owns(user, document) ? Users.canDo(user, `${collectionName}.remove.own`) : Users.canDo(user, `${collectionName}.remove.all`);
+      return Users.owns(user, document) ? Users.canDo(user, `${collectionName.toLowerCase()}.remove.own`) : Users.canDo(user, `${collectionName.toLowerCase()}.remove.all`);
     },
     
     mutation(root, {documentId}, context) {


### PR DESCRIPTION
Transform collection name to lower case as it is done with the other permission strings.