### PR TITLE
Update graphql.js

### DIFF
--- a/packages/vulcan-lib/lib/modules/graphql.js
+++ b/packages/vulcan-lib/lib/modules/graphql.js
@@ -129,7 +129,7 @@ export const GraphQLSchema = {
 
       const fieldType = getGraphQLType(schema, fieldName);
 
-      if (fieldName.indexOf('.') === -1) { // skip fields containing "$" in their name
+      if (fieldName.indexOf('.') === -1) { // skip fields containing "." in their name
 
         // if field has a resolveAs, push it to schema
         if (field.resolveAs) {

--- a/packages/vulcan-lib/lib/modules/graphql.js
+++ b/packages/vulcan-lib/lib/modules/graphql.js
@@ -129,7 +129,7 @@ export const GraphQLSchema = {
 
       const fieldType = getGraphQLType(schema, fieldName);
 
-      if (fieldName.indexOf('$') === -1) { // skip fields containing "$" in their name
+      if (fieldName.indexOf('.') === -1) { // skip fields containing "$" in their name
 
         // if field has a resolveAs, push it to schema
         if (field.resolveAs) {


### PR DESCRIPTION
this is a followup on the question i asked on slack. my understanding is that graphql gets confused when we give it `$` or `.`. Since any field that uses `$` in their name will also use `.`, I thought we could just amend the rule so that not only `Array`s get skipped, but also `Object`s.