### PR TITLE
RegisterFragment should respect comments in fragment literals

### DIFF
--- a/packages/vulcan-lib/lib/modules/fragments.js
+++ b/packages/vulcan-lib/lib/modules/fragments.js
@@ -15,7 +15,7 @@ export const extractFragmentName = fragmentText => fragmentText.match(/fragment 
 Register a fragment, including its text, the text of its subfragments, and the fragment object
 
 */
-export const registerFragment = fragmentText => {
+export const registerFragment = fragmentTextSource => {
   // remove comments
   const fragmentText = fragmentTextSource.replace(/\#.*\n/g, '\n');
 

--- a/packages/vulcan-lib/lib/modules/fragments.js
+++ b/packages/vulcan-lib/lib/modules/fragments.js
@@ -16,12 +16,14 @@ Register a fragment, including its text, the text of its subfragments, and the f
 
 */
 export const registerFragment = fragmentText => {
+  // remove comments
+  const fragmentText = fragmentTextSource.replace(/\#.*\n/g, '\n');
 
   // extract name from fragment text
   const fragmentName = extractFragmentName(fragmentText);
   
   // extract subFragments from text
-  const matchedSubFragments = fragmentText.match(/\.\.\.([^\s].*)/g) || [];
+  const matchedSubFragments = fragmentText.match(/\.{3}([_A-Za-z][_0-9A-Za-z]*)/g) || [];
   const subFragments = _.unique(matchedSubFragments.map(f => f.replace('...', '')));
   
   // register fragment


### PR DESCRIPTION
The fragment parser doesn't ignore comments if they include `...`, e.g.
```
fragment CategoriesList on Category {
# ...dontMindMe
  }
}
```
This PR should fix that.
Also I've modified the regex for parsing GraphQL fragment names to follow the GraphQL spec more exactly.