### PR TITLE
Option to remove the added custom Posts column in admin dashboard

### DIFF
--- a/packages/vulcan-lib/lib/modules/admin.js
+++ b/packages/vulcan-lib/lib/modules/admin.js
@@ -7,3 +7,7 @@ export const addAdminColumn = columnOrColumns => {
     AdminColumns.push(columnOrColumns);
   }
 }
+
+export const removeAdminColumn = columnOrColumns => {
+  AdminColumns.pop(columnOrColumns);
+}


### PR DESCRIPTION
This is mainly a solution to remove the Posts column, which is added by default in Vulcanjs. If you have the `vulcan:admin` package enabled in your custom package, this will allow you to remove the Posts column. The code below will allow you to remove the Posts column in the admin dashboard.

USAGE: Create an `admin.js` file in your custom package, and add the following code:

      import { removeAdminColumn } from 'meteor/vulcan:core';

      removeAdminColumn({
        name: 'posts'
      });

Note: Make sure to import your created `admin.js` file in you custom package's `modules.js` file.

      import "./admin.js";