### PR TITLE
Remove "unique" identifier file.

### DIFF
--- a/.meteor/.id
+++ b/.meteor/.id
@@ -1,7 +1,0 @@
-# This file contains a token that is unique to your project.
-# Check it into your repository along with the rest of this directory.
-# It can be used for purposes such as:
-#   - ensuring you don't accidentally deploy one app on top of another
-#   - providing package authors with aggregated statistics
-
-4ibiemui4bqn1j744h7


### PR DESCRIPTION
This PR removes the `.meteor/.id` file from the repository.  This is safe to delete because of [this code in Meteor](https://github.com/meteor/meteor/blob/devel/tools/project-context.js#L440-L466).

The `.id` file is meant to be a unique identifier for a project and is generated automatically in new (Meteor) projects.  Since VulcanJS is instead cloned as a boilerplate for a new application, this is less ideal since each project receives the same unique identifier.  The reason this is not ideal is explained within the comment of the removed file:

https://github.com/VulcanJS/Vulcan/blob/e634907530f9d4caf1c40f64b5df9f6c7e7524d4/.meteor/.id

Most importantly, this affects the ability to see any sort of traction on `vulcan:*` packages in Atmosphere since they are aggregated together.  This means that 10 or 1000 installs might just be tracked as 1!