### PR TITLE
Bump the react-bootstrap version to get rid of "isMounted is deprecated..." error when opening modals

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "react": "^15.6.1",
     "react-addons-pure-render-mixin": "^15.4.1",
     "react-apollo": "^1.1.1",
-    "react-bootstrap": "^0.30.7",
+    "react-bootstrap": "^0.31.3",
     "react-bootstrap-datetimepicker": "0.0.22",
     "react-cookie": "^0.4.6",
     "react-datetime": "^2.3.2",


### PR DESCRIPTION
bump react-bootstrap -> 0.31.3