### PR TITLE
Abstract out bootstrap-specific components in vulcan:forms

### DIFF
--- a/packages/vulcan-forms/lib/components/Flash.jsx
+++ b/packages/vulcan-forms/lib/components/Flash.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Alert from 'react-bootstrap/lib/Alert'
+import { registerComponent } from 'meteor/vulcan:core';
 
 const Flash = ({message, type}) => {
   
@@ -24,4 +25,4 @@ Flash.propTypes = {
   message: PropTypes.oneOfType([PropTypes.object.isRequired, PropTypes.array.isRequired])
 }
 
-export default Flash;
+registerComponent('FormFlash', Flash);

--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -25,12 +25,9 @@ This component expects:
 import { Components, Utils, runCallbacks } from 'meteor/vulcan:core';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, intlShape } from 'meteor/vulcan:i18n';
+import { intlShape } from 'meteor/vulcan:i18n';
 import Formsy from 'formsy-react';
-import Button from 'react-bootstrap/lib/Button';
-import Flash from "./Flash.jsx";
-import FormGroup from "./FormGroup.jsx";
-import { flatten, deepValue, getEditableFields, getInsertableFields } from '../modules/utils.js';
+import { getEditableFields, getInsertableFields } from '../modules/utils.js';
 
 /*
 
@@ -362,8 +359,8 @@ class Form extends Component {
             message = {content: error.message || this.context.intl.formatMessage({id: error.id, defaultMessage: error.id}, error.data)}
 
           }
-
-          return <Flash key={index} message={message} type="error"/>
+  
+          return <Components.FormFlash key={index} message={message} type="error"/>;
         })}
       </div>
     )
@@ -614,25 +611,20 @@ class Form extends Component {
           ref="form"
         >
           {this.renderErrors()}
-          {fieldGroups.map(group => <FormGroup key={group.name} {...group} updateCurrentValues={this.updateCurrentValues} />)}
-
-          <div className="form-submit">
-            <Button type="submit" bsStyle="primary">{this.props.submitLabel ? this.props.submitLabel : <FormattedMessage id="forms.submit"/>}</Button>
-            {this.props.cancelCallback ? <a className="form-cancel" onClick={(e) => {e.preventDefault(); this.props.cancelCallback(this.getDocument())}}>{this.props.cancelLabel ? this.props.cancelLabel : <FormattedMessage id="forms.cancel"/>}</a> : null}
-          </div>
+          {fieldGroups.map(group => <Components.FormGroup key={group.name} {...group} updateCurrentValues={this.updateCurrentValues} />)}
+  
+          <Components.FormSubmit submitLabel={this.props.submitLabel}
+                                 cancelLabel={this.props.cancelLabel}
+                                 cancelCallback={this.props.cancelCallback}
+                                 document={this.getDocument()}
+                                 deleteDocument={(this.props.formType === 'edit'
+                                   && this.props.showRemove
+                                   && this.deleteDocument)
+                                 || null}
+                                 collectionName={collectionName}
+          />
 
         </Formsy.Form>
-
-        {
-          this.props.formType === 'edit' && this.props.showRemove
-            ? <div>
-                <hr/>
-                <a href="javascript:void()" onClick={this.deleteDocument} className={`delete-link ${collectionName}-delete-link`}>
-                  <Components.Icon name="close"/> <FormattedMessage id="forms.delete"/>
-                </a>
-              </div>
-            : null
-        }
       </div>
     )
   }

--- a/packages/vulcan-forms/lib/components/FormComponent.jsx
+++ b/packages/vulcan-forms/lib/components/FormComponent.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { intlShape } from 'meteor/vulcan:i18n';
 import classNames from 'classnames';
 import { Components } from 'meteor/vulcan:core';
+import { registerComponent } from 'meteor/vulcan:core';
 
 class FormComponent extends PureComponent {
 
@@ -156,4 +157,4 @@ FormComponent.contextTypes = {
   intl: intlShape
 };
 
-export default FormComponent;
+registerComponent('FormComponent', FormComponent);

--- a/packages/vulcan-forms/lib/components/FormGroup.jsx
+++ b/packages/vulcan-forms/lib/components/FormGroup.jsx
@@ -1,8 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import FormComponent from './FormComponent.jsx';
 import { Components } from 'meteor/vulcan:core';
 import classNames from 'classnames';
+import { registerComponent } from 'meteor/vulcan:core';
 
 class FormGroup extends PureComponent {
 
@@ -40,7 +40,7 @@ class FormGroup extends PureComponent {
       <div className="form-section">
         {this.props.name === 'default' ? null : this.renderHeading()}
         <div className={classNames({'form-section-collapsed': this.state.collapsed && !hasErrors})}>
-          {this.props.fields.map(field => <FormComponent key={field.name} {...field} updateCurrentValues={this.props.updateCurrentValues} />)}
+          {this.props.fields.map(field => <Components.FormComponent key={field.name} {...field} updateCurrentValues={this.props.updateCurrentValues} />)}
         </div>
       </div>
     )
@@ -55,4 +55,4 @@ FormGroup.propTypes = {
   updateCurrentValues: PropTypes.func
 }
 
-export default FormGroup;
+registerComponent('FormGroup', FormGroup);

--- a/packages/vulcan-forms/lib/components/FormSubmit.jsx
+++ b/packages/vulcan-forms/lib/components/FormSubmit.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Components } from 'meteor/vulcan:core';
+import { registerComponent } from 'meteor/vulcan:core';
+import Button from 'react-bootstrap/lib/Button';
+import { FormattedMessage } from 'meteor/vulcan:i18n';
+
+
+const FormSubmit = ({
+                      submitLabel,
+                      cancelLabel,
+                      cancelCallback,
+                      document,
+                      deleteDocument,
+                      collectionName,
+                      classes
+                    }) => (
+  <div className="form-submit">
+    
+    <Button type="submit" bsStyle="primary">
+      {submitLabel ? submitLabel : <FormattedMessage id="forms.submit"/>}
+    </Button>
+    
+    {
+      cancelCallback
+        ?
+        <a className="form-cancel" onClick={(e) => {
+          e.preventDefault();
+          cancelCallback(document);
+        }}>{cancelLabel ? cancelLabel :
+          <FormattedMessage id="forms.cancel"/>}</a>
+        :
+        null
+    }
+    
+  </div>
+);
+
+
+FormSubmit.propTypes = {
+  submitLabel: PropTypes.string,
+  cancelLabel: PropTypes.string,
+  cancelCallback: PropTypes.func,
+  document: PropTypes.object,
+  deleteDocument: PropTypes.func,
+  collectionName: PropTypes.string,
+  classes: PropTypes.object,
+};
+
+
+registerComponent('FormSubmit', FormSubmit);

--- a/packages/vulcan-forms/lib/modules/components.js
+++ b/packages/vulcan-forms/lib/modules/components.js
@@ -9,4 +9,8 @@ import '../components/bootstrap/Select.jsx';
 import '../components/bootstrap/Textarea.jsx';
 import '../components/bootstrap/Url.jsx';
 
+import '../components/Flash.jsx';
+import '../components/FormComponent.jsx';
+import '../components/FormGroup.jsx';
+import '../components/FormSubmit.jsx';
 import '../components/FormWrapper.jsx';


### PR DESCRIPTION
Abstract out bootstrap-specific components in vulcan:forms and register them using registerComponent so that they can be overridden by other gui frameworks like material-ui.