### PR TITLE
Fix issue #1770

### DIFF
--- a/packages/example-instagram/lib/components/common/Header.jsx
+++ b/packages/example-instagram/lib/components/common/Header.jsx
@@ -11,7 +11,7 @@ component (if the "component" prop is specified).
 import React from 'react';
 import { registerComponent, Components, withCurrentUser } from 'meteor/vulcan:core';
 import Users from 'meteor/vulcan:users';
-import PicsNewForm from '../pics/PicsNewForm';
+// import PicsNewForm from '../pics/PicsNewForm';
 
 // navigation bar component when the user is logged in
 
@@ -33,7 +33,7 @@ const NavLoggedIn = ({currentUser}) =>
       </div>
 
       <Components.ModalTrigger label="Upload">
-        <PicsNewForm />
+        <Components.PicsNewForm />
       </Components.ModalTrigger>
 
   </div>

--- a/packages/example-membership/lib/components/common/Header.jsx
+++ b/packages/example-membership/lib/components/common/Header.jsx
@@ -11,7 +11,7 @@ component (if the "component" prop is specified).
 import React from 'react';
 import { registerComponent, Components, withCurrentUser } from 'meteor/vulcan:core';
 import Users from 'meteor/vulcan:users';
-import PicsNewForm from '../pics/PicsNewForm';
+// import PicsNewForm from '../pics/PicsNewForm';
 
 // navigation bar component when the user is logged in
 
@@ -33,7 +33,7 @@ const NavLoggedIn = ({currentUser}) =>
       </div>
 
       <Components.ModalTrigger label="Upload">
-        <PicsNewForm />
+        <Components.PicsNewForm />
       </Components.ModalTrigger>
 
   </div>

--- a/packages/example-permissions/lib/components/common/Header.jsx
+++ b/packages/example-permissions/lib/components/common/Header.jsx
@@ -11,7 +11,7 @@ component (if the "component" prop is specified).
 import React from 'react';
 import { registerComponent, Components, withCurrentUser } from 'meteor/vulcan:core';
 import Users from 'meteor/vulcan:users';
-import PicsNewForm from '../pics/PicsNewForm';
+// import PicsNewForm from '../pics/PicsNewForm';
 
 // navigation bar component when the user is logged in
 
@@ -34,7 +34,7 @@ const NavLoggedIn = ({currentUser}) =>
 
       {Users.canDo(currentUser, 'pics.new') ?
         <Components.ModalTrigger label="Upload">
-          <PicsNewForm />
+          <Components.PicsNewForm />
         </Components.ModalTrigger>
         : null
       }


### PR DESCRIPTION
PicsNewForm must be called as a registered component, not as an imported object.

This PR addresses issue #1770.

Three different tutorial example packages are affected.
