### PR TITLE
Add pre-validate callback on new user creation

### DIFF
--- a/packages/vulcan-users/lib/server/on_create_user.js
+++ b/packages/vulcan-users/lib/server/on_create_user.js
@@ -8,6 +8,8 @@ function onCreateUserCallback (options, user) {
   delete options.password; // we don't need to store the password digest
   delete options.username; // username is already in user object
 
+  options = runCallbacks(`users.new.pre_validate`, options);
+
   // validate options since they can't be trusted
   Users.simpleSchema().validate(options);
 


### PR DESCRIPTION
I had the necessity to modify the options which are passed to the user schema validation function. That's why I created a synchronous callback for it.

I'm concerned about the name of the hook. Please, give your advice and opinions.