### PR TITLE
NPM start calls 

### DIFF
--- a/prestart_vulcan.sh
+++ b/prestart_vulcan.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 if tput setaf 1 &> /dev/null; then
   purple=$(tput setaf 141)
@@ -15,15 +15,15 @@ fi
 command -v meteor >/dev/null 2>&1 || { 
 echo "Vulcan requires Meteor but it's not installed. Trying to Install..." >&2; 
 
-if [ "$(uname)" == "Darwin" ]; then
+if [ "$(uname)" = "Darwin" ]; then
     # Mac OS platform
    echo "🌋  ${bold}${purple}Good news you have a Mac and we will install it now! ${reset}"; 
    curl https://install.meteor.com/ | bash;
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
     # GNU/Linux platform
     echo "🌋  ${bold}${purple}Good news you are on  GNU/Linux platform and we will install Meteor now! ${reset}"; 
     curl https://install.meteor.com/ | bash;
-elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
+elif [ "$(expr substr $(uname -s) 1 10)" = "MINGW32_NT" ]; then
     # Windows NT platform
     echo "🌋  ${bold}${purple}Oh no! you are on a Windows platform and you will need to install Meteor Manually! ${reset}"; 
     echo "📖  ${blue}Meteor for Windows is available at: ${purple}https://install.meteor.com/windows";


### PR DESCRIPTION
On linux the bash script ```prestart_vulcan.sh``` is being called by sh causing this error.
```
> Vulcan@1.8.0 prestart /home/magan/Vulcan
> sh prestart_vulcan.sh

Vulcan requires Meteor but it's not installed. Trying to Install...
prestart_vulcan.sh: 18: [: Linux: unexpected operator
prestart_vulcan.sh: 22: [: Linux: unexpected operator
prestart_vulcan.sh: 26: [: Linux: unexpected operator
```

The quick solution is to just go removed the second = in the equality statements. I am sure there is a better long term solution.