### PR TITLE
Delete Posts and Comments when a user is deleted

### DIFF
--- a/packages/vulcan-lib/lib/server/mutations.js
+++ b/packages/vulcan-lib/lib/server/mutations.js
@@ -219,6 +219,11 @@ export const removeMutation = async ({ collection, documentId, currentUser, vali
   if (collection.loader) {
     collection.loader.clear(documentId);
   }
+  //Set options to delete Posts and Comments when a user gets deleted
+  if(collectionName == 'users') {
+    currentUser.deletePosts = true;
+    currentUser.deleteComments = true;
+  }
 
   runCallbacksAsync(`${collectionName}.remove.async`, document, currentUser, collection);
 


### PR DESCRIPTION
Set options to delete Posts and Comments when a user gets deleted. Currently it creates an issue when a user is deleted. No post gets loaded on home page when a user who has some posts gets deleted.