### PR TITLE
deleted user post bug

### DIFF
--- a/packages/example-forum/lib/modules/posts/collection.js
+++ b/packages/example-forum/lib/modules/posts/collection.js
@@ -64,11 +64,14 @@ Posts.statuses = [
 ];
 
 Posts.checkAccess = (currentUser, post) => {
-  if (Users.isAdmin(currentUser) || Users.owns(currentUser, post)) { // admins can always see everything, users can always see their own posts
+  if (!Users.getUser(post.userId)) {
+    return false;
+  }
+  else if (Users.isAdmin(currentUser) || Users.owns(currentUser, post)) { // admins can always see everything, users can always see their own posts
     return true;
   } else if (post.isFuture) {
     return false;
-  } else { 
+  } else {
     const status = _.findWhere(Posts.statuses, {value: post.status});
     return Users.canDo(currentUser, `posts.view.${status.label}`);
   }


### PR DESCRIPTION
Addresses: https://github.com/VulcanJS/Vulcan/issues/1776

* fix bug where post from deleted user causes this example to break.  Now it just hides those posts