### PR TITLE
fix admin delete user hide bug

### DIFF
--- a/packages/vulcan-core/lib/modules/components/Datatable.jsx
+++ b/packages/vulcan-core/lib/modules/components/Datatable.jsx
@@ -89,11 +89,11 @@ const DatatableHeader = ({ collection, column }, { intl }) => {
   /*
 
   use either:
-  
+
   1. the column name translation
   2. the column name label in the schema (if the column name matches a schema field)
   3. the raw column name.
-  
+
   */
   const formattedLabel = intl.formatMessage({ id: `${collection._name}.${columnName}`, defaultMessage: schema[columnName] ? schema[columnName].label : columnName });
   return <th>{formattedLabel}</th>;
@@ -113,7 +113,7 @@ DatatableContents Component
 
 const DatatableContents = (props) => {
   const {collection, columns, results, loading, loadMore, count, totalCount, networkStatus, showEdit, currentUser, emptyState} = props;
-  
+
   if (loading) {
     return <Components.Loading />;
   } else if (!results.length) {
@@ -137,10 +137,10 @@ const DatatableContents = (props) => {
           </tbody>
         </table>
         <div className="admin-users-load-more">
-          {hasMore ? 
-            isLoadingMore ? 
-              <Components.Loading/> 
-              : <Button bsStyle="primary" onClick={e => {e.preventDefault(); loadMore();}}>Load More ({count}/{totalCount})</Button> 
+          {hasMore ?
+            isLoadingMore ?
+              <Components.Loading/>
+              : <Button bsStyle="primary" onClick={e => {e.preventDefault(); loadMore();}}>Load More ({count}/{totalCount})</Button>
             : null
           }
         </div>
@@ -159,11 +159,11 @@ const DatatableRow = ({ collection, columns, document, showEdit, currentUser }, 
   <tr className="datatable-item">
 
     {_.sortBy(columns, column => column.order).map((column, index) => <Components.DatatableCell key={index} column={column} document={document} currentUser={currentUser} />)}
-  
-    {showEdit ? 
+
+    {showEdit ?
       <td>
-        <Components.ModalTrigger 
-          label={intl.formatMessage({id: 'datatable.edit'})} 
+        <Components.ModalTrigger
+          label={intl.formatMessage({id: 'datatable.edit'})}
           component={<Button bsStyle="primary"><FormattedMessage id="datatable.edit" /></Button>}
         >
           <Components.DatatableEditForm collection={collection} document={document} />
@@ -185,11 +185,14 @@ DatatableEditForm Component
 
 */
 const DatatableEditForm = ({ collection, document, closeModal }) =>
-  <Components.SmartForm 
+  <Components.SmartForm
     collection={collection}
     documentId={document._id}
     showRemove={true}
     successCallback={document => {
+      closeModal();
+    }}
+    removeSuccessCallback={document => {
       closeModal();
     }}
   />


### PR DESCRIPTION
Fix a simple bug in vulcan:admin user list page after a user delete

Repro:
1) go to /admin
2) edit another user, scroll down & click delete, click "ok" to confirm delete

notice the modal stays displayed after the user is successfully deleted