### PR TITLE
Form loading state fix

### DIFF
--- a/packages/vulcan-forms/lib/components/FormWrapper.jsx
+++ b/packages/vulcan-forms/lib/components/FormWrapper.jsx
@@ -158,7 +158,7 @@ class FormWrapper extends PureComponent {
     // displays the loading state if needed, and passes on loading and document/data
     const Loader = props => {
       const { document, loading } = props;
-      return loading ?
+      return (!document && loading) ?
         <Components.Loading /> :
         <Form
           document={document}


### PR DESCRIPTION
In some cases it seems that the loading property is set to true altough the document is already there.