### PR TITLE
Fix Newsletter Banner SSR

### DIFF
--- a/packages/example-forum/lib/components/common/Newsletter.jsx
+++ b/packages/example-forum/lib/components/common/Newsletter.jsx
@@ -17,8 +17,14 @@ class Newsletter extends PureComponent {
     this.dismissBanner = this.dismissBanner.bind(this);
 
     this.state = {
-      showBanner: showBanner(props.currentUser)
+      showBanner: false
     };
+  }
+
+  componentDidMount() {
+    this.setState({
+      showBanner: showBanner(this.props.currentUser)
+    });
   }
 
   componentWillReceiveProps(nextProps, nextContext) {


### PR DESCRIPTION
Alright, really weird one related to React16 SSR changes.
https://github.com/facebook/react/issues/10591
Basically, React changed it's diff algorithm and now reuses components differently.
So, when the check for showing the newsletter was inside the constructor, instead of generating something along the line of
```html
<div className="newsletter">
{ ... rest of Newsletter code }
</div>
<div>
{ ...content }
</div>
```
the actual result was
```html
<div className="newsletter">
  <div>
  { ...content }
  </div>
</div>
```

Setting showBanner inside `componentDidMount` fixes that.