### PR TITLE
showEdit on Card

### DIFF
--- a/packages/vulcan-core/lib/modules/components/Card.jsx
+++ b/packages/vulcan-core/lib/modules/components/Card.jsx
@@ -119,10 +119,10 @@ const CardEditForm = ({ collection, document, closeModal }) =>
     }}
   />
 
-const Card = ({className, collection, document, currentUser, fields}, {intl}) => {
+const Card = ({className, collection, document, currentUser, fields, showEdit = true}, {intl}) => {
 
   const fieldNames = fields ? fields : _.without(_.keys(document), '__typename');
-  const canEdit = currentUser && collection.options.mutations.edit.check(currentUser, document);
+  const canEdit = showEdit && currentUser && collection.options.mutations.edit.check(currentUser, document);
 
   return (
     <div className={classNames(className, 'datacard', `datacard-${collection._name}`)}>
@@ -146,6 +146,7 @@ Card.propTypes = {
   document: PropTypes.object,
   currentUser: PropTypes.object,
   fields: PropTypes.array,
+  showEdit: PropTypes.bool
 }
 
 Card.contextTypes = {


### PR DESCRIPTION
This make the Card consistent with the Datatable, and allow to hide the `edit` button on cards using the `showEdit` prop.