### PR TITLE
Fix circular dependencies between schemas and collections

### DIFF
--- a/packages/example-forum/lib/modules/categories/schema.js
+++ b/packages/example-forum/lib/modules/categories/schema.js
@@ -5,7 +5,6 @@ Categories schema
 */
 
 import { Utils } from 'meteor/vulcan:core';
-import { Categories } from './collection.js';
 
 export function getCategoriesAsOptions (categories) {
   // give the form component (here: checkboxgroup) exploitable data
@@ -70,13 +69,13 @@ const schema = {
     onInsert: category => {
       // if no slug has been provided, generate one
       const slug = category.slug || Utils.slugify(category.name);
-      return Utils.getUnusedSlug(Categories, slug);
+      return Utils.getUnusedSlugByCollectionName('Categories', slug);
     },
     onEdit: (modifier, category) => {
       // if slug is changing
       if (modifier.$set && modifier.$set.slug && modifier.$set.slug !== category.slug) {
         const slug = modifier.$set.slug;
-        return Utils.getUnusedSlug(Categories, slug);
+        return Utils.getUnusedSlugByCollectionName('Categories', slug);
       }
     }
   },

--- a/packages/example-forum/lib/modules/posts/schema.js
+++ b/packages/example-forum/lib/modules/posts/schema.js
@@ -5,8 +5,7 @@ Posts schema
 */
 
 import Users from 'meteor/vulcan:users';
-import { Posts } from './collection.js';
-import { Utils, getSetting, registerSetting } from 'meteor/vulcan:core';
+import { Utils, getSetting, registerSetting, getCollection } from 'meteor/vulcan:core';
 import moment from 'moment';
 import marked from 'marked';
 
@@ -60,7 +59,7 @@ const schema = {
     group: formGroups.admin,
     onInsert: (post, currentUser) => {
       // Set the post's postedAt if it's going to be approved
-      if (!post.postedAt && Posts.getDefaultStatus(currentUser) === Posts.config.STATUS_APPROVED) {
+      if (!post.postedAt && getCollection('Posts').getDefaultStatus(currentUser) === getCollection('Posts').config.STATUS_APPROVED) {
         return new Date();
       }
     }
@@ -208,17 +207,17 @@ const schema = {
     control: 'select',
     onInsert: (document, currentUser) => {
       if (!document.status) {
-        return Posts.getDefaultStatus(currentUser);
+        return getCollection('Posts').getDefaultStatus(currentUser);
       }
     },
     onEdit: (modifier, document, currentUser) => {
       // if for some reason post status has been removed, give it default status
       if (modifier.$unset && modifier.$unset.status) {
-        return Posts.getDefaultStatus(currentUser);
+        return getCollection('Posts').getDefaultStatus(currentUser);
       }
     },
     form: {
-      options: () => Posts.statuses,
+      options: () => getCollection('Posts').statuses,
     },
     group: formGroups.admin
   },
@@ -358,7 +357,7 @@ const schema = {
     viewableBy: ['guests'],
     resolveAs: {
       type: 'String',
-      resolver: (post, args, context) => {
+      resolver: (post, args, { Posts }) => {
         return Posts.getPageUrl(post, true);
       },
     }
@@ -370,7 +369,7 @@ const schema = {
     viewableBy: ['guests'],
     resolveAs: {
       type: 'String',
-      resolver: (post, args, context) => {
+      resolver: (post, args, { Posts }) => {
         return post.url ? Utils.getOutgoingUrl(post.url) : Posts.getPageUrl(post, true);
       },
     }
@@ -426,7 +425,7 @@ const schema = {
     viewableBy: ['guests'],
     resolveAs: {
       type: 'String',
-      resolver: (post) => {
+      resolver: (post, args, { Posts }) => {
         return Posts.getEmailShareUrl(post);
       }
     }
@@ -438,7 +437,7 @@ const schema = {
     viewableBy: ['guests'],
     resolveAs: {
       type: 'String',
-      resolver: (post) => {
+      resolver: (post, args, { Posts }) => {
         return Posts.getTwitterShareUrl(post);
       }
     }
@@ -450,7 +449,7 @@ const schema = {
     viewableBy: ['guests'],
     resolveAs: {
       type: 'String',
-      resolver: (post) => {
+      resolver: (post, args, { Posts }) => {
         return Posts.getFacebookShareUrl(post);
       }
     }

--- a/packages/vulcan-lib/lib/modules/collections.js
+++ b/packages/vulcan-lib/lib/modules/collections.js
@@ -12,6 +12,8 @@ registerSetting('maxDocumentsPerRequest', 1000, 'Maximum documents per request')
 
 export const Collections = [];
 
+export const getCollection = name => Collections.find(({ options: { collectionName }}) => name === collectionName);
+
 /**
  * @summary replacement for Collection2's attachSchema. Pass either a schema, to
  * initialize or replace the schema, or some fields, to extend the current schema

--- a/packages/vulcan-lib/lib/modules/utils.js
+++ b/packages/vulcan-lib/lib/modules/utils.js
@@ -12,6 +12,7 @@ import getSlug from 'speakingurl';
 import { getSetting, registerSetting } from './settings.js';
 import { Routes } from './routes.js';
 import { isAbsolute } from 'path';
+import { getCollection } from './collections.js';
 
 registerSetting('debug', false, 'Enable debug mode (more verbose logging)');
 
@@ -169,6 +170,10 @@ Utils.getUnusedSlug = function (collection, slug) {
   }
 
   return slug+suffix;
+};
+
+Utils.getUnusedSlugByCollectionName = function (collectionName, slug) {
+  return Utils.getUnusedSlug(getCollection(collectionName), slug);
 };
 
 Utils.getShortUrl = function(post) {


### PR DESCRIPTION
`collection.js` is importing `schema.js` for `createCollection` but `schema.js` is importing `collection.js` for varying runtime function definitions resulting in undefined circular load order on files.