### PR TITLE
Fix the Edit and Reply cancel methods on Comments component in example-forum package

### DIFF
--- a/packages/example-forum/lib/components/comments/CommentsItem.jsx
+++ b/packages/example-forum/lib/components/comments/CommentsItem.jsx
@@ -22,7 +22,6 @@ class CommentsItem extends PureComponent {
   }
 
   replyCancelCallback(event) {
-    event.preventDefault();
     this.setState({showReply: false});
   }
 
@@ -36,7 +35,6 @@ class CommentsItem extends PureComponent {
   }
 
   editCancelCallback(event) {
-    event.preventDefault();
     this.setState({showEdit: false});
   }
 


### PR DESCRIPTION
I noticed that the "Edit" and "Reply" cancel methods in CommentsItem.jsx file are not working. For example, when I edit a comment, the "Cancel" option is not working. Likewise with the Reply form.

I confirmed with @justinr1234 for this fix and he said that this is okay because "... SmartForms code already prevents default before calling this callback."

For more details, please see issue reference: #1870

Thanks!