### PR TITLE
 Apollov2 2nd update

### DIFF
--- a/packages/vulcan-core/lib/modules/callbacks.js
+++ b/packages/vulcan-core/lib/modules/callbacks.js
@@ -1,9 +1,9 @@
 import { addCallback, getActions } from 'meteor/vulcan:lib';
 
 /*
-  
-  Core callbacks 
-  
+
+  Core callbacks
+
 */
 
 /**
@@ -13,7 +13,7 @@ import { addCallback, getActions } from 'meteor/vulcan:lib';
  * @param {Object} Apollo Client reference instantiated on the current connected client
  */
 function RouterClearMessages(unusedItem, nextRoute, store, apolloClient) {
-  store.dispatch(getActions().messages.clearSeen());
+  // store.dispatch(getActions().messages.clearSeen());
   
   return unusedItem;
 }

--- a/packages/vulcan-lib/lib/client/render_context.js
+++ b/packages/vulcan-lib/lib/client/render_context.js
@@ -15,8 +15,8 @@ export const initContext = () => {
   const history = browserHistory;
   const loginToken = global.localStorage['Meteor.loginToken'];
   const apolloClient = createApolloClient();
-  addReducer({ apollo: apolloClient.reducer() });
-  addMiddleware(apolloClient.middleware());
+  addReducer({ apollo: apolloClient.store });
+  // addMiddleware(apolloClient.middleware());
 
   // init context
   context = {
@@ -37,24 +37,23 @@ export const initContext = () => {
     return next => (action) => {
       if (!chain) {
         chain = context.getMiddlewares().map(middleware => middleware(store));
-        newDispatch = compose(...chain)(next)
+        newDispatch = compose(...chain)(next);
       }
       return newDispatch(action);
     };
-  })
-}
+  });
+};
 
 // render context object
-export const renderContext = { 
+export const renderContext = {
   get: () => {
 
     if (typeof context === 'undefined') {
       initContext();
     }
 
-    return context
-
-  } 
+    return context;
+  }
 };
 
 // render context get function

--- a/packages/vulcan-lib/lib/modules/apollo.js
+++ b/packages/vulcan-lib/lib/modules/apollo.js
@@ -1,4 +1,9 @@
-import ApolloClient, { createNetworkInterface, createBatchingNetworkInterface } from 'apollo-client';
+import { ApolloClient } from 'apollo-client';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+import { createHttpLink } from 'apollo-link-http';
+import { setContext } from 'apollo-link-context';
+import { onError } from 'apollo-link-error';
+import { ApolloLink } from 'apollo-link';
 import 'cross-fetch/polyfill';
 import { Meteor } from 'meteor/meteor';
 import { getSetting, registerSetting } from './settings.js';
@@ -16,7 +21,10 @@ const defaultNetworkInterfaceConfig = {
 };
 
 const createMeteorNetworkInterface = (givenConfig = {}) => {
-  const config = { ...defaultNetworkInterfaceConfig, ...givenConfig };
+  const config = {
+    ...defaultNetworkInterfaceConfig,
+    ...givenConfig,
+  };
 
   // absoluteUrl adds a '/', so let's remove it first
   let path = config.path;
@@ -28,14 +36,12 @@ const createMeteorNetworkInterface = (givenConfig = {}) => {
   const uri = getSetting('graphQLendpointURL', defaultUri);
 
   // allow the use of a batching network interface; if the options.batchingInterface is not specified, fallback to the standard network interface
-  const interfaceToUse = config.batchingInterface ? createBatchingNetworkInterface : createNetworkInterface;
+  // const interfaceToUse = config.batchingInterface ? createBatchingNetworkInterface : createNetworkInterface;
 
   // default interface options
   const interfaceOptions = {
     uri,
-    opts: {
-      credentials: 'same-origin', // http://dev.apollodata.com/react/auth.html#Cookie
-    },
+    credentials: 'same-origin', // http://dev.apollodata.com/react/auth.html#Cookie
   };
 
   // if a BatchingNetworkInterface is used with a correct batch interval, add it to the options
@@ -48,56 +54,135 @@ const createMeteorNetworkInterface = (givenConfig = {}) => {
     interfaceOptions.opts = config.opts;
   }
 
-  const networkInterface = interfaceToUse(interfaceOptions);
-
+  const httpLink = createHttpLink(interfaceOptions);
+  // const networkInterface = interfaceToUse(interfaceOptions);
+  let middlewareLink = [];
   if (config.useMeteorAccounts) {
-    networkInterface.use([{
-      applyBatchMiddleware(request, next) {
-        const currentUserToken = Meteor.isClient ? global.localStorage['Meteor.loginToken'] : config.loginToken;
-
-        if (!currentUserToken) {
-          next();
-          return;
+    middlewareLink = setContext((context) => {
+      // Example context
+      // context =>  {
+      //   variables:
+      //   { terms: { limit: 5, itemsPerPage: 5 },
+      //     enableCache: false,
+      //     currentUser: null
+      //   },
+      //   extensions: {},
+      //   operationName: 'MoviesListQuery',
+      //   query: {
+      //     kind: 'Document',
+      //     definitions: [ [Object], [Object] ],
+      //     loc: { start: 0, end: 375, source: [Object] } } }
+      const currentUserToken = Meteor.isClient ? global.localStorage['Meteor.loginToken'] : config.loginToken;
+      return {
+        headers: {
+          authorization: currentUserToken, // this should become the norm.
+          Authorization: currentUserToken, // purch this
         }
-
-        if (!request.options.headers) {
-          request.options.headers = new Headers();
-        }
-
-        request.options.headers.Authorization = currentUserToken;
-
-        next();
-      },
-    }]);
+      };
+    });
   }
 
-  return networkInterface;
+  const errorLink = onError(({ networkError, graphQLErrors }) => {
+    // TODO: This will help to throw better
+    if (networkError.statusCode === 401) {
+      console.log('Do something on 401, also become a better Error then your predecessor!');
+      // new Meteor.Error();
+    }
+  });
+
+  const logger = new ApolloLink((operation, forward) => {
+    // console.log('logger => ', operation.operationName);
+    return forward(operation).map((result) => {
+      // console.log(`logger => received result from ${operation.operationName}`);
+      return result;
+    });
+  });
+
+  return logger.concat(
+    errorLink.concat(
+      middlewareLink.concat(
+        httpLink
+      )
+    )
+  );
 };
 
+const dataIdFromObject = result => {
+  // console.log('dataIdFromObject => ', result);
+  if (result._id && result.__typename) {
+    const dataId = result.__typename + result._id;
+    return dataId;
+  }
+  return null;
+};
+
+const cache = new InMemoryCache({
+  dataIdFromObject,// custom idGetter,
+  addTypename: true,
+  cacheRedirects: {},
+  // cacheResolvers: {},
+  fragmentMatcher: getFragmentMatcher(),
+});
+
 const meteorClientConfig = networkInterfaceConfig => {
-
+  // This is still a work in progress
   return {
+    link: createMeteorNetworkInterface(networkInterfaceConfig),
+    // use restore on the cache instead of initialState
+    cache: cache.restore(typeof window !== 'undefined' && window.__APOLLO_CLIENT__),
     ssrMode: Meteor.isServer,
-    networkInterface: createMeteorNetworkInterface(networkInterfaceConfig),
     queryDeduplication: true, // http://dev.apollodata.com/core/network.html#query-deduplication
-    addTypename: true,
-    fragmentMatcher: getFragmentMatcher(),
-
-    // Default to using Mongo _id, must use _id for queries.
-    dataIdFromObject(result) {
-      if (result._id && result.__typename) {
-        const dataId = result.__typename + result._id;
-        return dataId;
-      }
-      return null;
-    },
+    ssrForceFetchDelay: 100,
+    connectToDevTools: true,
   }
 };
 
 export const createApolloClient = options => {
-
   runCallbacks('apolloclient.init.before');
 
   return new ApolloClient(meteorClientConfig(options));
-
 };
+
+// Apollo boost example
+
+// const client = new ApolloClient({
+//   uri: 'https://nx9zvp49q7.lp.gql.zone/graphql',
+//   fetchOptions: {
+//     credentials: 'include'
+//   },
+//   request: async (operation) => {
+//     const token = await AsyncStorage.getItem('token');
+//     operation.setContext({
+//       headers: {
+//         authorization: token
+//       }
+//     });
+//   },
+//   onError: ({ graphQLErrors, networkError }) => {
+//     if (graphQLErrors) {
+//       sendToLoggingService(graphQLErrors);
+//     }
+//     if (networkError) {
+//       logoutUser();
+//     }
+//   },
+//   clientState: {
+//     defaults: {
+//       isConnected: true
+//     },
+//     resolvers: {
+//       Mutation: {
+//         updateNetworkStatus: (_, { isConnected }, { cache }) => {
+//           cache.writeData({ data: { isConnected }});
+//           return null;
+//         }
+//       }
+//     }
+//   },
+//   cacheRedirects: {
+//     Query: {
+//       movie: (_, { id }, { getCacheKey }) =>
+//         getCacheKey({ __typename: 'Movie', id });
+// }
+// }
+// });

--- a/packages/vulcan-lib/lib/server/render_context.js
+++ b/packages/vulcan-lib/lib/server/render_context.js
@@ -79,8 +79,8 @@ webAppConnectHandlersUse(Meteor.bindEnvironment(function initRenderContextMiddle
   const loginToken = req.cookies && req.cookies.meteor_login_token;
   const apolloClient = createApolloClient({ loginToken: loginToken });
   let actions = {};
-  let reducers = { apollo: apolloClient.reducer() };
-  let middlewares = [Utils.defineName(apolloClient.middleware(), 'apolloClientMiddleware')];
+  // let reducers = { apollo: apolloClient.reducer ? apolloClient.reducer() : {} };
+  // let middlewares = apolloClient.middleware ? [Utils.defineName(apolloClient.middleware(), 'apolloClientMiddleware')] : null;
 
   // renderContext object
   req.renderContext = {
@@ -95,32 +95,36 @@ webAppConnectHandlersUse(Meteor.bindEnvironment(function initRenderContextMiddle
       return { ...getActions(), ...actions };
     },
     addReducer(addedReducer) { // context.addReducer: add reducer to renderContext
-      reducers = { ...reducers, ...addedReducer };
+      const reducers = { ...addedReducer };
+      // reducers = { ...reducers, ...addedReducer };
       return this.getReducers();
     },
     getReducers() { // SSR reducers = server reducers + renderContext reducers
-      return { ...getReducers(), ...reducers };
+      return { ...getReducers() };
+      // return { ...getReducers(), ...reducers };
     },
     addMiddleware(middlewareOrMiddlewareArray) { // context.addMiddleware: add middleware to renderContext
       const addedMiddleware = Array.isArray(middlewareOrMiddlewareArray) ? middlewareOrMiddlewareArray : [middlewareOrMiddlewareArray];
-      middlewares = [...middlewares, ...addedMiddleware];
+      const middlewares = [...addedMiddleware];
+      // middlewares = [...middlewares, ...addedMiddleware];
       return this.getMiddlewares();
     },
     getMiddlewares() { // SSR middlewares = server middlewares + renderContext middlewares
-      return [...getMiddlewares(), ...middlewares];
+      return [...getMiddlewares()];
+      // return [...getMiddlewares(), ...middlewares];
     },
   };
 
   // create store
   req.renderContext.store = configureStore(req.renderContext.getReducers, {}, (store) => {
     let chain, newDispatch;
-     
+
     return next => (action) => {
       try {
         if (!chain) {
           chain = req.renderContext.getMiddlewares().map(middleware => middleware(store));
         }
-        newDispatch = compose(...chain)(next)
+        newDispatch = compose(...chain)(next);
         return newDispatch(action);
       } catch (error) {
         // console.log(error)

--- a/packages/vulcan-routing/lib/client/routing.jsx
+++ b/packages/vulcan-routing/lib/client/routing.jsx
@@ -42,12 +42,15 @@ Meteor.startup(() => {
       const context = getRenderContext();
       context.initialState = initialState;
       const apolloClientReducer = (state = {}, action) => {
-        if (initialState && initialState.apollo && !_.isEmpty(initialState.apollo.data) && _.isEmpty(state.data)) {
-          state = initialState.apollo
-        }
-        const newState = context.apolloClient.reducer()(state, action);
-        return newState;
-      }
+        console.log(state);
+        // if (initialState && initialState.apollo && !_.isEmpty(initialState.apollo.data) && _.isEmpty(state.data)) {
+        //   state = initialState.apollo
+        // }
+        // const newState = context.apolloClient.extract();
+        // const newState = context.apolloClient.reducer()(state, action);
+        // TODO: Check if any of the reducer makes any sense in the future?
+        return context.apolloClient.extract();
+      };
       context.addReducer({ apollo: apolloClientReducer });
       context.store.reload();
       context.store.dispatch({ type: '@@nova/INIT' }) // the first dispatch will generate a newDispatch function from middleware
@@ -71,7 +74,8 @@ Meteor.startup(() => {
           return !(nextRouterProps.location.action === 'REPLACE');
         }))
       }));
-      return <ApolloProvider store={store} client={apolloClient}>{app}</ApolloProvider>;
+      return <ApolloProvider client={apolloClient}>{app}</ApolloProvider>;
+      // return <ApolloProvider store={store} client={apolloClient}>{app}</ApolloProvider>;
     },
   };
 

--- a/packages/vulcan-routing/lib/server/routing.jsx
+++ b/packages/vulcan-routing/lib/server/routing.jsx
@@ -22,7 +22,7 @@ Meteor.startup(() => {
   initializeFragments();
   populateComponentsApp();
   populateRoutesApp();
-  
+
   const indexRoute = _.filter(Routes, route => route.path === '/')[0];
   const childRoutes = _.reject(Routes, route => route.path === '/');
 
@@ -50,7 +50,8 @@ Meteor.startup(() => {
       store.reload();
       store.dispatch({ type: '@@nova/INIT' }) // the first dispatch will generate a newDispatch function from middleware
       const app = runCallbacks('router.server.wrapper', appGenerator(), { req, res, store, apolloClient });
-      return <ApolloProvider store={store} client={apolloClient}>{app}</ApolloProvider>;
+      return <ApolloProvider client={apolloClient}>{app}</ApolloProvider>;
+      // return <ApolloProvider store={store} client={apolloClient}>{app}</ApolloProvider>;
     },
     preRender(req, res, app) {
       runCallbacks('router.server.preRender', { req, res, app });
@@ -58,7 +59,9 @@ Meteor.startup(() => {
     },
     dehydrateHook(req, res) {
       const context = runCallbacks('router.server.dehydrate', getRenderContext(), { req, res });
-      return context.apolloClient.store.getState();
+      // will return the representation of Apollo Store.
+      // However, I am not sure if this will be necessary in the future
+      return context.apolloClient.extract();
     },
     postRender(req, res) {
       runCallbacks('router.server.postRender', { req, res });


### PR DESCRIPTION
This is the first stage of getting rid of redux. ApolloClients has no reducer anymore. The container HOCs will have to fetch from cache and Minimongo must go. Anyway, this version puts data into the cache but the components still refer to old reducers. So this will be the next update. Talking about getting rid of Minimongo, the subscriptions will have to be invoked somewhere. There is a pull request for subscriptions which puts subscriptions into the default Mutations which isn't the correct place for them, in my opinion. Some thoughts on where to put subscriptions, either you put a re-fetch into a Component mutation, or you utilize the middleware context, or you do some work on the cache which I have not figured out yet. However, I prefer the middleware solution for now. On that note, subscriptions should go in a separate package since those might not be necessary for all collections, this was also proposed in the pull request. Here is a thought querying several ApolloClient related issues. ApolloClient seems to change faster than I like and most people are unhappy that MDG doesn't provide for a redux reducer anymore. They would have hoped for a softer cut. I do feel this will put a dent in a fast adoption for ApolloClient 2.0. However, I really like what MDG delivered so far!