### PR TITLE
Add incorrect password string to en-us i18n

### DIFF
--- a/packages/vulcan-i18n-en-us/lib/en_US.js
+++ b/packages/vulcan-i18n-en-us/lib/en_US.js
@@ -2,6 +2,7 @@ import { addStrings } from 'meteor/vulcan:core';
 
 addStrings('en', {
 
+  "accounts.error_incorrect_password": "Incorrect password",
   "accounts.error_email_required": "Email required",
   "accounts.error_email_already_exists": "Email already exists",
   "accounts.error_invalid_email": "Invalid email",


### PR DESCRIPTION
I know sometimes you might not want to differentiate between incorrect password vs login but that logic should not happen at the level of translation. Without this string the error is just "Unknown".