### PR TITLE
Update FormComponent (custom control class)

### DIFF
--- a/packages/vulcan-forms/lib/components/FormComponent.jsx
+++ b/packages/vulcan-forms/lib/components/FormComponent.jsx
@@ -163,7 +163,7 @@ class FormComponent extends PureComponent {
   render() {
 
     const hasErrors = this.props.errors && this.props.errors.length;
-    const inputClass = classNames('form-input', `input-${this.props.name}`, `form-component-${this.props.control || 'default'}`,{'input-error': hasErrors});
+    const inputClass = classNames('form-input', `input-${this.props.name}`, `form-component-${this.props.control.componentName || 'default'}`,{'input-error': hasErrors});
 
     return (
       <div className={inputClass}>


### PR DESCRIPTION
Updated where previously custom control component would render its entirety in the class (now set to React's componentName attribute)