### PR TITLE
vulcan:debug : Components Dashboard now shows all hocs

### DIFF
--- a/packages/vulcan-debug/lib/components/Components.jsx
+++ b/packages/vulcan-debug/lib/components/Components.jsx
@@ -1,10 +1,21 @@
-import React from 'react';
-import { registerComponent, Components, ComponentsTable } from 'meteor/vulcan:lib';
+import React from "react";
+import {
+  registerComponent,
+  Components,
+  ComponentsTable
+} from "meteor/vulcan:lib";
 
-const ComponentHOCs = ({ document }) => 
-  <div><ul>{document.hocs.map((hoc, i) => <li key={i}>{hoc.name}</li>)}</ul></div>
+const ComponentHOCs = ({ document }) => (
+  <div>
+    <ul>
+      {document.hocs.map((hoc, i) => (
+        <li key={i}>{typeof hoc.name === "string" ? hoc.name : hoc[0].name}</li>
+      ))}
+    </ul>
+  </div>
+);
 
-const ComponentsDashboard = props => 
+const ComponentsDashboard = props => (
   <div className="components">
     <Components.Datatable
       showSearch={false}
@@ -12,13 +23,14 @@ const ComponentsDashboard = props =>
       showEdit={false}
       data={Object.values(ComponentsTable)}
       columns={[
-        'name',
+        "name",
         {
-          name: 'hocs',
+          name: "hocs",
           component: ComponentHOCs
-        },
+        }
       ]}
     />
   </div>
+);
 
-registerComponent('Components', ComponentsDashboard);
+registerComponent("Components", ComponentsDashboard);


### PR DESCRIPTION
Previously, the hocs registered with options (ex: `registerComponent('Foo', FooComponent, [withBar,barOptions])`   ) were not shown in the dashboard from the debug package