### PR TITLE
Remove sanitizeHtml import on client

### DIFF
--- a/packages/vulcan-lib/lib/modules/utils.js
+++ b/packages/vulcan-lib/lib/modules/utils.js
@@ -7,7 +7,6 @@ Utilities
 import marked from 'marked';
 import urlObject from 'url';
 import moment from 'moment';
-import sanitizeHtml from 'sanitize-html';
 import getSlug from 'speakingurl';
 import { getSetting, registerSetting } from './settings.js';
 import { Routes } from './routes.js';
@@ -208,20 +207,6 @@ Utils.cleanUp = function(s) {
 };
 
 Utils.sanitize = function(s) {
-  // console.log('// before sanitization:')
-  // console.log(s)
-  if(Meteor.isServer){
-    s = sanitizeHtml(s, {
-      allowedTags: [
-        'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul',
-        'ol', 'nl', 'li', 'b', 'i', 'strong', 'em', 'strike',
-        'code', 'hr', 'br', 'div', 'table', 'thead', 'caption',
-        'tbody', 'tr', 'th', 'td', 'pre', 'img'
-      ]
-    });
-    // console.log('// after sanitization:')
-    // console.log(s)
-  }
   return s;
 };
 

--- a/packages/vulcan-lib/lib/server/main.js
+++ b/packages/vulcan-lib/lib/server/main.js
@@ -12,3 +12,4 @@ export * from '../modules/index.js';
 export * from './mutators.js';
 export * from './render_context.js';
 export * from './inject_data.js';
+export * from './utils.js';

--- a/packages/vulcan-lib/lib/server/utils.js
+++ b/packages/vulcan-lib/lib/server/utils.js
@@ -1,0 +1,16 @@
+import sanitizeHtml from 'sanitize-html';
+
+import { Utils } from '../modules';
+
+Utils.sanitize = function(s) {
+  return sanitizeHtml(s, {
+    allowedTags: [
+      'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul',
+      'ol', 'nl', 'li', 'b', 'i', 'strong', 'em', 'strike',
+      'code', 'hr', 'br', 'div', 'table', 'thead', 'caption',
+      'tbody', 'tr', 'th', 'td', 'pre', 'img'
+    ]
+  });
+};
+
+export { Utils };


### PR DESCRIPTION
By importing this module on client many other server side only modules end up being bundled to the client and causing some issues with older browsers or [Cordova](https://github.com/VulcanJS/Vulcan/issues/1798), since those modules are not transpiled.

I've just refactored the code to prevent statically importing `sanitizeHtml` on the `modules/utils.js` (that is bundled to the client) and that it is only imported on the server.