### PR TITLE
Fix TypeError: this.formControl is undefined @ FormComponent.jsx:30:6

### DIFF
--- a/packages/vulcan-forms/lib/components/FormComponent.jsx
+++ b/packages/vulcan-forms/lib/components/FormComponent.jsx
@@ -27,7 +27,7 @@ class FormComponent extends PureComponent {
 
   handleBlur() {
     // see https://facebook.github.io/react/docs/more-about-refs.html
-    if (this.formControl !== null) {
+    if (this.formControl && this.formControl.getValue) {
       this.props.updateCurrentValues({[this.props.name]: this.formControl.getValue()});
     }
   }

--- a/packages/vulcan-forms/lib/components/FormComponent.jsx
+++ b/packages/vulcan-forms/lib/components/FormComponent.jsx
@@ -27,7 +27,7 @@ class FormComponent extends PureComponent {
 
   handleBlur() {
     // see https://facebook.github.io/react/docs/more-about-refs.html
-    if (this.formControl && this.formControl.getValue) {
+    if (this.formControl) {
       this.props.updateCurrentValues({[this.props.name]: this.formControl.getValue()});
     }
   }


### PR DESCRIPTION
Some user's of our site are experiencing this issue when submiting a form on Windows 7 and 10, both in Chrome and Firefox.

I've changed the check performed in order to update current values: `this.formControl` is not checked for null strict equality, but to safe retrieve the `getValue` property from it.

Another more restrictive option would be to check if `getValue` is indeed a function, but I think is unnecessary since `this.formControl` is being set in the `refFunction`.