### PR TITLE
Update mingo to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "marked": "^0.3.9",
     "metascraper": "^1.0.6",
     "meteor-node-stubs": "^0.2.3",
-    "mingo": "^0.8.1",
+    "mingo": "^2.2.0",
     "moment": "^2.13.0",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",

--- a/packages/vulcan-core/lib/modules/containers/withList.js
+++ b/packages/vulcan-core/lib/modules/containers/withList.js
@@ -236,7 +236,7 @@ const queryReducer = (previousResults, action, collection, mergedTerms, listReso
   const result = collection.getParameters(mergedTerms, apolloClient);
   const { selector, options } = result;
 
-  const mingoQuery = Mingo.Query(selector);
+  const mingoQuery = new Mingo.Query(selector);
 
   // function to remove a document from a results object, used by edit and remove cases below
   const removeFromResults = (results, document) => {

--- a/packages/vulcan-lib/lib/modules/mongo_redux.js
+++ b/packages/vulcan-lib/lib/modules/mongo_redux.js
@@ -4,7 +4,7 @@ Mongo.Collection.prototype.findInStore = function (store, selector = {}, options
   const typeName = this.options && this.options.typeName;
   const docs = _.where(store.getState().apollo.data, {__typename: typeName})
   
-  const mingoQuery = Mingo.Query(selector);
+  const mingoQuery = new Mingo.Query(selector);
 
   const cursor = mingoQuery.find(docs);
   const sortedDocs = cursor.sort(options.sort).all();


### PR DESCRIPTION
### Why update?

Basically I found that when having a query selector containing a nested field, mingo would not safe retrieve that value from the documents already present in the local state. That causes the `withList` HOC to break when inserting or editing documents of a type with an active query with that query selector.

More precisely, the change I'm interested in is from [getValue@0.8.1](https://github.com/kofrasa/mingo/blob/bc287e076630a568d92e8e444077172eeab9663f/mingo.js#L2417) to [getValue@2.2.0](https://github.com/kofrasa/mingo/blob/master/lib/internal.js#L140).

As you can see, in 2.2.0 the object is being checked before retrieving the value, so the error is avoided.

### Replicate error

1. Create a query that uses a selector with a nested field. For example:
```
{
  'someField.someProperty': true,
}
```
2. List elements using `withList` HOC and that query
3. Perform a `newMutation` (I think `editMutation` would trigger the error too) with a document of that type, but make sure that it is saved without that field. For example, the saved document would be:
```
{
  _id: '12345678',
  someField: null, // or simply not defined
}
```

The error is caused by mingo when trying to retrieve 'someProperty' from the retrieved 'someField', being it null and throwing the `TypeError: Cannot read property 'someProperty' of null`

### Revision/test

Note that I've made only the changes that I needed to run my projects -where I use the `withList` and perform `new` and `edit` mutations-, but I've not fully tested with the Vulcan-Starter examples. More in depth testing should be done to make sure that mingo hasn't had any breaking changes between versions 0 and 2.