### PR TITLE
use this.getCollection() instead of props.collection

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -66,9 +66,9 @@ class Form extends Component {
     };
 
     // convert SimpleSchema schema into JSON object
-    this.schema = convertSchema(props.collection.simpleSchema());
+    this.schema = convertSchema(this.getCollection().simpleSchema());
     // Also store all field schemas (including nested schemas) in a flat structure
-    this.flatSchema = convertSchema(props.collection.simpleSchema(), true);
+    this.flatSchema = convertSchema(this.getCollection().simpleSchema(), true);
 
     // the initial document passed as props
     this.initialDocument = merge({}, this.props.prefilledProps, this.props.document);


### PR DESCRIPTION
In vulcan-form, in Form.jsx, convertschema was using props.collection instead of this.getCollection() that was creating an error on using collectionName and not collection in Smartform: 
```js
<Components.SmartForm collectionName="myAwesomeCollection"/>
```

This fixes it