### PR TITLE
Fix nested forms after props renaming

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -305,10 +305,10 @@ class Form extends Component {
       field.help = fieldSchema.description;
     }
 
-    // nested fields: set formInput to "nested"
+    // nested fields: set input to "nested"
     if (fieldSchema.schema) {
       field.nestedSchema = fieldSchema.schema;
-      field.formInput = 'nested';
+      field.input = 'nested';
       // get nested schema
       // for each nested field, get field object by calling createField recursively
       field.nestedFields = this.getFieldNames({ schema: field.nestedSchema }).map(subFieldName => {

--- a/packages/vulcan-forms/lib/components/FormNested.jsx
+++ b/packages/vulcan-forms/lib/components/FormNested.jsx
@@ -62,8 +62,8 @@ class FormNested extends PureComponent {
   };
 
   render() {
-    // do not pass FormNested's own value and control props down
-    const properties = _.omit(this.props, 'value', 'control');
+    // do not pass FormNested's own value, control and inputProperties props down
+    const properties = _.omit(this.props, 'value', 'control', 'inputProperties');
 
     return (
       <div className="form-group row form-nested">


### PR DESCRIPTION
Commit 45d508c broke Nestedforms, this should do the trick. 
On Form.jsx, control was replaced by formInput in 45d508c, it should have been input. 
On FormNested, added inputProperties to omitted props passed to FormNestedInput, to avoid overwriting inputProperties of nested fields