### PR TITLE
Add MongoDB aggregation to Collections

### DIFF
--- a/packages/vulcan-lib/lib/modules/collections.js
+++ b/packages/vulcan-lib/lib/modules/collections.js
@@ -6,6 +6,7 @@ import { runCallbacks } from './callbacks.js';
 import { getSetting, registerSetting } from './settings.js';
 import { registerFragment, getDefaultFragmentText } from './fragments.js';
 import escapeStringRegexp from 'escape-string-regexp';
+wrapAsync = (Meteor.wrapAsync)? Meteor.wrapAsync : Meteor._wrapAsync;
 // import { debug } from './debug.js';
 
 registerSetting('maxDocumentsPerRequest', 1000, 'Maximum documents per request');
@@ -77,6 +78,16 @@ Mongo.Collection.prototype.addDefaultView = function (view) {
  */
 Mongo.Collection.prototype.addView = function (viewName, view) {
   this.views[viewName] = view;
+};
+
+/**
+ * @summary Allow mongodb aggregation
+ * @param {Array} pipelines mongodb pipeline
+ * @param {Object} options mongodb option object 
+ */
+Mongo.Collection.prototype.aggregate = function (pipelines, options) {
+  var coll = this.rawCollection();
+  return wrapAsync(coll.aggregate.bind(coll))(pipelines, options);
 };
 
 // see https://github.com/dburles/meteor-collection-helpers/blob/master/collection-helpers.js


### PR DESCRIPTION
It would be great to allow mongodb aggregation. I am personally using geoNear for example.
Since version 1.9.0 there is also connectors for mongodb. Maybe it would be better to add it there?
This was my solution for earlier releases.