### PR TITLE
Decompose complex objects to array of _id for CheckboxGroup

### DIFF
--- a/packages/vulcan-forms/lib/components/FormComponent.jsx
+++ b/packages/vulcan-forms/lib/components/FormComponent.jsx
@@ -198,10 +198,18 @@ class FormComponent extends PureComponent {
           return <Components.FormComponentCheckbox {...properties} />;
 
         case 'checkboxgroup':
-          // formsy-react-components expects an array value
-          // https://github.com/twisty/formsy-react-components/blob/v0.11.1/src/checkbox-group.js#L42
-          if (!Array.isArray(properties.inputProperties.value)) {
+          // Convert complex objects into list of _id
+          if (Array.isArray(properties.inputProperties.value)) {
+            const value = properties.inputProperties.value[0];
+            if (![null, undefined].includes(value) && typeof value === 'object' && value._id) {
+              properties.inputProperties.value = properties.inputProperties.value.map(({ _id }) => _id);
+              properties.value = properties.inputProperties.value;
+            }
+          } else {
+            // formsy-react-components expects an array value
+            // https://github.com/twisty/formsy-react-components/blob/v0.11.1/src/checkbox-group.js#L42
             properties.inputProperties.value = [properties.inputProperties.value];
+            properties.value = properties.inputProperties.value;
           }
           // in case of checkbox groups, check "checked" option to populate value if this is a "new document" form
           const checkedValues = _.where(properties.options, { checked: true }).map(option => option.value);


### PR DESCRIPTION
For CheckboxGroup, if your schema returns an array of objects (such as Categories for Posts), then the new form code will use that array of objects as the value for a CheckboxGroup. In this instance, we should check if the current value of `document` is an array of objects and then build a list of `_id` since this is a sane default behavior.