### PR TITLE
Fix field errors display

### DIFF
--- a/packages/vulcan-forms/lib/components/FieldErrors.jsx
+++ b/packages/vulcan-forms/lib/components/FieldErrors.jsx
@@ -10,7 +10,7 @@ const FieldErrors = ({ errors }) => (
         {error.message || (
           <FormattedMessage
             id={error.id}
-            values={{ ...error.data }}
+            values={{ ...error.data, ...error.properties }} //keep data for backwards compatibility ? 
             defaultMessage={JSON.stringify(error)}
           />
         )}


### PR DESCRIPTION
Added `error.properties` to follow fae7b5a03282b1e1586f5483a1f2717ed22c8cef .
Kept `error.data` for backwards compatibility, not sure that it's needed. If it is, it might be good to add it to FormErrors too