### PR TITLE
Change arrow functions into purecomponents

### DIFF
--- a/packages/vulcan-ui-bootstrap/lib/components/forms/Checkbox.jsx
+++ b/packages/vulcan-ui-bootstrap/lib/components/forms/Checkbox.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 import { Checkbox } from 'formsy-react-components';
 import { registerComponent } from 'meteor/vulcan:core';
 
-const CheckboxComponent = ({refFunction, inputProperties, ...properties}) => <Checkbox {...inputProperties} ref={refFunction} />
-
+class CheckboxComponent {
+  render() {
+    const { refFunction, inputProperties, ...properties } = this.props;
+    return <Checkbox {...inputProperties} ref={refFunction} />;
+  }
+}
 registerComponent('FormComponentCheckbox', CheckboxComponent);

--- a/packages/vulcan-ui-bootstrap/lib/components/forms/Checkboxgroup.jsx
+++ b/packages/vulcan-ui-bootstrap/lib/components/forms/Checkboxgroup.jsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { CheckboxGroup } from 'formsy-react-components';
 import { registerComponent } from 'meteor/vulcan:core';
 
-const CheckboxGroupComponent = ({refFunction, inputProperties, ...properties}) => <CheckboxGroup {...inputProperties} ref={refFunction} />
+class CheckboxGroupComponent {
+  render() {
+    const { refFunction, inputProperties, ...properties } = this.props;
+    return <CheckboxGroup {...inputProperties} ref={refFunction} />;
+  }
+}
 
 registerComponent('FormComponentCheckboxGroup', CheckboxGroupComponent);

--- a/packages/vulcan-ui-bootstrap/lib/components/forms/Default.jsx
+++ b/packages/vulcan-ui-bootstrap/lib/components/forms/Default.jsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { Input } from 'formsy-react-components';
 import { registerComponent } from 'meteor/vulcan:core';
 
-const Default = ({refFunction, inputProperties, ...properties}) => <Input {...inputProperties} ref={refFunction} type="text" />
+class Default extends React.PureComponent {
+  render() {
+    const {refFunction, inputProperties, ...properties} = this.props;
+    return <Input {...inputProperties} ref={refFunction} type='text' />;
+  }
+}
 
 registerComponent('FormComponentDefault', Default);

--- a/packages/vulcan-ui-bootstrap/lib/components/forms/Email.jsx
+++ b/packages/vulcan-ui-bootstrap/lib/components/forms/Email.jsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { Input } from 'formsy-react-components';
 import { registerComponent } from 'meteor/vulcan:core';
 
-const EmailComponent = ({refFunction, inputProperties, ...properties}) => <Input {...inputProperties} ref={refFunction} type="email" />
+class EmailComponent extends React.PureComponent {
+  render() {
+    const { refFunction, inputProperties, ...properties } = this.props;
+    return <Input {...inputProperties} ref={refFunction} type="email" />;
+  }
+}
 
 registerComponent('FormComponentEmail', EmailComponent);

--- a/packages/vulcan-ui-bootstrap/lib/components/forms/Number.jsx
+++ b/packages/vulcan-ui-bootstrap/lib/components/forms/Number.jsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { Input } from 'formsy-react-components';
 import { registerComponent } from 'meteor/vulcan:core';
 
-const NumberComponent = ({refFunction, inputProperties, ...properties}) => <Input {...inputProperties} ref={refFunction} type="number" />
+class NumberComponent extends React.PureComponent {
+  render() {
+    const {refFunction, inputProperties, ...properties} = this.props;
+    return <Input ref={refFunction} {...inputProperties} type="number"/>;
+  }
+}
 
 registerComponent('FormComponentNumber', NumberComponent);

--- a/packages/vulcan-ui-bootstrap/lib/components/forms/Radiogroup.jsx
+++ b/packages/vulcan-ui-bootstrap/lib/components/forms/Radiogroup.jsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { RadioGroup } from 'formsy-react-components';
 import { registerComponent } from 'meteor/vulcan:core';
 
-const RadioGroupComponent = ({refFunction, inputProperties, ...properties}) => <RadioGroup {...inputProperties} ref={refFunction}/>
+class RadioGroupComponent extends React.PureComponent {
+  render() {
+    const {refFunction, inputProperties, ...properties} = this.props;
+    return <RadioGroup {...inputProperties} ref={refFunction}/>;
+  }
+}
 
 registerComponent('FormComponentRadioGroup', RadioGroupComponent);

--- a/packages/vulcan-ui-bootstrap/lib/components/forms/Select.jsx
+++ b/packages/vulcan-ui-bootstrap/lib/components/forms/Select.jsx
@@ -2,6 +2,12 @@ import React from 'react';
 import { Select } from 'formsy-react-components';
 import { registerComponent } from 'meteor/vulcan:core';
 
-const SelectComponent = ({refFunction, inputProperties, ...properties}) => <Select {...inputProperties} ref={refFunction}/>
+class SelectComponent extends React.PureComponent {
+  render(){
+    console.log(this.props.name);
+    const {refFunction, inputProperties, ...properties} = this.props;
+    return <Select ref={refFunction} {...inputProperties}/>;
+  }
+}
 
 registerComponent('FormComponentSelect', SelectComponent);

--- a/packages/vulcan-ui-bootstrap/lib/components/forms/Textarea.jsx
+++ b/packages/vulcan-ui-bootstrap/lib/components/forms/Textarea.jsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { Textarea } from 'formsy-react-components';
 import { registerComponent } from 'meteor/vulcan:core';
 
-const TextareaComponent = ({refFunction, inputProperties, ...properties}) => <Textarea ref={refFunction} {...inputProperties}/>
+class TextareaComponent extends React.PureComponent {
+  render(){
+    const {refFunction, inputProperties, ...properties} = this.props;
+    return <Textarea ref={refFunction} {...inputProperties}/>;
+  }
+}
 
 registerComponent('FormComponentTextarea', TextareaComponent);

--- a/packages/vulcan-ui-bootstrap/lib/components/forms/Url.jsx
+++ b/packages/vulcan-ui-bootstrap/lib/components/forms/Url.jsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { Input } from 'formsy-react-components';
 import { registerComponent } from 'meteor/vulcan:core';
 
-const UrlComponent = ({refFunction, inputProperties, ...properties}) => <Input ref={refFunction} {...inputProperties} type="url" />
+class UrlComponent extends React.PureComponent {
+  render(){
+    const {refFunction, inputProperties, ...properties} = this.props;
+    return <Input ref={refFunction} {...inputProperties} type='url'/>;
+  }
+}
 
 registerComponent('FormComponentUrl', UrlComponent);


### PR DESCRIPTION
Arrow functions are not Pure and were updating at every form change. See #1967.
At this point, there are still some unwanted updates, but i think these are from `formsy-react-components`, so there is not much we can do about it unless getting rid of Formsy.