### PR TITLE
Include document prop in mutationErrorCallback method

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -594,7 +594,7 @@ class Form extends Component {
       this.props
         .editMutation(args)
         .then(this.editMutationSuccessCallback)
-        .catch(this.mutationErrorCallback);
+        .catch(error => this.mutationErrorCallback(document, error));
     }
   };
 
@@ -621,10 +621,7 @@ class Form extends Component {
           if (this.props.removeSuccessCallback) this.props.removeSuccessCallback({ documentId, documentTitle });
           if (this.props.refetch) this.props.refetch();
         })
-        .catch(error => {
-          // eslint-disable-next-line no-console
-          console.log(error);
-        });
+        .catch(error => this.mutationErrorCallback(document, error));
     }
   };
 

--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -621,7 +621,10 @@ class Form extends Component {
           if (this.props.removeSuccessCallback) this.props.removeSuccessCallback({ documentId, documentTitle });
           if (this.props.refetch) this.props.refetch();
         })
-        .catch(error => this.mutationErrorCallback(document, error));
+        .catch(error => {
+          // eslint-disable-next-line no-console
+          console.log(error);
+        });
     }
   };
 

--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -508,7 +508,7 @@ class Form extends Component {
   };
 
   // catch graphql errors
-  mutationErrorCallback = error => {
+  mutationErrorCallback = (document, error) => {
     this.setState(prevState => ({ disabled: false }));
 
     // eslint-disable-next-line no-console
@@ -524,9 +524,8 @@ class Form extends Component {
       this.throwError(error);
     }
 
-    // note: we don't have access to the document here :( maybe use redux-forms and get it from the store?
     // run error callback if it exists
-    // if (this.props.errorCallback) this.props.errorCallback(document, error);
+    if (this.props.errorCallback) this.props.errorCallback(document, error);
   };
 
   /*
@@ -567,7 +566,7 @@ class Form extends Component {
       this.props
         .newMutation({ document })
         .then(this.newMutationSuccessCallback)
-        .catch(this.mutationErrorCallback);
+        .catch(error => this.mutationErrorCallback(document, error));
     } else {
       // edit document form
 


### PR DESCRIPTION
This helps with the problem reported in https://github.com/VulcanJS/Vulcan/issues/1958 while using `errorCallback` on `SmartForm` component.
