### PR TITLE
Update FormSubmit.jsx

### DIFF
--- a/packages/vulcan-forms/lib/components/FormSubmit.jsx
+++ b/packages/vulcan-forms/lib/components/FormSubmit.jsx
@@ -33,7 +33,7 @@ const FormSubmit = ({
     {deleteDocument ? (
       <div>
         <hr />
-        <a href="javascript:void()" onClick={deleteDocument} className={`delete-link ${collectionName}-delete-link`}>
+        <a href="javascript:void(0)" onClick={deleteDocument} className={`delete-link ${collectionName}-delete-link`}>
           <Components.Icon name="close" /> <FormattedMessage id="forms.delete" />
         </a>
       </div>


### PR DESCRIPTION
`void` expects one argument, otherwise it throws `Uncaught SyntaxError: Unexpected token )`

```
> void()
Uncaught SyntaxError: Unexpected token )
> void(0)
undefined
```