### PR TITLE
Update Flash component and withMessages container

### DIFF
--- a/packages/vulcan-core/lib/modules/components/Flash.jsx
+++ b/packages/vulcan-core/lib/modules/components/Flash.jsx
@@ -21,19 +21,19 @@ class Flash extends PureComponent {
   }
 
   getProperties = () => {
-    const { errorObject } = this.props;
-    if (typeof errorObject === 'string') {
+    const messageObject = this.props.message;
+    if (typeof messageObject === 'string') {
       // if error is a string, use it as message
       return {
-        message: errorObject,
+        message: messageObject,
         type: 'error'
       }
     } else {
       // else return full error object after internationalizing message
-      const { id, message, properties } = errorObject;
+      const { id, message, properties } = messageObject;
       const translatedMessage = this.context.intl.formatMessage({ id, defaultMessage: message }, properties);
       return {
-        ...errorObject,
+        ...messageObject,
         message: translatedMessage,
       };
     }
@@ -42,7 +42,7 @@ class Flash extends PureComponent {
   render() {
 
     const { message, type } = this.getProperties();
-    const flashType = type === "error" ? "danger" : flashType; // if flashType is "error", use "danger" instead
+    const flashType = type === 'error' ? 'danger' : type; // if flashType is "error", use "danger" instead
 
     return (
       <Components.Alert className="flash-message" variant={flashType} onDismiss={this.dismissFlash}>
@@ -72,7 +72,7 @@ const FlashMessages = ({messages, clear, markAsSeen}) => {
   );
 }
 
-FlashMessages.displayName = "FlashMessages";
+FlashMessages.displayName = 'FlashMessages';
 
 registerComponent('FlashMessages', FlashMessages, withMessages);
 

--- a/packages/vulcan-core/lib/modules/containers/withMessages.js
+++ b/packages/vulcan-core/lib/modules/containers/withMessages.js
@@ -9,18 +9,17 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 /*
-  
+
   Messages actions
 
 */
 
 addAction({
   messages: {
-    flash(content, flashType) {
+    flash(content) {
       return {
         type: 'FLASH',
         content,
-        flashType,
       };
     },
     clear(i) {
@@ -45,7 +44,7 @@ addAction({
 
 
 /*
-  
+
   Messages reducers
 
 */
@@ -53,14 +52,20 @@ addAction({
 addReducer({
   messages: (state = [], action) => {
     // default values
-    const flashType = typeof action.flashType === 'undefined' ? 'error' : action.flashType;
+    const flashType = action.content && typeof action.content.type !== 'undefined' ? action.content.type : 'error';
     const currentMsg = typeof action.i === 'undefined' ? {} : state[action.i];
 
     switch(action.type) {
       case 'FLASH':
         return [
           ...state,
-          { _id: state.length, content: action.content, flashType, seen: false, show: true },
+          {
+            _id: state.length,
+            ...action.content,
+            type: flashType,
+            seen: false,
+            show: true,
+          },
         ];
       case 'MARK_AS_SEEN':
         return [


### PR DESCRIPTION
While testing the Posting edit action with latest from `devel` I stumbled on an issue:

```
Form.jsx:517
TypeError: Cannot read property 'id' of undefined
    at Flash._this.getProperties (Flash.jsx:33)
    at Flash.render (Flash.jsx:44)
    at finishClassComponent (modules.js?hash=ffcdd80922dc5d0dd7afe11426e1665a70c9d671:94083)
    at updateClassComponent (modules.js?hash=ffcdd80922dc5d0dd7afe11426e1665a70c9d671:94051)
    at beginWork (modules.js?hash=ffcdd80922dc5d0dd7afe11426e1665a70c9d671:94676)
    at performUnitOfWork (modules.js?hash=ffcdd80922dc5d0dd7afe11426e1665a70c9d671:97508)
    at workLoop (modules.js?hash=ffcdd80922dc5d0dd7afe11426e1665a70c9d671:97537)
    at renderRoot (modules.js?hash=ffcdd80922dc5d0dd7afe11426e1665a70c9d671:97568)
    at performWorkOnRoot (modules.js?hash=ffcdd80922dc5d0dd7afe11426e1665a70c9d671:98143)
    at performWork (modules.js?hash=ffcdd80922dc5d0dd7afe11426e1665a70c9d671:98064)
```

These js undefined errors breaks the entire application frontend.

---

Hi @SachaG, please let me know if this helps or if you have something different in mind.

I noticed recent changes here https://github.com/VulcanJS/Vulcan/commit/a086e6e584cfec0650da0acf92118bf776354b04 and found a fix. Not sure how much this would overall affect the platform tho.

As far as I understood, the `flash` action now will be triggered like this
```
this.props.flash({ id: 'posts.edit_success', type: 'success', properties: { title: post.title } });
```