### PR TITLE
withList Loading prop adjustment

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/withList.js
+++ b/packages/vulcan-core/lib/modules/containers/withList.js
@@ -154,7 +154,7 @@ const withList = (options) => {
                 results = props.data[listResolverName],
                 totalCount = props.data[totalResolverName],
                 networkStatus = props.data.networkStatus,
-                loading = props.data.networkStatus === 1,
+                loading = props.data.loading,
                 loadingMore = props.data.networkStatus === 2,
                 error = props.data.error,
                 propertyName = options.propertyName || 'results';


### PR DESCRIPTION
Follows the recommanded loading from Apollo. See the Apollo docs about [`data.networkstatus`](https://www.apollographql.com/docs/react/api/react-apollo.html#graphql-query-data-networkStatus) and [`data.loading`](https://www.apollographql.com/docs/react/api/react-apollo.html#graphql-query-data-loading).

One of the issue here was that `loading` did not cover the `refetch` method. The `loading` prop will now be set to `true` whenever some query is on flight, might it be an initial query, a refetch, a loadmore, a poll, or a variable change.
We can still differentiate a `loadmore` state from a `loading` state with the prop `loadmore` which behaviour has not changed.