### PR TITLE
Add selector to editMutation & subfields to withMutation

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/withEdit.js
+++ b/packages/vulcan-core/lib/modules/containers/withEdit.js
@@ -37,8 +37,8 @@ export default function withEdit(options) {
         mutationName = collection.options.mutations.edit.name;
 
   return graphql(gql`
-    mutation ${mutationName}($documentId: String, $set: ${collection.options.collectionName}Input, $unset: ${collection.options.collectionName}Unset) {
-      ${mutationName}(documentId: $documentId, set: $set, unset: $unset) {
+    mutation ${mutationName}($documentId: String, $set: ${collection.options.collectionName}Input, $unset: ${collection.options.collectionName}Unset, $selector: JSON) {
+      ${mutationName}(documentId: $documentId, set: $set, unset: $unset, selector: $selector) {
         ...${fragmentName}
       }
     }
@@ -49,7 +49,7 @@ export default function withEdit(options) {
       editMutation: (args) => {
         const { documentId, set, unset } = args;
         return mutate({ 
-          variables: { documentId, set, unset }
+          variables: { documentId, set, unset, selector }
           // note: updateQueries is not needed for editing documents
         });
       }

--- a/packages/vulcan-core/lib/modules/containers/withMutation.js
+++ b/packages/vulcan-core/lib/modules/containers/withMutation.js
@@ -1,35 +1,40 @@
 /*
 
-HoC that provides a simple mutation that expects a single JSON object in return
+ HoC that provides a simple mutation that expects a single JSON object in return
 
-Example usage:
+ Example usage:
 
-export default withMutation({
-  name: 'getEmbedData',
-  args: {url: 'String'},
-})(EmbedURL);
+ export default withMutation({
+ name: 'getEmbedData',
+ args: {url: 'String'},
+ })(EmbedURL);
 
-*/
+ */
 
 import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
 
-export default function withMutation({name, args}) {
+export default function withMutation({name, args, subfields}) {
 
   let mutation;
+
+  let subfieldSelection = '';
+  if (subfields) {
+    subfieldSelection = `__typename, ${subfields.reduce((final, current) => `, ${current}`, '')}`;
+  }
 
   if (args) {
     const args1 = _.map(args, (type, name) => `$${name}: ${type}`); // e.g. $url: String
     const args2 = _.map(args, (type, name) => `${name}: $${name}`); // e.g. $url: url
     mutation = `
       mutation ${name}(${args1}) {
-        ${name}(${args2})
+        ${name}(${args2})${subfieldSelection ? ` { ${subfieldSelection} }` : ''}
       }
     `
   } else {
     mutation = `
       mutation ${name} {
-        ${name}
+        ${name}${subfieldSelection ? ` { ${subfieldSelection}` : ''}
       }
     `
   }
@@ -38,7 +43,7 @@ export default function withMutation({name, args}) {
     alias: 'withMutation',
     props: ({ownProps, mutate}) => ({
       [name]: (vars) => {
-        return mutate({ 
+        return mutate({
           variables: vars,
         });
       }

--- a/packages/vulcan-core/lib/modules/default_mutations.js
+++ b/packages/vulcan-core/lib/modules/default_mutations.js
@@ -71,7 +71,7 @@ export const getDefaultMutations = (collectionName, options = {}) => {
         return Users.owns(user, document) ? Users.canDo(user, `${collectionName.toLowerCase()}.edit.own`) : Users.canDo(user, `${collectionName.toLowerCase()}.edit.all`);
       },
 
-      async mutation(root, {documentId, set, unset}, context) {
+      async mutation(root, { documentId, set, unset, selector }, context) {
 
         const collection = context[collectionName];
 
@@ -84,9 +84,10 @@ export const getDefaultMutations = (collectionName, options = {}) => {
         // call editMutator boilerplate function
         return await editMutator({
           collection, 
-          documentId: documentId, 
-          set: set, 
-          unset: unset, 
+          documentId: documentId,
+          set: set,
+          unset: unset,
+          selector: selector,
           currentUser: context.currentUser,
           validate: true,
           context,

--- a/packages/vulcan-lib/lib/modules/collections.js
+++ b/packages/vulcan-lib/lib/modules/collections.js
@@ -198,7 +198,9 @@ export const createCollection = options => {
     # An array of fields to insert
     set: ${collectionName}Input, 
     # An array of fields to delete
-    unset: ${collectionName}Unset
+    unset: ${collectionName}Unset,
+    # Fields to match on when doing update
+    selector: JSON
   ) : ${typeName}`, mutations.edit.description);
         mutationResolvers[mutations.edit.name] = mutations.edit.mutation.bind(mutations.edit);
       }


### PR DESCRIPTION
- Fix nested debug statements in resolvers when there's a graphql exception (prevent a pyramid of debug statements)
- Add `selector` as an option to `editMutation`. This allows you to match not only on `documentId` alone but also on anything you want. It will default to still using `documentId` if you do not provide a `selector`. This allows you to avoid race conditions where you only want to update a document based on a condition. For instance: `editMutation({ set: { wasUsed: true }, selector: { someOtherValue: 'myValue', wasUsed: false } })`. This would only update the record if some other thread or server had not set the value while this thread was attempting to set the same value.
- Allow a selection of subfields to be defined for `withMutation`. This is necessary if your mutation returns a complex object type instead of a basic Scalar. As it stands, the default Vulcan `withMutation` usages only have mutation which return things like `String` or `Float`. If you have a mutation which returns `Comment` for instance, it will fail with the classic GraphQL error `must have a selection of subfields`. This allows you to specify in your `withMutation` options which fields you want to use. `__typename` is included by default if you specify any subfields. Subfields could also be `[]` if you only wanted to include `__typename`.