### PR TITLE
check for redirect before trying to redirect

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/withAccess.js
+++ b/packages/vulcan-core/lib/modules/containers/withAccess.js
@@ -19,7 +19,7 @@ export default function withAccess (options) {
       // redirect on constructor if user cannot access
       constructor(props) {
         super(props);
-        if(!this.canAccess(props.currentUser)) {
+        if(!this.canAccess(props.currentUser) && typeof redirect === 'string') {
           props.router.push(redirect);
         }
       }


### PR DESCRIPTION
using `withAccess` without setting redirect used to crash the client because there was no test on `redirect`.  New behaviour is: if redirect is not a string then no redirection is done and the component simply is not displayed. If redirect is a string then we push to that direction in the constructor, as it was previously