### PR TITLE
Restrict value altering to allow multiple datatypes in FormComponent

### DIFF
--- a/packages/vulcan-forms/lib/components/FormComponent.jsx
+++ b/packages/vulcan-forms/lib/components/FormComponent.jsx
@@ -7,6 +7,8 @@ import { registerComponent } from 'meteor/vulcan:core';
 import debounce from 'lodash.debounce';
 import get from 'lodash/get';
 import merge from 'lodash/merge';
+import find from 'lodash/find';
+import isObjectLike from 'lodash/isObjectLike';
 import { isEmptyValue } from '../modules/utils.js';
 
 class FormComponent extends Component {
@@ -80,11 +82,11 @@ class FormComponent extends Component {
     if (isDeleted) {
       value = '';
     } else {
-      if (datatype[0].type === Array) {
+      if (Array.isArray(currentValue) && find(datatype, ['type', Array])) {
         // for object and arrays, use lodash's merge
         // if field type is array, use [] as merge seed to force result to be an array as well
         value = merge([], documentValue, currentValue);
-      } else if (datatype[0].type === Object) {
+      } else if (isObjectLike(currentValue) && find(datatype, ['type', Object])) {
         value = merge({}, documentValue, currentValue);
       } else {
         // note: value has to default to '' to make component controlled


### PR DESCRIPTION
## Problem

Values are casted to the first field's datatype without taking into account whether the field can have other types or if the actual values matches the first type.

## Use case

Have multiple data types for one field. As a concrete example, we are working on a files package that defines a field's type like:

```
const FileOrId = SimpleSchema.oneOf(
  // accept generic object so the file itself can be send the first time and be saved
  // into a files collection
  { type: Object, blackbox: true },
  // once the file is saved, the field will the document id as a reference to the document
  // in the files collection
  String,
);
```

The described problem causes the id to be merged with an object, so if the id is `'1234'` it is converted to `{0: '1', 1: '2', 2: '3', 3: '4'}`.

## Proposed solution

Cast value only if the current value is array or object, and if it is also a valid type. I don't know if it would be necessary perform the same check to the document Value.