### PR TITLE
Display field label on error messages in SmartForm

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -347,6 +347,12 @@ class Form extends Component {
       defaultMessage: this.state.flatSchema[fieldName].label,
     });
   };
+  
+  getLabelFromPath = path => {
+    const splittedPath = path.split('.');
+    const fieldName = splittedPath[splittedPath.length - 1];
+    return this.getLabel(fieldName);
+  }
 
   // --------------------------------------------------------------------- //
   // ------------------------------- Errors ------------------------------ //
@@ -365,6 +371,20 @@ class Form extends Component {
   */
   throwError = error => {
     let formErrors = getErrors(error);
+
+  //enhance errors with field label
+  //formErrors should always be an array but it's good to test before a map
+  if (Array.isArray(formErrors)) {
+    const formErrorsLabeled = formErrors.map(error => {
+      //check if the path is defined and is a string
+      if (typeof error.path === 'string') {
+        let labeledError = error;
+        let label = this.getLabelFromPath(error.path);
+        _.extend(labeledError, { properties: { label: label, ...error.properties } });
+        return labeledError;
+      } else return error; //don't label the field if path was not defined
+    });
+  }
 
     // eslint-disable-next-line no-console
     console.log(formErrors);


### PR DESCRIPTION
So i've worked a little on getting back to the original error displaying of errors in SmartForm, which included the label of the field concerned by the error.

**Current Behaviour**: The label of the field is not passed as an error value. The current messages are, for example : `Field "{name}" is required` where {name} is actually the name of the field in the schema, not its label; So if my field is called `userFavoriteMovie` and the label is "Favorite Movie" the error will display `Field "userFavoriteMovie" is required` instead of `Field "Favorite Movie" is required`, which is in my opinion not user-friendly. 

**Behaviour after this PR**: the errors are enhanced with: `properties.label` and we can now define our error message in i18n as: `Field "{label}" is required` . I used properties.label and not properties.name to avoid overriding the current API where the actual name of the field is returned, because someone could use the name too and i think it makes more sense in terms of naming. 

**I need feedback on the API about keeping properties.label or overwriting properties.name**
I will update the default translations to fit the API we chose in this PR too, so don't merge it now