### PR TITLE
SubSchema Fields

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -44,6 +44,7 @@ import compact from 'lodash/compact';
 import update from 'lodash/update';
 import merge from 'lodash/merge';
 import find from 'lodash/find';
+import pick from 'lodash/pick';
 import isEqualWith from 'lodash/isEqualWith';
 
 import { convertSchema, formProperties } from '../modules/schema_utils';
@@ -158,7 +159,7 @@ class Form extends Component {
     // only keep relevant fields
     // for intl fields, make sure we look in foo_intl and not foo
     const fields = this.getFieldNames({ excludeHiddenFields: false, replaceIntlFields: true });
-    let data = cloneDeep(_.pick(this.getDocument(), ...fields));
+    let data = pick(this.getDocument(), ...fields);
 
     // remove any deleted values
     // (deleted nested fields cannot be added to $unset, instead we need to modify their value directly)
@@ -723,6 +724,8 @@ class Form extends Component {
 
       // only keep unset keys that correspond to a field (get rid of nested keys)
       unsetKeys = _.intersection(unsetKeys, this.getFieldNames());
+
+      unsetKeys = unsetKeys.filter(key => !key.includes('.'));
 
       // build mutation arguments object
       const args = { documentId: document._id, set: set, unset: {} };

--- a/packages/vulcan-forms/lib/components/FormComponent.jsx
+++ b/packages/vulcan-forms/lib/components/FormComponent.jsx
@@ -32,7 +32,7 @@ class FormComponent extends Component {
     const { currentValues, deletedValues, errors } = nextProps;
     const { path } = this.props;
 
-    const valueChanged = currentValues[path] !== this.props.currentValues[path];
+    const valueChanged = get(currentValues, path) !== get(this.props.currentValues, path);
     const errorChanged = !isEqual(this.getErrors(errors), this.getErrors());
     const deleteChanged = deletedValues.includes(path) !== this.props.deletedValues.includes(path);
     const charsChanged = nextState.charsRemaining !== this.state.charsRemaining;
@@ -124,7 +124,7 @@ class FormComponent extends Component {
     // for intl field fetch the actual field value by adding .value to the path
     const path = p.locale ? `${this.getPath(p)}.value` : this.getPath(p);
     const documentValue = get(document, path);
-    const currentValue = currentValues[path];
+    const currentValue = get(currentValues, path);
     const isDeleted = p.deletedValues.includes(path);
 
     if (isDeleted) {

--- a/packages/vulcan-lib/lib/modules/collections.js
+++ b/packages/vulcan-lib/lib/modules/collections.js
@@ -331,9 +331,10 @@ export const createCollection = options => {
       }
     }
 
-    // limit number of items to 200 by default
+    // limit number of items to 1000 by default
     const maxDocuments = getSetting('maxDocumentsPerRequest', 1000);
-    parameters.options.limit = (!terms.limit || terms.limit < 1 || terms.limit > maxDocuments) ? maxDocuments : terms.limit;
+    const limit = terms.limit || parameters.options.limit;
+    parameters.options.limit = (!limit || limit < 1 || limit > maxDocuments) ? maxDocuments : limit;
 
     // console.log(parameters);
 


### PR DESCRIPTION
- Added support for fields that have their own subschema
- The code flattens the sub-fields, so the path for `address: { street }` becomes `'address.street'`
- The parent's values are also merged into each child - this way field properties like `editableBy` and `group` can be set on the parent for all children, and can still be overridden by children
- Minor changes were needed in several places to properly support paths, so `currentValues[path]` becomes `get(currentValues, path)`
- In Form.getData(), replaced underscore's `pick` with lodash's `pick` which properly supports paths and returns a new object
- Fixed a bug in collection.getParameters that made it impossible to specify a `limit` with addView or addDefaultView