### PR TITLE
Allow passing multiple args to HOCs

### DIFF
--- a/packages/vulcan-lib/lib/modules/components.js
+++ b/packages/vulcan-lib/lib/modules/components.js
@@ -57,7 +57,11 @@ export const getComponent = (name) => {
   if (!component) {
     throw new Error(`Component ${name} not registered.`)
   }
-  const hocs = component.hocs.map(hoc => Array.isArray(hoc) ? hoc[0](hoc[1]) : hoc);
+  const hocs = component.hocs.map(hoc => {
+    if(!Array.isArray(hoc)) return hoc;
+    const [actualHoc, ...args] = hoc;
+    return actualHoc(...args);
+  });
   return compose(...hocs)(component.rawComponent)
 };
 


### PR DESCRIPTION
I needed this for:
```
registerComponent('Component', Component, [withStyles, styles, { withTheme: true }], withCurrentUser);
```

where ```withStyles``` takes 2 args.