### PR TITLE
Remove hardcoded limit to users List resolver

### DIFF
--- a/packages/vulcan-users/lib/modules/resolvers.js
+++ b/packages/vulcan-users/lib/modules/resolvers.js
@@ -39,7 +39,6 @@ const resolvers = {
 
       // get selector and options from terms and perform Mongo query
       let {selector, options} = await Users.getParameters(terms);
-      options.limit = (terms.limit < 1 || terms.limit > 100) ? 100 : terms.limit;
       options.skip = terms.offset;
       const users = await Connectors.find(Users, selector, options);
 


### PR DESCRIPTION
The limit is already set in `Users.getParameters`, where it's taken from the setting `maxDocumentsPerRequest`, and was overwritten to be maxed at 100.