### PR TITLE
collection.getParameters handles schema extension for searchable fields

### DIFF
--- a/packages/vulcan-lib/lib/modules/collections.js
+++ b/packages/vulcan-lib/lib/modules/collections.js
@@ -246,8 +246,8 @@ export const createCollection = options => {
     if (terms.query) {
         
       const query = escapeStringRegexp(terms.query);
-
-      const searchableFieldNames = _.filter(_.keys(schema), fieldName => schema[fieldName].searchable);
+      const currentSchema = collection.simpleSchema()._schema; 
+      const searchableFieldNames = _.filter(_.keys(currentSchema), fieldName => currentSchema[fieldName].searchable);
       if (searchableFieldNames.length) {
         parameters = Utils.deepExtend(true, parameters, {
           selector: {


### PR DESCRIPTION
Instead of using `schema` passed when creating the collection, `getParameters` should fetch the schema from `collection.simpleSchema()._schema` to include the fields added with `collection.addField`.

I originally found this when trying to make the `groups` field searchable in the Users collection, with: 
```
Users.addField([
  {
    fieldName: 'groups',
    fieldSchema: {
      type: Array,
      searchable: true,
    },
  },
  {
    fieldName: 'groups.$',
    fieldSchema: {
      type: String,
    },
  },
]);
```

I thought a better way to define `collection.getParameters` was outside of `collection.createCollection`, like `collection.addField` is defined ( `Mongo.collection.prototype.addField = function (...) {...}` ), but when trying to rewrite it this way i stumbled on lots of errors, and found out that the committed solution is simpler to write and remains a valid solution.