### PR TITLE
Pass opencrud field properties to the form

### DIFF
--- a/packages/vulcan-forms/lib/modules/schema_utils.js
+++ b/packages/vulcan-forms/lib/modules/schema_utils.js
@@ -93,9 +93,12 @@ export const schemaProperties = [
   'onInsert', // field insert callback
   'onEdit', // field edit callback
   'onRemove', // field remove callback
-  'viewableBy',
-  'insertableBy',
-  'editableBy',
+  'canRead',
+  'canCreate',
+  'canUpdate',
+  'viewableBy', // OpenCRUD backwards compatibility
+  'insertableBy', // OpenCRUD backwards compatibility
+  'editableBy', // OpenCRUD backwards compatibility
   'resolveAs',
   'searchable',
   'description',


### PR DESCRIPTION
I was trying to use SmartForm with a collection only using the new OpenCrud API (`canRead` instead of `insertableBy`, etc) and I found that no fields were showing because the schema arriving to `Form.jsx` did not contain those properties.