### PR TITLE
Dynamic fragment initalization

### DIFF
--- a/packages/vulcan-lib/lib/modules/fragments.js
+++ b/packages/vulcan-lib/lib/modules/fragments.js
@@ -188,10 +188,18 @@ export const getFragmentText = fragmentName => {
 
 /*
 
+Get names of non initialized fragments.
+
+*/
+export const getNonInitializedFragmentNames = () =>
+  _.keys(Fragments).filter(name => !Fragments[name].fragmentObject);
+
+/*
+
 Perform all fragment extensions (called from routing)
 
 */
-export const initializeFragments = () => {
+export const initializeFragments = (fragments = getNonInitializedFragmentNames()) => {
 
   const errorFragmentKeys = [];
 
@@ -207,7 +215,7 @@ export const initializeFragments = () => {
   // create fragment objects
 
   // initialize fragments *with no subfragments* first to avoid unresolved dependencies
-  const keysWithoutSubFragments = _.filter(_.keys(Fragments), fragmentName => !Fragments[fragmentName].subFragments);
+  const keysWithoutSubFragments = _.filter(fragments, fragmentName => !Fragments[fragmentName].subFragments);
   _.forEach(keysWithoutSubFragments, fragmentName => {
     const fragment = Fragments[fragmentName];
     fragment.fragmentObject = getFragmentObject(fragment.fragmentText, fragment.subFragments)

--- a/packages/vulcan-lib/lib/modules/fragments.js
+++ b/packages/vulcan-lib/lib/modules/fragments.js
@@ -167,7 +167,7 @@ export const getFragment = fragmentName => {
     throw new Error(`Fragment "${fragmentName}" not registered.`);
   }
   if (!Fragments[fragmentName].fragmentObject) {
-    throw new Error(`Fragment "${fragmentName}" registered, but not initialized.`)
+    initializeFragments([fragmentName]);
   }
   // return fragment object created by gql
   return Fragments[fragmentName].fragmentObject;  


### PR DESCRIPTION
Features:

- more fine grained fragment initialization, as `initializeFragements` can now be parametrized with the names of the fragments to initialize (defaults to all non-initialized fragments)
- when retrieving an already registered fragment with `getFragment`, it will be initalized if it isn't

This allows:

1. to use HOCs such as `withList` at compile time. The only requirement now is that all the fragments used are registered.
2. to register fragments in dynamic imports and use them normally