### PR TITLE
Minor default resolvers and mutations improvements

### DIFF
--- a/packages/vulcan-core/lib/modules/default_mutations.js
+++ b/packages/vulcan-core/lib/modules/default_mutations.js
@@ -17,12 +17,12 @@ export function getDefaultMutations (options) {
     // new single-argument API
     typeName = arguments[0].typeName;
     collectionName = arguments[0].collectionName || getCollectionName(typeName);
-    mutationOptions = arguments[0].options || defaultOptions;
+    mutationOptions = { ...defaultOptions, ...arguments[0].options };
   } else {
     // OpenCRUD backwards compatibility
     collectionName = arguments[0];
     typeName = getTypeName(collectionName);
-    mutationOptions = arguments[1] || defaultOptions;
+    mutationOptions = { ...defaultOptions, ...arguments[1] };
   }
   
   // register callbacks for documentation purposes

--- a/packages/vulcan-core/lib/modules/default_mutations.js
+++ b/packages/vulcan-core/lib/modules/default_mutations.js
@@ -26,7 +26,7 @@ export function getDefaultMutations (options) {
   }
   
   // register callbacks for documentation purposes
-  registerCollectionCallbacks(typeName);
+  registerCollectionCallbacks(typeName, mutationOptions);
 
   const mutations = {};
 
@@ -201,124 +201,128 @@ export function getDefaultMutations (options) {
   return mutations;
 }
 
-const registerCollectionCallbacks = typeName => {
+const registerCollectionCallbacks = (typeName, options) => {
   typeName = typeName.toLowerCase();
 
-  registerCallback({
-    name: `${typeName}.create.validate`,
-    iterator: { document: 'The document being inserted' },
-    properties: [
-      { document: 'The document being inserted' },
-      { currentUser: 'The current user' },
-      { validationErrors: 'An object that can be used to accumulate validation errors' },
-    ],
-    runs: 'sync',
-    returns: 'document',
-    description: `Validate a document before insertion (can be skipped when inserting directly on server).`,
-  });
-  registerCallback({
-    name: `${typeName}.create.before`,
-    iterator: { document: 'The document being inserted' },
-    properties: [ { currentUser: 'The current user' }],
-    runs: 'sync',
-    returns: 'document',
-    description: `Perform operations on a new document before it's inserted in the database.`,
-  });
-  registerCallback({
-    name: `${typeName}.create.after`,
-    iterator: { document: 'The document being inserted' },
-    properties: [{ currentUser: 'The current user' }],
-    runs: 'sync',
-    returns: 'document',
-    description: `Perform operations on a new document after it's inserted in the database but *before* the mutation returns it.`,
-  });
-  registerCallback({
-    name: `${typeName}.create.async`,
-    iterator: { document: 'The document being inserted' },
-    properties: [
-      { currentUser: 'The current user' },
-      { collection: 'The collection the document belongs to' },
-    ],
-    runs: 'async',
-    returns: null,
-    description: `Perform operations on a new document after it's inserted in the database asynchronously.`,
-  });
-
-  registerCallback({
-    name: `${typeName}.update.validate`,
-    iterator: { data: 'The client data' },
-    properties: [
-      { document: 'The document being edited' },
-      { currentUser: 'The current user' },
-      { validationErrors: 'An object that can be used to accumulate validation errors' },
-    ],
-    runs: 'sync',
-    returns: 'modifier',
-    description: `Validate a document before update (can be skipped when updating directly on server).`,
-  });
-  registerCallback({
-    name: `${typeName}.update.before`,
-    iterator: { data: 'The client data'},
-    properties: [
-      { document: 'The document being edited' },
-      { currentUser: 'The current user' },
-    ],
-    runs: 'sync',
-    returns: 'modifier',
-    description: `Perform operations on a document before it's updated in the database.`,
-  });
-  registerCallback({
-    name: `${typeName}.update.after`,
-    iterator: { newDocument: 'The document after the update'},
-    properties: [
-      { document: 'The document being edited' },
-      { currentUser: 'The current user' },
-    ],
-    runs: 'sync',
-    returns: 'document',
-    description: `Perform operations on a document after it's updated in the database but *before* the mutation returns it.`,
-  });
-  registerCallback({
-    name: `${typeName}.update.async`,
-    iterator: { newDocument: 'The document after the edit' },
-    properties: [
-      { document: 'The document before the edit' },
-      { currentUser: 'The current user' },
-      { collection: 'The collection the document belongs to' },
-    ],
-    runs: 'async',
-    returns: null,
-    description: `Perform operations on a document after it's updated in the database asynchronously.`,
-  });
-
-  registerCallback({
-    name: `${typeName}.delete.validate`,
-    iterator: { document: 'The document being removed' },
-    properties: [
-      { currentUser: 'The current user' },
-      { validationErrors: 'An object that can be used to accumulate validation errors' },
-    ],
-    runs: 'sync',
-    returns: 'document',
-    description: `Validate a document before removal (can be skipped when removing directly on server).`,
-  });
-  registerCallback({
-    name: `${typeName}.delete.before`,
-    iterator: { document: 'The document being removed' },
-    properties: [{ currentUser: 'The current user' }],
-    runs: 'sync',
-    returns: null,
-    description: `Perform operations on a document before it's removed from the database.`,
-  });
-  registerCallback({
-    name: `${typeName}.delete.async`,
-    properties: [
-      { document: 'The document being removed' },
-      { currentUser: 'The current user' },
-      { collection: 'The collection the document belongs to' },
-    ],
-    runs: 'async',
-    returns: null,
-    description: `Perform operations on a document after it's removed from the database asynchronously.`,
-  });
+  if (options.create) {
+    registerCallback({
+      name: `${typeName}.create.validate`,
+      iterator: { document: 'The document being inserted' },
+      properties: [
+        { document: 'The document being inserted' },
+        { currentUser: 'The current user' },
+        { validationErrors: 'An object that can be used to accumulate validation errors' },
+      ],
+      runs: 'sync',
+      returns: 'document',
+      description: `Validate a document before insertion (can be skipped when inserting directly on server).`,
+    });
+    registerCallback({
+      name: `${typeName}.create.before`,
+      iterator: { document: 'The document being inserted' },
+      properties: [{ currentUser: 'The current user' }],
+      runs: 'sync',
+      returns: 'document',
+      description: `Perform operations on a new document before it's inserted in the database.`,
+    });
+    registerCallback({
+      name: `${typeName}.create.after`,
+      iterator: { document: 'The document being inserted' },
+      properties: [{ currentUser: 'The current user' }],
+      runs: 'sync',
+      returns: 'document',
+      description: `Perform operations on a new document after it's inserted in the database but *before* the mutation returns it.`,
+    });
+    registerCallback({
+      name: `${typeName}.create.async`,
+      iterator: { document: 'The document being inserted' },
+      properties: [
+        { currentUser: 'The current user' },
+        { collection: 'The collection the document belongs to' },
+      ],
+      runs: 'async',
+      returns: null,
+      description: `Perform operations on a new document after it's inserted in the database asynchronously.`,
+    });
+  }
+  if (options.update) {
+    registerCallback({
+      name: `${typeName}.update.validate`,
+      iterator: { data: 'The client data' },
+      properties: [
+        { document: 'The document being edited' },
+        { currentUser: 'The current user' },
+        { validationErrors: 'An object that can be used to accumulate validation errors' },
+      ],
+      runs: 'sync',
+      returns: 'modifier',
+      description: `Validate a document before update (can be skipped when updating directly on server).`,
+    });
+    registerCallback({
+      name: `${typeName}.update.before`,
+      iterator: { data: 'The client data' },
+      properties: [
+        { document: 'The document being edited' },
+        { currentUser: 'The current user' },
+      ],
+      runs: 'sync',
+      returns: 'modifier',
+      description: `Perform operations on a document before it's updated in the database.`,
+    });
+    registerCallback({
+      name: `${typeName}.update.after`,
+      iterator: { newDocument: 'The document after the update' },
+      properties: [
+        { document: 'The document being edited' },
+        { currentUser: 'The current user' },
+      ],
+      runs: 'sync',
+      returns: 'document',
+      description: `Perform operations on a document after it's updated in the database but *before* the mutation returns it.`,
+    });
+    registerCallback({
+      name: `${typeName}.update.async`,
+      iterator: { newDocument: 'The document after the edit' },
+      properties: [
+        { document: 'The document before the edit' },
+        { currentUser: 'The current user' },
+        { collection: 'The collection the document belongs to' },
+      ],
+      runs: 'async',
+      returns: null,
+      description: `Perform operations on a document after it's updated in the database asynchronously.`,
+    });
+  }
+  if (options.delete) {
+    registerCallback({
+      name: `${typeName}.delete.validate`,
+      iterator: { document: 'The document being removed' },
+      properties: [
+        { currentUser: 'The current user' },
+        { validationErrors: 'An object that can be used to accumulate validation errors' },
+      ],
+      runs: 'sync',
+      returns: 'document',
+      description: `Validate a document before removal (can be skipped when removing directly on server).`,
+    });
+    registerCallback({
+      name: `${typeName}.delete.before`,
+      iterator: { document: 'The document being removed' },
+      properties: [{ currentUser: 'The current user' }],
+      runs: 'sync',
+      returns: null,
+      description: `Perform operations on a document before it's removed from the database.`,
+    });
+    registerCallback({
+      name: `${typeName}.delete.async`,
+      properties: [
+        { document: 'The document being removed' },
+        { currentUser: 'The current user' },
+        { collection: 'The collection the document belongs to' },
+      ],
+      runs: 'async',
+      returns: null,
+      description: `Perform operations on a document after it's removed from the database asynchronously.`,
+    });
+  }
 };

--- a/packages/vulcan-core/lib/modules/default_mutations.js
+++ b/packages/vulcan-core/lib/modules/default_mutations.js
@@ -16,7 +16,7 @@ export function getDefaultMutations (options) {
   if (typeof arguments[0] === 'object') {
     // new single-argument API
     typeName = arguments[0].typeName;
-    collectionName = getCollectionName(typeName); // TODO: find more reliable way to get type name from collection name?
+    collectionName = arguments[0].collectionName || getCollectionName(typeName);
     mutationOptions = arguments[0].options || defaultOptions;
   } else {
     // OpenCRUD backwards compatibility

--- a/packages/vulcan-core/lib/modules/default_resolvers.js
+++ b/packages/vulcan-core/lib/modules/default_resolvers.js
@@ -19,12 +19,12 @@ export function getDefaultResolvers(options) {
     // new single-argument API
     typeName = arguments[0].typeName;
     collectionName = arguments[0].collectionName || getCollectionName(typeName);
-    resolverOptions = arguments[0].options || defaultOptions;
+    resolverOptions = { ...defaultOptions, ...arguments[0].options };
   } else {
     // OpenCRUD backwards compatibility
     collectionName = arguments[0];
     typeName = getTypeName(collectionName);
-    resolverOptions = arguments[1] || defaultOptions;
+    resolverOptions = { ...defaultOptions, ...arguments[1] };
   }
   
   return {

--- a/packages/vulcan-core/lib/modules/default_resolvers.js
+++ b/packages/vulcan-core/lib/modules/default_resolvers.js
@@ -18,7 +18,7 @@ export function getDefaultResolvers(options) {
   if (typeof arguments[0] === 'object') {
     // new single-argument API
     typeName = arguments[0].typeName;
-    collectionName = getCollectionName(typeName); // TODO: find more reliable way to get type name from collection name
+    collectionName = arguments[0].collectionName || getCollectionName(typeName);
     resolverOptions = arguments[0].options || defaultOptions;
   } else {
     // OpenCRUD backwards compatibility

--- a/packages/vulcan-lib/lib/modules/collections.js
+++ b/packages/vulcan-lib/lib/modules/collections.js
@@ -20,8 +20,10 @@ export const Collections = [];
 
 export const getCollection = name => Collections.find(({ options: { collectionName }}) => name === collectionName || name === collectionName.toLowerCase());
 
+// TODO: find more reliable way to get collection name from type name?
 export const getCollectionName = typeName => Utils.pluralize(typeName);
 
+// TODO: find more reliable way to get type name from collection name?
 export const getTypeName = collectionName => collectionName.slice(0,-1);
 
 /**


### PR DESCRIPTION
- allow to specify the `collectionName` for the single-argument API
- merge default options
- register callbacks only for created mutations