### PR TITLE
Warn when replacing a non-registered component and register it anyway

### DIFF
--- a/packages/vulcan-lib/lib/modules/components.js
+++ b/packages/vulcan-lib/lib/modules/components.js
@@ -97,8 +97,8 @@ export const populateComponentsApp = () => {
  * This function keeps track of the previous HOCs and wrap the new HOCs around previous ones
  *
  * @param {String} name The name of the component to register.
- * @param {React Component} rawComponent Interchangeable/extendable component.
- * @param {...Function} hocs The HOCs to compose with the raw component.
+ * @param {React Component} newComponent Interchangeable/extendable component.
+ * @param {...Function} newHocs The HOCs to compose with the raw component.
  * @returns {Function|React Component} A component callable with Components[name]
  *
  * Note: when a component is registered without higher order component, `hocs` will be
@@ -107,8 +107,17 @@ export const populateComponentsApp = () => {
  */
  export const replaceComponent = (name, newComponent, ...newHocs) => {
   const previousComponent = ComponentsTable[name];
-  
-  // xxx : throw an error if the previous component doesn't exist
+
+  if (!previousComponent) {
+    console.warn(
+      `Trying to replace non-registered component ${name}. The component is ` +
+      'being registered. If you were trying to replace a component defined by ' +
+      'another package, make sure that you haven\'t misspelled the name. Check ' +
+      'also if the original component is still being registered or that it ' +
+      'hasn\'t been renamed.',
+    );
+    return registerComponent(name, newComponent, ...newHocs);
+  }
 
   // console.log('// replacing component');
   // console.log(name);


### PR DESCRIPTION
@SachaG feel free to improve the warning in order to make it more understandable.

Example of current message:

>Trying to replace non-registered component FormNested. The component is being registered. If you were trying to replace a component defined by another package, make sure that you haven't misspelled the name. Check also if the original component is still being registered or that it hasn't been renamed.