### PR TITLE
[Forms] Add currentDocument to clearForm

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -705,6 +705,7 @@ class SmartForm extends Component {
     this.setState(prevState => ({
       errors: clearErrors ? [] : prevState.errors,
       currentValues: clearCurrentValues ? {} : prevState.currentValues,
+      currentDocument: clearCurrentValues ? {} : prevState.currentDocument,
       deletedValues: clearDeletedValues ? [] : prevState.deletedValues,
       initialDocument: document && !clearCurrentValues ? document : prevState.initialDocument,
       disabled: false,


### PR DESCRIPTION
allows for the form fields to be correctly cleared when calling clearForm with `clearCurrentValues == true`