### PR TITLE
OpenCRUD fixes

### DIFF
--- a/packages/vulcan-lib/lib/server/mutators.js
+++ b/packages/vulcan-lib/lib/server/mutators.js
@@ -108,7 +108,7 @@ export const createMutator = async ({ collection, document, data, currentUser, v
   // }
 
   // run sync callbacks
-  newDocument = await runCallbacks({ name: `${typeName}.create.before`, iterator: newDocument, properties: { currentUser }});
+  newDocument = await runCallbacks({ name: `${typeName.toLowerCase()}.create.before`, iterator: newDocument, properties: { currentUser }});
   newDocument = await runCallbacks({ name: `*.create.before`, iterator: newDocument, properties: { currentUser }});
   // OpenCRUD backwards compatibility
   newDocument = await runCallbacks(`${collectionName.toLowerCase()}.new.before`, newDocument, currentUser);

--- a/packages/vulcan-users/lib/modules/mutations.js
+++ b/packages/vulcan-users/lib/modules/mutations.js
@@ -1,4 +1,4 @@
-import { createMutator, updateMutator, deleteMutator, Utils, Connectors } from 'meteor/vulcan:lib';
+import { createMutator, updateMutator, deleteMutator, Utils, Connectors, registerCallback } from 'meteor/vulcan:lib';
 import Users from './collection'; // TODO: circular dependency?
 
 const performCheck = (mutation, user, document) => {
@@ -95,3 +95,121 @@ const mutations = {
 };
 
 export default mutations;
+
+registerCallback({
+  name:'user.create.validate',
+  iterator: {document:'the document being inserted'},
+  properties: [
+    { document: 'The document being inserted' },
+    { currentUser: 'The current user' },
+    { validationErrors: 'An object that can be used to accumulate validation errors' },
+  ],
+  runs: 'sync',
+  returns: 'document',
+  description: `Validate a document before insertion (can be skipped when inserting directly on server).`,
+});
+registerCallback({
+  name:'user.create.before',
+  iterator: {document:'the document being inserted'},
+  properties: [
+    { document: 'The document being inserted' },
+    { currentUser: 'The current user' },
+    { validationErrors: 'An object that can be used to accumulate validation errors' },
+  ],
+  runs: 'sync',
+  returns: 'document',
+  description: `Perform operations on a new document before it's inserted in the database.`,
+});
+registerCallback({
+  name:'user.create.after',
+  iterator: {document:'the document after being inserted in the database'},
+  properties: [
+    { currentUser: 'The current user' },
+  ],
+  runs: 'sync',
+  returns: 'document',
+  description: `Perform operations on a new document after it's inserted in the database but *before* the mutation returns it.`,
+});
+registerCallback({
+  name:'user.create.async',
+  iterator: {data:'the document after being inserted in the database'},
+  properties: [
+    {insertedDocument: 'The document that was inserted to the collection'},
+    { currentUser: 'The current user' },
+    {collection: 'The Users collection'}
+  ],
+  runs: 'async',
+  returns: 'document',
+  description: `Perform operations on a new document after it's inserted in the database asynchronously.`,
+});
+registerCallback({
+  name: 'user.update.validate',
+  iterator: {data: 'The client data'},
+  properties: [
+    {document: 'The document being updated'}, 
+    {currentUser: 'The current user.'},
+    {validationErrors: 'an object that can be used to accumulate validation errors.'},
+  ],
+  runs: 'sync',
+  description: 'Validate a document before update (can be skipped when updating directly on server).'
+});
+registerCallback({
+  name: 'user.update.before',
+  iterator: {data:'The client data'},
+  properties: [
+    {document: 'The document being edited'},
+    {currentUser: 'The current user'},
+    {newDocument: 'A preview of the future document'},
+  ],
+  runs: 'sync',
+  description: `Perform operations on a document before it's updated on the database.`,
+});
+registerCallback({
+  name: 'user.update.after',
+  iterator: {newdocument: 'The document after the update'},
+  properties: [
+    {document: 'The document before the update'},
+    {currentUser: 'The current user'},
+  ],
+  runs: 'sync',
+  description: `Perform operations on a document after it's updated in the database but *before* the mutation returns it.`
+});
+registerCallback({
+  name: 'user.update.async',
+  properties: [
+    {newDocument: 'The document after the update'},
+    {document: 'The document before the update'},
+    {currentUser: 'The current user'},
+    {collection: 'The Users collection'},
+  ],
+  runs: 'async',
+  description: `Perform operations on a document after it's updated in the database asynchronously.`
+});
+registerCallback({
+  name: 'user.delete.validate',
+  iterator: {document: 'The document being deleted'},
+  properties: [
+    {currentUser: 'The current user'},
+  ],
+  runs: 'sync',
+  description: `Validate a document before deletion (can be skipped when deleting directly on the server)`
+});
+registerCallback({
+  name: 'user.delete.before',
+  iterator: {document: 'The document being deleted'},
+  properties: [
+    {currentUser: 'The current user'},
+  ],
+  runs: 'sync',
+  description: `Perform operations on a document before it's deleted from the database`,
+});
+registerCallback({
+  name: 'user.delete.async',
+  properties:[
+    {document: 'The document being deleted'},
+    {currentUser: 'The current user'},
+    {collection: 'The Users collection'},
+  ],
+  runs: 'async',
+  description: `Perform operations on a document after it's deleted from the database asynchronously.`
+});

--- a/packages/vulcan-users/lib/modules/mutations.js
+++ b/packages/vulcan-users/lib/modules/mutations.js
@@ -19,7 +19,7 @@ const createMutation = {
 
   mutation(root, { data }, context) {
     const { Users, currentUser } = context;
-    performCheck(this, currentUser, document);
+    performCheck(this, currentUser, data);
 
     return createMutator({
       collection: Users,

--- a/packages/vulcan-users/lib/server/on_create_user.js
+++ b/packages/vulcan-users/lib/server/on_create_user.js
@@ -52,7 +52,7 @@ function onCreateUserCallback(options, user) {
       user[fieldName] = autoValue;
     }
   }
-
+  user = runCallbacks({ name: 'user.create.before', iterator: user });
   user = runCallbacks('users.new.sync', user);
 
   runCallbacksAsync({name: "user.create.async", properties: {data: user}});

--- a/packages/vulcan-users/lib/server/on_create_user.js
+++ b/packages/vulcan-users/lib/server/on_create_user.js
@@ -14,7 +14,7 @@ function onCreateUserCallback(options, user) {
   delete options.password; // we don't need to store the password digest
   delete options.username; // username is already in user object
 
-  options = runCallbacks(`user.new.validate.before`, options);
+  options = runCallbacks({name: `user.create.validate.before`, iterator: options});
   // OpenCRUD backwards compatibility
   options = runCallbacks(`users.new.validate.before`, options);
 
@@ -33,7 +33,7 @@ function onCreateUserCallback(options, user) {
   user = Object.assign(user, options);
 
   // run validation callbacks
-  user = runCallbacks(`user.new.validate`, user);
+  user = runCallbacks({name:`user.create.validate`, iterator: user});
   // OpenCRUD backwards compatibility
   user = runCallbacks(`users.new.validate`, user);
 
@@ -55,7 +55,7 @@ function onCreateUserCallback(options, user) {
 
   user = runCallbacks('users.new.sync', user);
 
-  runCallbacksAsync("user.new.async", user);
+  runCallbacksAsync({name: "user.create.async", properties: {data: user}});
   // OpenCRUD backwards compatibility
   runCallbacksAsync("users.new.async", user);
 

--- a/packages/vulcan-users/lib/server/urls.js
+++ b/packages/vulcan-users/lib/server/urls.js
@@ -1,4 +1,7 @@
-if (typeof Accounts !== 'undefined') {
-  Accounts.urls.resetPassword = (token) => Meteor.absoluteUrl(`reset-password/${token}`);
-  Accounts.urls.enrollAccount = (token) => Meteor.absoluteUrl(`enroll-account/${token}`);
-}
+Meteor.startup(() => {
+  console.log(typeof Accounts);
+  if (typeof Accounts !== 'undefined') {
+    Accounts.urls.resetPassword = token => Meteor.absoluteUrl(`reset-password/${token}`);
+    Accounts.urls.enrollAccount = token => Meteor.absoluteUrl(`enroll-account/${token}`);
+  }
+});


### PR DESCRIPTION
Various fixes on the openCrud features, mostly regarding users and mutators: 

### Users 
- In my last PR #2033 i left a small bug. It's fixed, hopefully there are none left since i've done more testing on the mutations. 45e951a
- The user callback hooks are now registered and can be seen at `localhost:3000/callbacks` with the debug package enabled. fad9db6
- The usual user creation workflow (sign-up through Accounts.createUser) did not call `user.create.before` 80d390e
- Release 1.11.1 broke the urls in enrollment and password reset emails in f3c1f7bf3191742525c5d8408662ab68ea8a18f4, putting them back to the default Meteor ones (with the `/#/`). 4c4f11b

### Mutators
- The default mutator for creation called `Typename.create.before` instead of `typename.create.before`. The upper case was in contradiction with the rest of the callback API. It was also using `runCallbacks` the old way, with multiple arguments instead of one. 3492ac4