### PR TITLE
defer creation of apolloClient until it is first used

### DIFF
--- a/packages/vulcan-lib/lib/client/render_context.js
+++ b/packages/vulcan-lib/lib/client/render_context.js
@@ -14,15 +14,12 @@ export const initContext = () => {
   // init
   const history = browserHistory;
   const loginToken = global.localStorage['Meteor.loginToken'];
-  const apolloClient = createApolloClient();
-  addReducer({ apollo: apolloClient.reducer() });
-  addMiddleware(apolloClient.middleware());
+  let apolloClient;
 
   // init context
   context = {
     history,
     loginToken,
-    apolloClient,
     addAction, // context.addAction same as addAction
     getActions, // context.getActions same as getActions
     addReducer, // context.addReducer same as addReducer
@@ -30,6 +27,19 @@ export const initContext = () => {
     addMiddleware, // context.addMiddleware same as addMiddleware
     getMiddlewares, // context.getMiddlewares same as getMiddlewares
   };
+
+  // defer creation of apolloClient until it is first used
+  Object.defineProperty(context, 'apolloClient', {
+    enumerable: true,
+    get: () => {
+      if (!apolloClient) {
+        apolloClient = createApolloClient();
+        addReducer({ apollo: apolloClient.reducer() });
+        addMiddleware(apolloClient.middleware());
+      }
+      return apolloClient;
+    },
+  });
 
   // init store
   context.store = configureStore(context.getReducers, {}, (store) => {


### PR DESCRIPTION
I've found that the context is initialized quite early (due to `loginToken` being set by [resetToken](https://github.com/VulcanJS/Vulcan/blob/485f7bad379ba3021278e3cf8de0f2ad23bf6be4/packages/vulcan-lib/lib/client/auth.js#L23)), and usually before many modules have been yet executed. That causes that the `apolloClient` is created before many of the collections are created.

Though in most cases that is not a problem (because the client does not need to know about collections, types, etc.), this causes some problems in more advanced use cases, mainly when using interfaces or unions.

In my particular case, I have a project that relies extensivelly in interfaces. In the hook `apolloclient.init.before` I'm preparing a fragment matcher so the apollo client knows which interfaces exist and which types implement them. The problem is that, as estated above, apollo client is created way early and collections do not exist in `apolloclient.init.before` hook, making it impossible to prepare the fragment matcher types. (ofc it could be done in a hardcoded way, but that is far from ideal).

Changes in this PR are quite simple: `context.apolloClient` is now a getter that will create it the first time it is invoked.
