### PR TITLE
[WIP] Improve Users creation/management workflows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Vulcan",
-  "version": "1.12.0",
+  "version": "1.12.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -25,12 +25,24 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.38.tgz",
-      "integrity": "sha512-ZvPtlcvH2ZRzr1U5pkmCE7U3RIun3Nf29XHem47aScmJgMuL06ulkp+4oPBee3QrUVFErDjwNWtC67BzNuxLVw==",
+      "version": "7.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.55.tgz",
+      "integrity": "sha1-C8M6paasCwEvN+JbnmqqLkiakWs=",
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.1"
+        "core-js": "^2.5.7",
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
       }
     },
     "@segment/loosely-validate-event": {
@@ -5285,11 +5297,11 @@
           "version": "git+https://github.com/meteor/readable-stream.git#2e9112d7d31a2af6e0682db0e18679b1e5fd4694",
           "from": "git+https://github.com/meteor/readable-stream.git",
           "requires": {
-            "inherits": "~2.0.1",
+            "inherits": "~2.0.3",
             "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "^5.0.1",
-            "string_decoder": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.0",
             "util-deprecate": "~1.0.1"
           }
         },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "npm run test-unit"
   },
   "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.38",
+    "@babel/runtime": "7.0.0-beta.55",
     "analytics-node": "^2.1.1",
     "apollo-client": "^1.2.2",
     "apollo-engine": "^0.5.4",

--- a/packages/vulcan-core/lib/modules/containers/withDelete.js
+++ b/packages/vulcan-core/lib/modules/containers/withDelete.js
@@ -33,12 +33,22 @@ import { getFragment, getFragmentName, getCollection, deleteClientTemplate } fro
 
 const withDelete = (options) => {
 
-  const { collectionName } = options;
+  const collectionName = options.collectionName || options.collection.options.collectionName
   const collection = options.collection || getCollection(collectionName);
-  const fragment = options.fragment || getFragment(options.fragmentName || `${collectionName}DefaultFragment`);
-  const fragmentName = getFragmentName(fragment);
   const typeName = collection.options.typeName;
+
+  let fragment
+  if (options.fragment) {
+    fragment = options.fragment;
+  } else if (options.fragmentName) {
+    fragment = getFragment(options.fragmentName);
+  } else {
+    fragment = getFragment(`${collection.options.collectionName}DefaultFragment`);
+  }
+  const fragmentName = getFragmentName(fragment);
+
   const query = gql`${deleteClientTemplate({ typeName, fragmentName })}${fragment}`;
+
 
   return graphql(query, {
     alias: `withDelete${typeName}`,
@@ -46,7 +56,7 @@ const withDelete = (options) => {
 
       [`delete${typeName}`]: (args) => {
         const { selector } = args;
-        return mutate({ 
+        return mutate({
           variables: { selector }
         });
       },
@@ -55,7 +65,7 @@ const withDelete = (options) => {
       removeMutation: (args) => {
         const { documentId } = args;
         const selector = { documentId };
-        return mutate({ 
+        return mutate({
           variables: { selector }
         });
       },

--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -218,7 +218,7 @@ class SmartForm extends Component {
         - Nested array item: 'addresses.1.city'
 
         */
-       compactParent(data, path);
+        compactParent(data, path);
       }
     });
 
@@ -563,10 +563,10 @@ class SmartForm extends Component {
 
     // default to overwriting old value with new
     const { mode = 'overwrite' } = options;
-    
+
     // keep the previous ones and extend (with possible replacement) with new ones
     this.setState(prevState => {
-      
+
       // keep only the relevant properties
       const { currentValues, currentDocument, deletedValues } = cloneDeep(prevState);
       const newState = { currentValues, currentDocument, deletedValues, foo: {} };
@@ -802,7 +802,7 @@ class SmartForm extends Component {
 
     // if there's a submit callback, run it
     if (this.props.submitCallback) {
-      data = this.props.submitCallback(data);
+      data = this.props.submitCallback(data) || data;
     }
 
     if (this.getFormType() === 'new') {

--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -56,6 +56,7 @@ import isObject from 'lodash/isObject';
 import { convertSchema, formProperties } from '../modules/schema_utils';
 import { isEmptyValue } from '../modules/utils';
 import { getParentPath } from '../modules/path_utils';
+import SimpleSchema from 'simpl-schema'
 
 // unsetCompact
 const unsetCompact = (object, path) => {
@@ -74,7 +75,7 @@ const compactParent = (object, path) => {
 
 const getInitialStateFromProps = (nextProps) => {
   const collection = nextProps.collection || getCollection(nextProps.collectionName);
-  const schema = collection.simpleSchema();
+  const schema = collection.simpleSchema().extend(nextProps.schema || {});
   // we need to clone object passed from props otherwise they'll be immutable
   const initialDocument = merge({}, nextProps.prefilledProps, nextProps.document);
   // remove all instances of the `__typename` property from document

--- a/packages/vulcan-forms/test/components.test.js
+++ b/packages/vulcan-forms/test/components.test.js
@@ -129,6 +129,11 @@ describe('vulcan-forms/components', function () {
                 expect(formGroup).toHaveLength(1)
             })
         })
+        const getFormFields = (wrapper) => {
+            const defaultGroup = wrapper.find('FormGroup').first()
+            const fields = defaultGroup.prop('fields')
+            return fields
+        }
         describe('nested object', function () {
             it('shallow render', () => {
                 const wrapper = shallowWithContext(<Form collection={WithObjects} />)
@@ -141,11 +146,6 @@ describe('vulcan-forms/components', function () {
                 expect(fields).toHaveLength(1) // addresses field
             })
 
-            const getFormFields = (wrapper) => {
-                const defaultGroup = wrapper.find('FormGroup').first()
-                const fields = defaultGroup.prop('fields')
-                return fields
-            }
             const getFirstField = () => {
                 const wrapper = shallowWithContext(<Form collection={WithObjects} />)
                 const fields = getFormFields(wrapper)
@@ -154,6 +154,36 @@ describe('vulcan-forms/components', function () {
             it('define the nestedSchema', () => {
                 const addressField = getFirstField()
                 expect(addressField.nestedSchema.street).toBeDefined()
+            })
+        })
+
+        describe('schema extension', function () {
+            const BasicCollection = createCollection({
+                collectionName: 'BasicCollections',
+                typeName: 'BasicCollection',
+                schema: {
+                    name: {
+                        type: String,
+                        label: "Name"
+                    },
+                }
+                //resolvers: getDefaultResolvers('BasicCollections'),
+                //mutations: getDefaultMutations('BasicCollections'),
+            });
+            const additionnalField = {
+                type: String,
+                label: "Lastname"
+            }
+            it('override default props', () => {
+                const wrapper = shallowWithContext(<Form collection={BasicCollection} schema={{ name: { label: 'NEWNAME' } }} />)
+                const fields = getFormFields(wrapper)
+                const nameField = fields[0]
+                expect(nameField.label).toEqual('NEWNAME')
+            })
+            it('handle additionnal field - edition', () => {
+                const wrapper = shallowWithContext(<Form collection={BasicCollection} schema={additionnalField} document={{ name: "John" }} />)
+                const fields = getFormFields(wrapper)
+                expect(fields).toHaveLength(2)
             })
         })
     })

--- a/packages/vulcan-users/lib/modules/schema.js
+++ b/packages/vulcan-users/lib/modules/schema.js
@@ -62,6 +62,22 @@ const schema = {
     },
     searchable: true
   },
+  _password: {
+    type: String,
+    label: "Password",
+    optional: true,
+    canRead: [],
+    canCreate: ["admins"],
+    canUpdate: ["admins"],
+    onCreate: ({ newDocument, currentUser }) => {
+   
+      delete newDocument._password // not sure if needed
+      return "" // SHOULD NEVER BE ACTUALLY STORED
+    },
+    inputProperties:{
+      type: "password"
+    }
+  },
   emails: {
     type: Array,
     optional: true,

--- a/packages/vulcan-users/lib/modules/schema.js
+++ b/packages/vulcan-users/lib/modules/schema.js
@@ -62,6 +62,9 @@ const schema = {
     },
     searchable: true
   },
+  // TODO: this field only concerns the frontend, however SmartForm does 
+  // not allow yet to pass additionnal schema property when generating the form
+  // (version 1.12.3)
   _password: {
     type: String,
     label: "Password",
@@ -70,13 +73,13 @@ const schema = {
     canCreate: ["admins"],
     canUpdate: ["admins"],
     onCreate: ({ newDocument, currentUser }) => {
-   
-      delete newDocument._password // not sure if needed
-      return "" // SHOULD NEVER BE ACTUALLY STORED
+      delete newDocument._password; // not sure if needed
+      return ""; // SHOULD NEVER BE ACTUALLY STORED
     },
-    inputProperties:{
+    inputProperties: {
       type: "password"
     }
+    //min: Accounts.ui._options.minimumPasswordLength
   },
   emails: {
     type: Array,

--- a/packages/vulcan-users/lib/modules/schema.js
+++ b/packages/vulcan-users/lib/modules/schema.js
@@ -62,25 +62,6 @@ const schema = {
     },
     searchable: true
   },
-  // TODO: this field only concerns the frontend, however SmartForm does 
-  // not allow yet to pass additionnal schema property when generating the form
-  // (version 1.12.3)
-  _password: {
-    type: String,
-    label: "Password",
-    optional: true,
-    canRead: [],
-    canCreate: ["admins"],
-    canUpdate: ["admins"],
-    onCreate: ({ newDocument, currentUser }) => {
-      delete newDocument._password; // not sure if needed
-      return ""; // SHOULD NEVER BE ACTUALLY STORED
-    },
-    inputProperties: {
-      type: "password"
-    }
-    //min: Accounts.ui._options.minimumPasswordLength
-  },
   emails: {
     type: Array,
     optional: true,

--- a/packages/vulcan-users/lib/modules/schema.js
+++ b/packages/vulcan-users/lib/modules/schema.js
@@ -53,9 +53,10 @@ const schema = {
     type: String,
     optional: true,
     canRead: ['guests'],
+    canUpdate: ['admins'],
     canCreate: ['members'],
     onInsert: user => {
-      if (user.services && user.services.twitter && user.services.twitter.screenName) {
+      if (!user.username && user.services && user.services.twitter && user.services.twitter.screenName) {
         return user.services.twitter.screenName;
       }
     },
@@ -202,7 +203,7 @@ const schema = {
       fieldName: 'avatarUrl',
       type: 'String',
       resolver: async (user, args, { Users }) => {
- 
+
         if (_.isEmpty(user)) return null;
 
         if (user.avatarUrl) {
@@ -213,7 +214,7 @@ const schema = {
           const fullUser = await Users.loader.load(user._id);
           return Users.avatar.getUrl(fullUser);
         }
-        
+
       }
     }
   },
@@ -232,9 +233,9 @@ const schema = {
       return Utils.getUnusedSlugByCollectionName('Users', basicSlug);
     }
   },
-    /**
-    The user's Twitter username
-  */
+  /**
+  The user's Twitter username
+*/
   twitterUsername: {
     type: String,
     optional: true,
@@ -269,7 +270,7 @@ const schema = {
     form: {
       options: function () {
         const groups = _.without(_.keys(getCollection('Users').groups), "guests", "members", "admins");
-        return groups.map(group => {return {value: group, label: group};});
+        return groups.map(group => { return { value: group, label: group }; });
       }
     },
   },
@@ -289,7 +290,7 @@ const schema = {
       resolver: (user, args, { Users }) => {
         return Users.getProfileUrl(user, true);
       },
-    }  
+    }
   },
 
   editUrl: {
@@ -301,7 +302,7 @@ const schema = {
       resolver: (user, args, { Users }) => {
         return Users.getEditUrl(user, true);
       },
-    }  
+    }
   }
 
 };


### PR DESCRIPTION
I wish to allow more complex workflow out-of-the box when it comes to user management, mainly targeted at companies. Here is a short summary on possible workflows, and the one I'd like to add:

- [X] Creating your own account, with email and password. Works perfectly fine and fits most B2C use cases.
- [X] As an admin, creating an User with an email and send him an enrollment email to set his password afterward. To create the User, simply use a SmartForm on the Users collection from `vulcan:users`, or use the `newMutation` if you want to create them programmatically. For the enrollment part, you can create a simple Meteor method that calls `Accounts.sendEnrollmentEmail`
- [ ] As an admin, create an User and specify his password. Right now it is doable but this would require a custom form that calls the `Accounts` method, like how it is done in the `AccountsLoginForm` on signup. Check the `vulcan:accounts` package if you need this absolutely.
 A solution could be to change the `onCreate`/`onUpdate` workflow of the password field, or maybe to tweak the Users creation mutations.

**In this workflow, the User should not need to have an email**. This makes sense for small companies whose employees do not necessarilly an email.
- [ ] As an admin, create an User and autogenerate a first password, that will be send to him by email. Cool when you need to create 6 000 users or change their passwords

All those workflow should of course allow password update with a similar system (allow admin to change the password directly, to reset it, or to trigger a reset email).
