### PR TITLE
Allow to edit username, and 3rd party name if it is set

### DIFF
--- a/packages/vulcan-users/lib/modules/schema.js
+++ b/packages/vulcan-users/lib/modules/schema.js
@@ -53,9 +53,10 @@ const schema = {
     type: String,
     optional: true,
     canRead: ['guests'],
+    canUpdate: ['admins'],
     canCreate: ['members'],
     onInsert: user => {
-      if (user.services && user.services.twitter && user.services.twitter.screenName) {
+      if ((!user.username) && user.services && user.services.twitter && user.services.twitter.screenName) {
         return user.services.twitter.screenName;
       }
     },
@@ -202,7 +203,7 @@ const schema = {
       fieldName: 'avatarUrl',
       type: 'String',
       resolver: async (user, args, { Users }) => {
- 
+
         if (_.isEmpty(user)) return null;
 
         if (user.avatarUrl) {
@@ -213,7 +214,7 @@ const schema = {
           const fullUser = await Users.loader.load(user._id);
           return Users.avatar.getUrl(fullUser);
         }
-        
+
       }
     }
   },
@@ -232,9 +233,9 @@ const schema = {
       return Utils.getUnusedSlugByCollectionName('Users', basicSlug);
     }
   },
-    /**
-    The user's Twitter username
-  */
+  /**
+  The user's Twitter username
+*/
   twitterUsername: {
     type: String,
     optional: true,
@@ -269,7 +270,7 @@ const schema = {
     form: {
       options: function () {
         const groups = _.without(_.keys(getCollection('Users').groups), "guests", "members", "admins");
-        return groups.map(group => {return {value: group, label: group};});
+        return groups.map(group => { return { value: group, label: group }; });
       }
     },
   },
@@ -289,7 +290,7 @@ const schema = {
       resolver: (user, args, { Users }) => {
         return Users.getProfileUrl(user, true);
       },
-    }  
+    }
   },
 
   editUrl: {
@@ -301,7 +302,7 @@ const schema = {
       resolver: (user, args, { Users }) => {
         return Users.getEditUrl(user, true);
       },
-    }  
+    }
   }
 
 };


### PR DESCRIPTION
All in the title, username was not editable and was overriden by 3rd party auth tools.
Changing the username will also work as expected.

I did not test it with twitter, google authentication etc. though, I have no app that uses 3rd party auth to test.