### PR TITLE
Cleaned up the options management in hocs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,9 @@
     "no-await-in-loop": 1,
     "comma-dangle": 0,
     "key-spacing": 0,
+    "meteor/audit-argument-checks": 0,
+    "no-case-declarations": 0,
+    "no-console": 1,
     "no-extra-boolean-cast": 0,
     "no-undef": 1,
     "no-unused-vars": [
@@ -44,11 +47,12 @@
         "varsIgnorePattern": "React|PropTypes|Component"
       }
     ],
-    "no-console": 1,
-    "react/prop-types": 0,
-    "meteor/audit-argument-checks": 0,
-    "no-case-declarations": 0,
-    "no-useless-escape": 0
+    "no-useless-escape": 0,
+    "quotes": [
+      1,
+      "single"
+    ],
+    "react/prop-types": 0
   },
   "env": {
     "browser": true,

--- a/packages/vulcan-core/lib/modules/containers/handleOptions.js
+++ b/packages/vulcan-core/lib/modules/containers/handleOptions.js
@@ -1,0 +1,32 @@
+import { getFragment, getCollection, getFragmentName } from "meteor/vulcan:core";
+/**
+ * Extract collectionName from collection
+ * or collection from collectionName
+ * @param {*} param0
+ */
+export const extractCollectionInfo = ({ collectionName, collection }) => {
+  if (!(collectionName || collection)) throw new Error("Please specify either collection or collectionName");
+  const _collectionName = collectionName || collection.options.collectionName;
+  const _collection = collection || getCollection(collectionName);
+  return { collection: _collection, collectionName: _collectionName };
+};
+/**
+ * Extract fragmentName from fragment
+ * or fragment from fragmentName
+ */
+export const extractFragmentInfo = ({ fragment, fragmentName }, collectionName) => {
+  if (!(fragment || fragmentName || collectionName))
+    throw new Error("Please specify either fragment or fragmentName, or pass a collectionName");
+  if (fragment) {
+    return {
+      fragment,
+      fragmentName: fragmentName || getFragmentName(fragment)
+    };
+  } else {
+    const _fragmentName = fragmentName || `${collectionName}DefaultFragment`;
+    return {
+      fragment: getFragment(_fragmentName),
+      fragmentName: _fragmentName
+    };
+  }
+};

--- a/packages/vulcan-core/lib/modules/containers/withCreate.js
+++ b/packages/vulcan-core/lib/modules/containers/withCreate.js
@@ -26,11 +26,11 @@ Child Props:
     
 */
 
-import React, { Component } from "react";
-import { graphql } from "react-apollo";
-import gql from "graphql-tag";
-import { createClientTemplate } from "meteor/vulcan:core";
-import { extractCollectionInfo, extractFragmentInfo } from "./handleOptions";
+import React, { Component } from 'react';
+import { graphql } from 'react-apollo';
+import gql from 'graphql-tag';
+import { createClientTemplate } from 'meteor/vulcan:core';
+import { extractCollectionInfo, extractFragmentInfo } from './handleOptions';
 
 const withCreate = options => {
   const { collectionName, collection } = extractCollectionInfo(options);

--- a/packages/vulcan-core/lib/modules/containers/withCreate.js
+++ b/packages/vulcan-core/lib/modules/containers/withCreate.js
@@ -26,41 +26,41 @@ Child Props:
     
 */
 
-import React, { Component } from 'react';
-import { graphql } from 'react-apollo';
-import gql from 'graphql-tag';
-import { getFragment, getFragmentName, getCollection, createClientTemplate } from 'meteor/vulcan:core';
+import React, { Component } from "react";
+import { graphql } from "react-apollo";
+import gql from "graphql-tag";
+import { createClientTemplate } from "meteor/vulcan:core";
+import { extractCollectionInfo, extractFragmentInfo } from "./handleOptions";
 
-const withCreate = (options) => {
+const withCreate = options => {
+  const { collectionName, collection } = extractCollectionInfo(options);
+  const { fragmentName, fragment } = extractFragmentInfo(options, collectionName);
 
-  const { collectionName } = options;
-  // get options
-  const collection = options.collection || getCollection(collectionName);
-  const fragment = options.fragment || getFragment(options.fragmentName || `${collectionName}DefaultFragment`);
-  const fragmentName = getFragmentName(fragment);
   const typeName = collection.options.typeName;
-  const query = gql`${createClientTemplate({ typeName, fragmentName })}${fragment}`;
+  const query = gql`
+    ${createClientTemplate({ typeName, fragmentName })}
+    ${fragment}
+  `;
 
   // wrap component with graphql HoC
   return graphql(query, {
     alias: `withCreate${typeName}`,
-    props: ({ownProps, mutate}) => ({
-      [`create${typeName}`]: (args) => {
+    props: ({ ownProps, mutate }) => ({
+      [`create${typeName}`]: args => {
         const { data } = args;
-        return mutate({ 
-          variables: { data },
+        return mutate({
+          variables: { data }
         });
       },
       // OpenCRUD backwards compatibility
-      newMutation: (args) => {
+      newMutation: args => {
         const { document } = args;
-        return mutate({ 
-          variables: { data: document },
+        return mutate({
+          variables: { data: document }
         });
       }
-    }),
+    })
   });
-
-}
+};
 
 export default withCreate;

--- a/packages/vulcan-core/lib/modules/containers/withDelete.js
+++ b/packages/vulcan-core/lib/modules/containers/withDelete.js
@@ -26,11 +26,11 @@ Child Props:
   
 */
 
-import React, { Component } from "react";
-import { graphql } from "react-apollo";
-import gql from "graphql-tag";
-import { deleteClientTemplate } from "meteor/vulcan:core";
-import { extractCollectionInfo, extractFragmentInfo } from "./handleOptions";
+import React, { Component } from 'react';
+import { graphql } from 'react-apollo';
+import gql from 'graphql-tag';
+import { deleteClientTemplate } from 'meteor/vulcan:core';
+import { extractCollectionInfo, extractFragmentInfo } from './handleOptions';
 
 const withDelete = options => {
   const { collectionName, collection } = extractCollectionInfo(options);

--- a/packages/vulcan-core/lib/modules/containers/withDelete.js
+++ b/packages/vulcan-core/lib/modules/containers/withDelete.js
@@ -26,42 +26,42 @@ Child Props:
   
 */
 
-import React, { Component } from 'react';
-import { graphql } from 'react-apollo';
-import gql from 'graphql-tag';
-import { getFragment, getFragmentName, getCollection, deleteClientTemplate } from 'meteor/vulcan:core';
+import React, { Component } from "react";
+import { graphql } from "react-apollo";
+import gql from "graphql-tag";
+import { deleteClientTemplate } from "meteor/vulcan:core";
+import { extractCollectionInfo, extractFragmentInfo } from "./handleOptions";
 
-const withDelete = (options) => {
+const withDelete = options => {
+  const { collectionName, collection } = extractCollectionInfo(options);
+  const { fragmentName, fragment } = extractFragmentInfo(options, collectionName);
 
-  const { collectionName } = options;
-  const collection = options.collection || getCollection(collectionName);
-  const fragment = options.fragment || getFragment(options.fragmentName || `${collectionName}DefaultFragment`);
-  const fragmentName = getFragmentName(fragment);
   const typeName = collection.options.typeName;
-  const query = gql`${deleteClientTemplate({ typeName, fragmentName })}${fragment}`;
+  const query = gql`
+    ${deleteClientTemplate({ typeName, fragmentName })}
+    ${fragment}
+  `;
 
   return graphql(query, {
     alias: `withDelete${typeName}`,
     props: ({ ownProps, mutate }) => ({
-
-      [`delete${typeName}`]: (args) => {
+      [`delete${typeName}`]: args => {
         const { selector } = args;
-        return mutate({ 
+        return mutate({
           variables: { selector }
         });
       },
 
       // OpenCRUD backwards compatibility
-      removeMutation: (args) => {
+      removeMutation: args => {
         const { documentId } = args;
         const selector = { documentId };
-        return mutate({ 
+        return mutate({
           variables: { selector }
         });
-      },
-
-    }),
+      }
+    })
   });
-}
+};
 
 export default withDelete;

--- a/packages/vulcan-core/lib/modules/containers/withMulti.js
+++ b/packages/vulcan-core/lib/modules/containers/withMulti.js
@@ -34,24 +34,24 @@ Terms object can have the following properties:
          
 */
 
-import React, { Component } from "react";
-import { withApollo, graphql } from "react-apollo";
-import gql from "graphql-tag";
-import update from "immutability-helper";
-import { getSetting, getFragment, getFragmentName, getCollection, Utils, multiClientTemplate } from "meteor/vulcan:lib";
-import Mingo from "mingo";
-import compose from "recompose/compose";
-import withState from "recompose/withState";
-import find from "lodash/find";
+import React, { Component } from 'react';
+import { withApollo, graphql } from 'react-apollo';
+import gql from 'graphql-tag';
+import update from 'immutability-helper';
+import { getSetting, Utils, multiClientTemplate } from 'meteor/vulcan:lib';
+import Mingo from 'mingo';
+import compose from 'recompose/compose';
+import withState from 'recompose/withState';
+import find from 'lodash/find';
 
-import { extractCollectionInfo, extractFragmentInfo } from "./handleOptions";
+import { extractCollectionInfo, extractFragmentInfo } from './handleOptions';
 
 export default function withMulti(options) {
   // console.log(options)
 
   const {
     limit = 10,
-    pollInterval = getSetting("pollInterval", 20000),
+    pollInterval = getSetting('pollInterval', 20000),
     enableTotal = true,
     enableCache = false,
     extraQueries
@@ -74,7 +74,7 @@ export default function withMulti(options) {
     withApollo,
 
     // wrap component with HoC that manages the terms object via its state
-    withState("paginationTerms", "setPaginationTerms", props => {
+    withState('paginationTerms', 'setPaginationTerms', props => {
       // get initial limit from props, or else options
       const paginationLimit = (props.terms && props.terms.limit) || limit;
       const paginationTerms = {
@@ -145,7 +145,7 @@ export default function withMulti(options) {
             loading = props.data.networkStatus === 1,
             loadingMore = props.data.networkStatus === 2,
             error = props.data.error,
-            propertyName = options.propertyName || "results";
+            propertyName = options.propertyName || 'results';
 
           if (error) {
             // eslint-disable-next-line no-console
@@ -169,11 +169,11 @@ export default function withMulti(options) {
             loadMore(providedTerms) {
               // if new terms are provided by presentational component use them, else default to incrementing current limit once
               const newTerms =
-                typeof providedTerms === "undefined"
+                typeof providedTerms === 'undefined'
                   ? {
                       /*...props.ownProps.terms,*/ ...props.ownProps.paginationTerms,
-                      limit: results.length + props.ownProps.paginationTerms.itemsPerPage
-                    }
+                    limit: results.length + props.ownProps.paginationTerms.itemsPerPage
+                  }
                   : providedTerms;
 
               props.ownProps.setPaginationTerms(newTerms);
@@ -184,7 +184,7 @@ export default function withMulti(options) {
             loadMoreInc(providedTerms) {
               // get terms passed as argument or else just default to incrementing the offset
               const newTerms =
-                typeof providedTerms === "undefined"
+                typeof providedTerms === 'undefined'
                   ? { ...props.ownProps.terms, ...props.ownProps.paginationTerms, offset: results.length }
                   : providedTerms;
 

--- a/packages/vulcan-core/lib/modules/containers/withSingle.js
+++ b/packages/vulcan-core/lib/modules/containers/withSingle.js
@@ -1,13 +1,13 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import { graphql } from "react-apollo";
-import gql from "graphql-tag";
-import { getSetting, singleClientTemplate, Utils } from "meteor/vulcan:lib";
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { graphql } from 'react-apollo';
+import gql from 'graphql-tag';
+import { getSetting, singleClientTemplate, Utils } from 'meteor/vulcan:lib';
 
-import { extractCollectionInfo, extractFragmentInfo } from "./handleOptions";
+import { extractCollectionInfo, extractFragmentInfo } from './handleOptions';
 
 export default function withSingle(options) {
-  const { pollInterval = getSetting("pollInterval", 20000), enableCache = false, extraQueries } = options;
+  const { pollInterval = getSetting('pollInterval', 20000), enableCache = false, extraQueries } = options;
 
   const { collectionName, collection } = extractCollectionInfo(options);
   const { fragmentName, fragment } = extractFragmentInfo(options, collectionName);
@@ -43,7 +43,7 @@ export default function withSingle(options) {
     props: returnedProps => {
       const { /* ownProps, */ data } = returnedProps;
 
-      const propertyName = options.propertyName || "document";
+      const propertyName = options.propertyName || 'document';
       const props = {
         loading: data.loading,
         // document: Utils.convertDates(collection, data[singleResolverName]),

--- a/packages/vulcan-core/lib/modules/containers/withSingle.js
+++ b/packages/vulcan-core/lib/modules/containers/withSingle.js
@@ -1,48 +1,37 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { graphql } from 'react-apollo';
-import gql from 'graphql-tag';
-import { getSetting, getFragment, getFragmentName, getCollection, singleClientTemplate, Utils } from 'meteor/vulcan:lib';
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { graphql } from "react-apollo";
+import gql from "graphql-tag";
+import { getSetting, singleClientTemplate, Utils } from "meteor/vulcan:lib";
+
+import { extractCollectionInfo, extractFragmentInfo } from "./handleOptions";
 
 export default function withSingle(options) {
+  const { pollInterval = getSetting("pollInterval", 20000), enableCache = false, extraQueries } = options;
 
-  const {
-    collectionName,
-    pollInterval = getSetting('pollInterval', 20000),
-    enableCache = false,
-    extraQueries,
-  } = options;
-
-  const collection = options.collection || getCollection(collectionName);
+  const { collectionName, collection } = extractCollectionInfo(options);
+  const { fragmentName, fragment } = extractFragmentInfo(options, collectionName);
   const typeName = collection.options.typeName;
   const resolverName = Utils.camelCaseify(typeName);
 
-  let fragment;
-
-  if (options.fragment) {
-    fragment = options.fragment;
-  } else if (options.fragmentName) {
-    fragment = getFragment(options.fragmentName);
-  } else {
-    fragment = getFragment(`${collection.options.collectionName}DefaultFragment`);
-  }
-
-  const fragmentName = getFragmentName(fragment);
-
-  const query = gql`${singleClientTemplate({ typeName, fragmentName, extraQueries })}${fragment}`;
+  const query = gql`
+    ${singleClientTemplate({ typeName, fragmentName, extraQueries })}
+    ${fragment}
+  `;
 
   return graphql(query, {
     alias: `with${typeName}`,
-      
-    options({ documentId, slug, selector = { documentId, slug } }) { // OpenCrud backwards compatibility
+
+    options({ documentId, slug, selector = { documentId, slug } }) {
+      // OpenCrud backwards compatibility
       const graphQLOptions = {
         variables: {
           input: {
             selector,
-            enableCache,
+            enableCache
           }
         },
-        pollInterval, // note: pollInterval can be set to 0 to disable polling (20s by default)
+        pollInterval // note: pollInterval can be set to 0 to disable polling (20s by default)
       };
 
       if (options.fetchPolicy) {
@@ -54,14 +43,14 @@ export default function withSingle(options) {
     props: returnedProps => {
       const { /* ownProps, */ data } = returnedProps;
 
-      const propertyName = options.propertyName || 'document';
+      const propertyName = options.propertyName || "document";
       const props = {
         loading: data.loading,
         // document: Utils.convertDates(collection, data[singleResolverName]),
         [propertyName]: data[resolverName] && data[resolverName].result,
         fragmentName,
         fragment,
-        data,
+        data
       };
 
       if (data.error) {
@@ -70,6 +59,6 @@ export default function withSingle(options) {
       }
 
       return props;
-    },
+    }
   });
 }

--- a/packages/vulcan-core/lib/modules/containers/withUpdate.js
+++ b/packages/vulcan-core/lib/modules/containers/withUpdate.js
@@ -27,48 +27,50 @@ Child Props:
   
 */
 
-import React, { Component } from 'react';
-import { graphql } from 'react-apollo';
-import gql from 'graphql-tag';
-import { getFragment, getFragmentName, getCollection, updateClientTemplate } from 'meteor/vulcan:lib';
-import clone from 'lodash/clone';
+import React, { Component } from "react";
+import { graphql } from "react-apollo";
+import gql from "graphql-tag";
+import { updateClientTemplate } from "meteor/vulcan:lib";
+import clone from "lodash/clone";
 
-const withUpdate = (options) => {
+import { extractCollectionInfo, extractFragmentInfo } from "./handleOptions";
 
-  const { collectionName } = options;
-  // get options
-  const collection = options.collection || getCollection(collectionName);
-  const fragment = options.fragment || getFragment(options.fragmentName || `${collectionName}DefaultFragment`);
-  const fragmentName = getFragmentName(fragment);
+const withUpdate = options => {
+  const { collectionName, collection } = extractCollectionInfo(options);
+  const { fragmentName, fragment } = extractFragmentInfo(options, collectionName);
+
   const typeName = collection.options.typeName;
-  const query = gql`${updateClientTemplate({ typeName, fragmentName })}${fragment}`;
+  const query = gql`
+    ${updateClientTemplate({ typeName, fragmentName })}
+    ${fragment}
+  `;
 
   return graphql(query, {
     alias: `withUpdate${typeName}`,
     props: ({ ownProps, mutate }) => ({
-      [`update${typeName}`]: (args) => {
+      [`update${typeName}`]: args => {
         const { selector, data } = args;
-        return mutate({ 
+        return mutate({
           variables: { selector, data }
           // note: updateQueries is not needed for editing documents
         });
       },
       // OpenCRUD backwards compatibility
-      editMutation: (args) => {
+      editMutation: args => {
         const { documentId, set, unset } = args;
         const selector = { documentId };
         const data = clone(set);
-        unset && Object.keys(unset).forEach(fieldName => {
-          data[fieldName] = null;
-        });
-        return mutate({ 
+        unset &&
+          Object.keys(unset).forEach(fieldName => {
+            data[fieldName] = null;
+          });
+        return mutate({
           variables: { selector, data }
           // note: updateQueries is not needed for editing documents
         });
       }
-    }),
+    })
   });
-
-}
+};
 
 export default withUpdate;

--- a/packages/vulcan-core/lib/modules/containers/withUpdate.js
+++ b/packages/vulcan-core/lib/modules/containers/withUpdate.js
@@ -27,13 +27,13 @@ Child Props:
   
 */
 
-import React, { Component } from "react";
-import { graphql } from "react-apollo";
-import gql from "graphql-tag";
-import { updateClientTemplate } from "meteor/vulcan:lib";
-import clone from "lodash/clone";
+import React, { Component } from 'react';
+import { graphql } from 'react-apollo';
+import gql from 'graphql-tag';
+import { updateClientTemplate } from 'meteor/vulcan:lib';
+import clone from 'lodash/clone';
 
-import { extractCollectionInfo, extractFragmentInfo } from "./handleOptions";
+import { extractCollectionInfo, extractFragmentInfo } from './handleOptions';
 
 const withUpdate = options => {
   const { collectionName, collection } = extractCollectionInfo(options);

--- a/packages/vulcan-core/lib/modules/containers/withUpsert.js
+++ b/packages/vulcan-core/lib/modules/containers/withUpsert.js
@@ -27,13 +27,13 @@ Child Props:
   
 */
 
-import React, { Component } from "react";
-import { graphql } from "react-apollo";
-import gql from "graphql-tag";
-import { upsertClientTemplate } from "meteor/vulcan:core";
-import clone from "lodash/clone";
+import React, { Component } from 'react';
+import { graphql } from 'react-apollo';
+import gql from 'graphql-tag';
+import { upsertClientTemplate } from 'meteor/vulcan:core';
+import clone from 'lodash/clone';
 
-import { extractCollectionInfo, extractFragmentInfo } from "./handleOptions";
+import { extractCollectionInfo, extractFragmentInfo } from './handleOptions';
 
 const withUpsert = options => {
   const { collectionName, collection } = extractCollectionInfo(options);

--- a/packages/vulcan-core/lib/modules/containers/withUpsert.js
+++ b/packages/vulcan-core/lib/modules/containers/withUpsert.js
@@ -27,50 +27,50 @@ Child Props:
   
 */
 
-import React, { Component } from 'react';
-import { graphql } from 'react-apollo';
-import gql from 'graphql-tag';
-import { getFragment, getFragmentName, getCollection, upsertClientTemplate } from 'meteor/vulcan:core';
-import clone from 'lodash/clone';
+import React, { Component } from "react";
+import { graphql } from "react-apollo";
+import gql from "graphql-tag";
+import { upsertClientTemplate } from "meteor/vulcan:core";
+import clone from "lodash/clone";
 
-const withUpsert = (options) => {
+import { extractCollectionInfo, extractFragmentInfo } from "./handleOptions";
 
-  const { collectionName } = options;
-  // get options
-  const collection = options.collection || getCollection(collectionName);
-  const fragment = options.fragment || getFragment(options.fragmentName || `${collectionName}DefaultFragment`);
-  const fragmentName = getFragmentName(fragment);
+const withUpsert = options => {
+  const { collectionName, collection } = extractCollectionInfo(options);
+  const { fragmentName, fragment } = extractFragmentInfo(options, collectionName);
+
   const typeName = collection.options.typeName;
-  const query = gql`${upsertClientTemplate({ typeName, fragmentName })}${fragment}`;
+  const query = gql`
+    ${upsertClientTemplate({ typeName, fragmentName })}
+    ${fragment}
+  `;
 
   return graphql(query, {
     alias: `withUpsert${typeName}`,
     props: ({ ownProps, mutate }) => ({
-
-      [`upsert${typeName}`]: (args) => {
+      [`upsert${typeName}`]: args => {
         const { selector, data } = args;
-        return mutate({ 
+        return mutate({
           variables: { selector, data }
           // note: updateQueries is not needed for editing documents
         });
       },
 
       // OpenCRUD backwards compatibility
-      upsertMutation: (args) => {
+      upsertMutation: args => {
         const { selector, set, unset } = args;
         const data = clone(set);
-        unset && Object.keys(unset).forEach(fieldName => {
-          data[fieldName] = null;
-        });
-        return mutate({ 
+        unset &&
+          Object.keys(unset).forEach(fieldName => {
+            data[fieldName] = null;
+          });
+        return mutate({
           variables: { selector, data }
           // note: updateQueries is not needed for editing documents
         });
       }
-
-    }),
+    })
   });
-
-}
+};
 
 export default withUpsert;

--- a/packages/vulcan-core/package.js
+++ b/packages/vulcan-core/package.js
@@ -1,28 +1,28 @@
 Package.describe({
-  name: "vulcan:core",
-  summary: "Vulcan core package",
-  version: "1.12.3",
-  git: "https://github.com/VulcanJS/Vulcan.git"
+  name: 'vulcan:core',
+  summary: 'Vulcan core package',
+  version: '1.12.3',
+  git: 'https://github.com/VulcanJS/Vulcan.git'
 });
 
-Package.onUse(function(api) {
-  api.versionsFrom("1.6.1");
+Package.onUse(function (api) {
+  api.versionsFrom('1.6.1');
 
   api.use([
-    "vulcan:lib@1.12.3",
-    "vulcan:i18n@1.12.3",
-    "vulcan:users@1.12.3",
-    "vulcan:routing@1.12.3",
-    "vulcan:debug@1.12.3"
+    'vulcan:lib@1.12.3',
+    'vulcan:i18n@1.12.3',
+    'vulcan:users@1.12.3',
+    'vulcan:routing@1.12.3',
+    'vulcan:debug@1.12.3'
   ]);
 
-  api.imply(["vulcan:lib@1.12.3"]);
+  api.imply(['vulcan:lib@1.12.3']);
 
-  api.mainModule("lib/server/main.js", "server");
-  api.mainModule("lib/client/main.js", "client");
+  api.mainModule('lib/server/main.js', 'server');
+  api.mainModule('lib/client/main.js', 'client');
 });
 
-Package.onTest(function(api) {
-  api.use(["ecmascript", "meteortesting:mocha", "vulcan:core"]);
-  api.mainModule("./test/index.js");
+Package.onTest(function (api) {
+  api.use(['ecmascript', 'meteortesting:mocha', 'vulcan:core']);
+  api.mainModule('./test/index.js');
 });

--- a/packages/vulcan-core/package.js
+++ b/packages/vulcan-core/package.js
@@ -1,27 +1,28 @@
 Package.describe({
   name: "vulcan:core",
   summary: "Vulcan core package",
-  version: '1.12.3',
+  version: "1.12.3",
   git: "https://github.com/VulcanJS/Vulcan.git"
 });
 
 Package.onUse(function(api) {
-
-  api.versionsFrom('1.6.1');
+  api.versionsFrom("1.6.1");
 
   api.use([
-    'vulcan:lib@1.12.3',
-    'vulcan:i18n@1.12.3',
-    'vulcan:users@1.12.3',
-    'vulcan:routing@1.12.3',
-    'vulcan:debug@1.12.3',
+    "vulcan:lib@1.12.3",
+    "vulcan:i18n@1.12.3",
+    "vulcan:users@1.12.3",
+    "vulcan:routing@1.12.3",
+    "vulcan:debug@1.12.3"
   ]);
 
-  api.imply([
-    'vulcan:lib@1.12.3'
-  ]);
+  api.imply(["vulcan:lib@1.12.3"]);
 
-  api.mainModule('lib/server/main.js', 'server');
-  api.mainModule('lib/client/main.js', 'client');
+  api.mainModule("lib/server/main.js", "server");
+  api.mainModule("lib/client/main.js", "client");
+});
 
+Package.onTest(function(api) {
+  api.use(["ecmascript", "meteortesting:mocha", "vulcan:core"]);
+  api.mainModule("./test/index.js");
 });

--- a/packages/vulcan-core/test/containers.test.js
+++ b/packages/vulcan-core/test/containers.test.js
@@ -1,39 +1,39 @@
-import { extractCollectionInfo, extractFragmentInfo } from "../lib/modules/containers/handleOptions";
-import expect from "expect";
+import { extractCollectionInfo, extractFragmentInfo } from '../lib/modules/containers/handleOptions';
+import expect from 'expect';
 
-describe("vulcan-core/containers", function() {
-  describe("handleOptions", function() {
-    const expectedCollectionName = "COLLECTION_NAME";
+describe('vulcan-core/containers', function () {
+  describe('handleOptions', function () {
+    const expectedCollectionName = 'COLLECTION_NAME';
     const expectedCollection = { options: { expectedCollectionName } };
-    it("get collectionName from collection", function() {
+    it('get collectionName from collection', function () {
       const options = { collection: expectedCollection };
       const { collection, collectionName } = extractCollectionInfo(options);
       expect(collection).toEqual(expectedCollection);
       expect(collectionName).toEqual(expectedCollectionName);
     });
-    it("get collection from collectioName", function() {
+    it('get collection from collectioName', function () {
       // MOCK getCollection
       const options = { collectionName: expectedCollectionName };
       const { collection, collectionName } = extractCollectionInfo(options);
       expect(collection).toEqual(expectedCollection);
       expect(collectionName).toEqual(expectedCollectionName);
     });
-    const expectedFragmentName = "FRAGMENT_NAME";
+    const expectedFragmentName = 'FRAGMENT_NAME';
     const expectedFragment = { definitions: [{ name: { value: expectedFragmentName } }] };
-    it("get fragment from fragmentName", function() {
+    it('get fragment from fragmentName', function () {
       // MOCK getCollection
       const options = { fragmentName: expectedFragmentName };
       const { fragment, fragmentName } = extractFragmentInfo(options);
       expect(fragment).toEqual(expectedFragment);
       expect(fragmentName).toEqual(expectedFragmentName);
     });
-    it("get fragmentName from fragment", function() {
+    it('get fragmentName from fragment', function () {
       const options = { fragment: expectedFragment };
       const { fragment, fragmentName } = extractFragmentInfo(options);
       expect(fragment).toEqual(expectedFragment);
       expect(fragmentName).toEqual(expectedFragmentName);
     });
-    it("get fragmentName and fragment from collectionName", function() {
+    it('get fragmentName and fragment from collectionName', function () {
       // if options does not contain fragment, we get the collection default fragment based on its name
       const options = {};
       const { fragment, fragmentName } = extractFragmentInfo(options, expectedCollectionName);

--- a/packages/vulcan-core/test/containers.test.js
+++ b/packages/vulcan-core/test/containers.test.js
@@ -1,0 +1,44 @@
+import { extractCollectionInfo, extractFragmentInfo } from "../lib/modules/containers/handleOptions";
+import expect from "expect";
+
+describe("vulcan-core/containers", function() {
+  describe("handleOptions", function() {
+    const expectedCollectionName = "COLLECTION_NAME";
+    const expectedCollection = { options: { expectedCollectionName } };
+    it("get collectionName from collection", function() {
+      const options = { collection: expectedCollection };
+      const { collection, collectionName } = extractCollectionInfo(options);
+      expect(collection).toEqual(expectedCollection);
+      expect(collectionName).toEqual(expectedCollectionName);
+    });
+    it("get collection from collectioName", function() {
+      // MOCK getCollection
+      const options = { collectionName: expectedCollectionName };
+      const { collection, collectionName } = extractCollectionInfo(options);
+      expect(collection).toEqual(expectedCollection);
+      expect(collectionName).toEqual(expectedCollectionName);
+    });
+    const expectedFragmentName = "FRAGMENT_NAME";
+    const expectedFragment = { definitions: [{ name: { value: expectedFragmentName } }] };
+    it("get fragment from fragmentName", function() {
+      // MOCK getCollection
+      const options = { fragmentName: expectedFragmentName };
+      const { fragment, fragmentName } = extractFragmentInfo(options);
+      expect(fragment).toEqual(expectedFragment);
+      expect(fragmentName).toEqual(expectedFragmentName);
+    });
+    it("get fragmentName from fragment", function() {
+      const options = { fragment: expectedFragment };
+      const { fragment, fragmentName } = extractFragmentInfo(options);
+      expect(fragment).toEqual(expectedFragment);
+      expect(fragmentName).toEqual(expectedFragmentName);
+    });
+    it("get fragmentName and fragment from collectionName", function() {
+      // if options does not contain fragment, we get the collection default fragment based on its name
+      const options = {};
+      const { fragment, fragmentName } = extractFragmentInfo(options, expectedCollectionName);
+      expect(fragment).toEqual(expectedFragment);
+      expect(fragmentName).toEqual(expectedFragmentName);
+    });
+  });
+});

--- a/packages/vulcan-core/test/index.js
+++ b/packages/vulcan-core/test/index.js
@@ -1,0 +1,1 @@
+import "./containers.test.js";


### PR DESCRIPTION
Will fix issues when not specifying a `fragmentName` or `fragment` in `withDelete`, now user only need to pass a `collection` and `collectionName` (default fragment will be used in this case). Also factorized code a bit to get a consistent behavior across hocs. 

I wrote test but could not run them, I have trouble with `@babel/runtime`. Also I did not found out how to mock package methods like `getCollection` during tests.