### PR TITLE
Merge the collection schema with the props schema

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -80,7 +80,11 @@ const getDefaultValues = convertedSchema => {
 
 const getInitialStateFromProps = (nextProps) => {
   const collection = nextProps.collection || getCollection(nextProps.collectionName);
-  const schema = collection.simpleSchema();
+  const collectionSchema = collection.simpleSchema()
+  // merge with schema passed in the props to allow local overrid of existing field
+  // will provoke errors if the user try to add a field however
+  const schema = nextProps.schema ? collectionSchema.extend(nextProps.schema) : collectionSchema;
+
   const convertedSchema = convertSchema(schema);
   const formType = nextProps.document ? 'edit' : 'new';
   // for new document forms, add default values to initial document

--- a/packages/vulcan-forms/test/components.test.js
+++ b/packages/vulcan-forms/test/components.test.js
@@ -129,6 +129,11 @@ describe('vulcan-forms/components', function () {
                 expect(formGroup).toHaveLength(1)
             })
         })
+        const getFormFields = (wrapper) => {
+            const defaultGroup = wrapper.find('FormGroup').first()
+            const fields = defaultGroup.prop('fields')
+            return fields
+        }
         describe('nested object', function () {
             it('shallow render', () => {
                 const wrapper = shallowWithContext(<Form collection={WithObjects} />)
@@ -140,12 +145,6 @@ describe('vulcan-forms/components', function () {
                 const fields = defaultGroup.prop('fields')
                 expect(fields).toHaveLength(1) // addresses field
             })
-
-            const getFormFields = (wrapper) => {
-                const defaultGroup = wrapper.find('FormGroup').first()
-                const fields = defaultGroup.prop('fields')
-                return fields
-            }
             const getFirstField = () => {
                 const wrapper = shallowWithContext(<Form collection={WithObjects} />)
                 const fields = getFormFields(wrapper)
@@ -154,6 +153,52 @@ describe('vulcan-forms/components', function () {
             it('define the nestedSchema', () => {
                 const addressField = getFirstField()
                 expect(addressField.nestedSchema.street).toBeDefined()
+            })
+        })
+        describe('schema extension', function () {
+            const BasicCollection = createCollection({
+                collectionName: 'BasicCollections',
+                typeName: 'BasicCollection',
+                schema: {
+                    name: {
+                        type: String,
+                        label: "Name"
+                    },
+                }
+                //resolvers: getDefaultResolvers('BasicCollections'),
+                //mutations: getDefaultMutations('BasicCollections'),
+            });
+            const additionnalField = {
+                type: String,
+                label: "Lastname"
+            }
+            describe('override existing fields', function () {
+                it('override default props', () => {
+                    const wrapper = shallowWithContext(<Form collection={BasicCollection} schema={{ name: { label: 'NEWNAME' } }} />)
+                    const fields = getFormFields(wrapper)
+                    const nameField = fields[0]
+                    expect(nameField.label).toEqual('NEWNAME')
+                })
+            })
+            describe('addFields', function () {
+                // TODO: adding field does not work
+                it.skip('display additionnal field - insertion', () => {
+                    const wrapper = shallowWithContext(<Form collection={BasicCollection} schema={additionnalField} />)
+                    const fields = getFormFields(wrapper)
+                    expect(fields).toHaveLength(2)
+                })
+                it.skip('display additionnal field - edition', () => {
+                    const wrapper = shallowWithContext(<Form collection={BasicCollection} schema={additionnalField} document={{ name: "John" }} />)
+                    const fields = getFormFields(wrapper)
+                    expect(fields).toHaveLength(2)
+                })
+                it.skip('remove additionnal field before sending data', () => {
+
+                })
+                it.skip('remove additionnal field before fetching data', () => {
+
+                })
+
             })
         })
     })


### PR DESCRIPTION
User can now pass a custom schema in the `SmartForm` to override default props.
It won't work if fields are added, only if existing fields are modified. It is mostly meant for replacing labels, controls and input options.

I also wrote tests in this PR but couldn't run them yet.