### PR TITLE
vulcan-users - permissions - filter out array based fields

### DIFF
--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -205,6 +205,7 @@ Users.isAdminById = Users.isAdmin;
 Users.getViewableFields = function (user, collection, document) {
   return Utils.arrayToFields(_.compact(_.map(collection.simpleSchema()._schema,
     (field, fieldName) => {
+      if (fieldName.indexOf('.$') > -1) return null;
       return Users.canReadField(user, field, document) ? fieldName : null;
     }
   )));


### PR DESCRIPTION
When using the resolver for the resolveAs examples from the documentation:

http://docs.vulcanjs.org/field-resolvers.html

I found that the Users.getViewableFields helper was return array based field names, which obviously are not compatible with the selector/options objects passed through to collection.findOne.

I did a search to see where the function is called in the DEVEL codebase and see that it is used only once.  That being said, others may well be using it and require the array field names, so perhaps might help to create a wrapper function that strips them out to use instead, but for now I figured I would submit this for you.