### PR TITLE
Added support for cc, bcc, and replyTo fields for email API

### DIFF
--- a/packages/vulcan-email/lib/server/email.js
+++ b/packages/vulcan-email/lib/server/email.js
@@ -59,8 +59,7 @@ VulcanEmail.generateTextVersion = html => {
   });
 }
 
-VulcanEmail.send = (to, subject, html, text, throwErrors) => {
-
+VulcanEmail.send = (to, cc, bcc, replyTo, subject, html, text, throwErrors) => {
   // TODO: limit who can send emails
   // TODO: fix this error: Error: getaddrinfo ENOTFOUND
 
@@ -76,6 +75,9 @@ VulcanEmail.send = (to, subject, html, text, throwErrors) => {
   const email = {
     from: from,
     to: to,
+    cc: cc,
+    bcc: bcc,
+    replyTo: replyTo,
     subject: subject,
     text: text,
     html: html
@@ -85,8 +87,9 @@ VulcanEmail.send = (to, subject, html, text, throwErrors) => {
 
     console.log('//////// sending email…'); // eslint-disable-line
     console.log('from: '+from); // eslint-disable-line
-    console.log('to: '+to); // eslint-disable-line
-    console.log('subject: '+subject); // eslint-disable-line
+    console.log("cc: " + cc); // eslint-disable-line
+    console.log("bcc: " + bcc); // eslint-disable-line
+    console.log("replyTo: " + replyTo); // eslint-disable-line
     // console.log('html: '+html);
     // console.log('text: '+text);
 
@@ -103,8 +106,9 @@ VulcanEmail.send = (to, subject, html, text, throwErrors) => {
     console.log('//////// sending email (simulation)…'); // eslint-disable-line
     console.log('from: '+from); // eslint-disable-line
     console.log('to: '+to); // eslint-disable-line
-    console.log('subject: '+subject); // eslint-disable-line
-    console.log('Note: emails turned off in development mode. Set "enableDevelopmentEmails" setting to "true" to enable.');
+    console.log("cc: " + cc); // eslint-disable-line
+    console.log("bcc: " + bcc); // eslint-disable-line
+    console.log("replyTo: " + replyTo); // eslint-disable-line
 
   }
 
@@ -129,15 +133,10 @@ VulcanEmail.build = async ({ emailName, variables, locale }) => {
   return { data, subject, html };
 }
 
-VulcanEmail.buildAndSend = async ({ to, emailName, variables, locale = getSetting('locale') }) => {
 
+VulcanEmail.buildAndSend = async ({ to, cc, bcc, replyTo, emailName, variables, locale = getSetting("locale") }) => {
   const email = await VulcanEmail.build({ to, emailName, variables, locale });
-  return VulcanEmail.send(to, email.subject, email.html);
-
+  return VulcanEmail.send(to, cc, bcc, replyTo, email.subject, email.html);
 };
 
-VulcanEmail.buildAndSendHTML = (to, subject, html) => VulcanEmail.send(
-  to,
-  subject,
-  VulcanEmail.buildTemplate(html)
-);
+VulcanEmail.buildAndSendHTML = (to, subject, html) => VulcanEmail.send(to,'','','', subject, VulcanEmail.buildTemplate(html));

--- a/packages/vulcan-email/lib/server/email.js
+++ b/packages/vulcan-email/lib/server/email.js
@@ -59,23 +59,22 @@ VulcanEmail.generateTextVersion = html => {
   });
 }
 
-VulcanEmail.send = (...args) => {
+VulcanEmail.send = (to, subject, html, text, throwErrors, cc, bcc, replyTo) => {
   // TODO: limit who can send emails
   // TODO: fix this error: Error: getaddrinfo ENOTFOUND
-
-  const oldArgs = ['to', 'subject', 'html', 'text', 'throwErrors'];
-  const options = Utils.argsAsObject(oldArgs, args);
-
-  let {
-    to,
-    cc,
-    bcc,
-    replyTo,
-    subject,
-    html,
-    text,
-    throwErrors,
-  } = options;
+  
+  if(typeof to === 'object'){
+    var {
+      to,
+      cc,
+      bcc,
+      replyTo,
+      subject,
+      html,
+      text,
+      throwErrors,
+    } = to;
+  }
 
   const from = getSetting('defaultEmail', 'noreply@example.com');
   const siteName = getSetting('title', 'Vulcan');

--- a/packages/vulcan-email/lib/server/email.js
+++ b/packages/vulcan-email/lib/server/email.js
@@ -59,9 +59,23 @@ VulcanEmail.generateTextVersion = html => {
   });
 }
 
-VulcanEmail.send = (to, cc, bcc, replyTo, subject, html, text, throwErrors) => {
+VulcanEmail.send = (...args) => {
   // TODO: limit who can send emails
   // TODO: fix this error: Error: getaddrinfo ENOTFOUND
+
+  const oldArgs = ['to', 'subject', 'html', 'text', 'throwErrors'];
+  const options = Utils.argsAsObject(oldArgs, args);
+
+  let {
+    to,
+    cc,
+    bcc,
+    replyTo,
+    subject,
+    html,
+    text,
+    throwErrors,
+  } = options;
 
   const from = getSetting('defaultEmail', 'noreply@example.com');
   const siteName = getSetting('title', 'Vulcan');
@@ -136,7 +150,7 @@ VulcanEmail.build = async ({ emailName, variables, locale }) => {
 
 VulcanEmail.buildAndSend = async ({ to, cc, bcc, replyTo, emailName, variables, locale = getSetting("locale") }) => {
   const email = await VulcanEmail.build({ to, emailName, variables, locale });
-  return VulcanEmail.send(to, cc, bcc, replyTo, email.subject, email.html);
+  return VulcanEmail.send({to, cc, bcc, replyTo, subject: email.subject, html: email.html});
 };
 
-VulcanEmail.buildAndSendHTML = (to, subject, html) => VulcanEmail.send(to,'','','', subject, VulcanEmail.buildTemplate(html));
+VulcanEmail.buildAndSendHTML = (to, subject, html) => VulcanEmail.send(to, subject, VulcanEmail.buildTemplate(html));

--- a/packages/vulcan-lib/lib/modules/utils.js
+++ b/packages/vulcan-lib/lib/modules/utils.js
@@ -508,20 +508,3 @@ Utils.removeProperty = (obj, propertyName) => {
     }
   }
 }
-
-/**
- * Handles an argument list and returns it as an object.
- *
- * Performs one of the following:
- *  - returns first argument if it is an object and there are no more arguments
- *  - keys each argument with the corresponding key in the keys array
- *
- * @param {String[]} keys
- * @param {*[]} args
- */
-Utils.argsAsObject = function argsAsObject(keys, args) {
-  if (typeof args[0] === 'object' && args.length === 1) {
-    return args[0];
-  }
-  return args.reduce((acc, arg, index) => ({ ...acc, [keys[index]]: arg }), {});
-};

--- a/packages/vulcan-lib/lib/modules/utils.js
+++ b/packages/vulcan-lib/lib/modules/utils.js
@@ -508,3 +508,20 @@ Utils.removeProperty = (obj, propertyName) => {
     }
   }
 }
+
+/**
+ * Handles an argument list and returns it as an object.
+ *
+ * Performs one of the following:
+ *  - returns first argument if it is an object and there are no more arguments
+ *  - keys each argument with the corresponding key in the keys array
+ *
+ * @param {String[]} keys
+ * @param {*[]} args
+ */
+Utils.argsAsObject = function argsAsObject(keys, args) {
+  if (typeof args[0] === 'object' && args.length === 1) {
+    return args[0];
+  }
+  return args.reduce((acc, arg, index) => ({ ...acc, [keys[index]]: arg }), {});
+};


### PR DESCRIPTION
`VulcanEmail.send` and `VulcanEmail.buildAndSend` now accepts cc, bcc, and replyTo fields.

`VulcanEmail.buildAndSendHTML` doesn't not support cc, bcc, and replyTo in order to keep it backwards compatible. 
