### PR TITLE
Allow "guests" in withAccess

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/withAccess.js
+++ b/packages/vulcan-core/lib/modules/containers/withAccess.js
@@ -13,7 +13,7 @@ export default function withAccess (options) {
 
       // if there are any groups defined check if user belongs, else just check if user exists
       canAccess = currentUser => {
-        return groups ? currentUser && Users.isMemberOf(currentUser, groups) : currentUser;
+        return groups ? Users.isMemberOf(currentUser, groups) : currentUser;
       }
 
       // redirect on constructor if user cannot access


### PR DESCRIPTION
`withAccess` was performing a redundant test: `currentUser && Users.isMemberOf(...)`.
Thus if you added `guests` to the allowed groups, it would fail because `currentUser` is undefined while `Users.isMemberOf()` would have returned true. So I removed the `currentUser` part, since `isMemberOf` will handle unsigned user anyway.

This might sounds weird, because why ass `withAccess` in the first place if we allow `guests`? My use case here is dynamic component generation: you may not know the allowed `groups` in the first place. Sometimes it can contains `guests`, sometimes not, so I prefer to handle both case in an unified way rather than adding a specific test for unsigned users.

Let me know your thoughts on this


