### PR TITLE
Add async hook to RouterHook and provide props as argument

### DIFF
--- a/packages/vulcan-core/lib/modules/callbacks.js
+++ b/packages/vulcan-core/lib/modules/callbacks.js
@@ -1,21 +1,18 @@
 import { addCallback, getActions } from 'meteor/vulcan:lib';
 
 /*
-  
-  Core callbacks 
-  
+
+  Core callbacks
+
 */
 
 /**
  * @summary Clear flash messages marked as seen when the route changes
- * @param {Object} Item needed by `runCallbacks` to iterate on, unused here
- * @param {Object} Redux store reference instantiated on the current connected client
- * @param {Object} Apollo Client reference instantiated on the current connected client
+ * @param {Object} props
+ * @param {Object} props.client Apollo Client reference instantiated on the current connected client
  */
-function RouterClearMessages(unusedItem, nextRoute, store, apolloClient) {
-  store.dispatch(getActions().messages.clearSeen());
-  
-  return unusedItem;
+function RouterClearMessages({ client }) {
+  client.store.dispatch(getActions().messages.clearSeen());
 }
 
-addCallback('router.onUpdate', RouterClearMessages);
+addCallback('router.onUpdate.async', RouterClearMessages);

--- a/packages/vulcan-core/lib/modules/components/RouterHook.jsx
+++ b/packages/vulcan-core/lib/modules/components/RouterHook.jsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { registerComponent, runCallbacks } from 'meteor/vulcan:lib';
+import { registerComponent, runCallbacks, runCallbacksAsync } from 'meteor/vulcan:lib';
 import { withApollo } from 'react-apollo';
 
 class RouterHook extends PureComponent {
@@ -8,15 +8,17 @@ class RouterHook extends PureComponent {
     this.runOnUpdateCallback(props);
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.runOnUpdateCallback(nextProps);
+  componentDidUpdate(nextProps) {
+    this.runOnUpdateCallback(this.props, nextProps);
   }
 
-  runOnUpdateCallback = props => {
+  runOnUpdateCallback = (props, nextProps = {}) => {
     const { currentRoute, client } = props;
     // the first argument is an item to iterate on, needed by vulcan:lib/callbacks
     // note: this item is not used in this specific callback: router.onUpdate
     runCallbacks('router.onUpdate', {}, currentRoute, client.store, client);
+
+    runCallbacksAsync('router.onUpdate.async', props, nextProps);
   };
 
   render() {

--- a/packages/vulcan-events/lib/modules/events.js
+++ b/packages/vulcan-events/lib/modules/events.js
@@ -37,7 +37,7 @@ export const addIdentifyFunction = f => {
 };
 
 export const addPageFunction = f => {
-  const f2 = (empty, route) => f(route);
+  const f2 = ({ currentRoute }) => f(currentRoute);
 
   // rename f2 to same name as f
   // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty
@@ -45,5 +45,5 @@ export const addPageFunction = f => {
   descriptor.value = f.name;
   Object.defineProperty(f2, 'name', descriptor);
 
-  addCallback('router.onUpdate', f2);
+  addCallback('router.onUpdate.async', f2);
 };

--- a/packages/vulcan-lib/lib/modules/callbacks.js
+++ b/packages/vulcan-lib/lib/modules/callbacks.js
@@ -169,17 +169,13 @@ export const runCallbacksAsync = function () {
 
   const callbacks = Array.isArray(hook) ? hook : Callbacks[hook];
 
-  if (Meteor.isServer && typeof callbacks !== 'undefined' && !!callbacks.length) {
-
-    // use defer to avoid holding up client
-    Meteor.defer(function () {
-      // run all post submit server callbacks on post object successively
-      callbacks.forEach(function (callback) {
+  if (typeof callbacks !== 'undefined' && !!callbacks.length) {
+    return Promise.all(
+      callbacks.map(callback => {
         debug(`\x1b[32m>> Running async callback [${callback.name}] on hook [${hook}]\x1b[0m`);
-        callback.apply(this, args);
-      });
-    });
-
+        return callback.apply(this, args);
+      }),
+    );
   }
-
+  return [];
 };


### PR DESCRIPTION
### Purpose of this PR

Pass entire props object to `router.onUpdate` hook.

### Modifications

- `runCallbacksAsync` now can be used on client: it uses promises to defer execution of callbacks instead of `Meteor.defer`
- add `router.onUpdate.async` to avoid breaking changes by changing signature of `router.onUpdate`

### Why I submitted this PR

Ok, this may seem some trivial changes, but I'll try to explain why I needed them and why I think they can be useful.

By default `router.onUpdate` hook is called everytime the **current Vulcan route** changes. Note the importance of it being the Vulcan route: it won't be called between route changes of the same route definition. For example, route changes between the same route but with different parameters won't trigger the `router.onUpdate`.

To make this to happen is quite straight forward (and didn't need any changes to the Vulcan's code): just replace the `RouterHook` component with itself and decorate it with the `withRouter` HOC:

```js
import { replaceComponent, getRawComponent } from 'meteor/vulcan:core';
import { withRouter } from 'react-router';

replaceComponent(
  'RouterHook',
  getRawComponent('RouterHook'),
  withRouter,
);
```

Now it will trigger for each actual route change, because `withRouter` will inject some props that will trigger a rerender.

The problem now is that we cannot access those props from `router.onUpdate` callbacks because they are not passed as arguments. And in my case, I wanted to acces the current route's parameters. With this PR, it can be done:

```js
import { addCallback } from 'meteor/vulcan:core';

addCallback(
  'router.onUpdate.async',
  // eslint-disable-next-line prefer-arrow-callback
  function callbackName({currentRoute, params, ...otherProps }) {
    // do something with `params`
  },
);
```

I hope I explained myself clearly and that you find that it makes sense.