### PR TITLE
[WIP] trying to fix pagination/load more when `checkAccess` is defined

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/withMulti.js
+++ b/packages/vulcan-core/lib/modules/containers/withMulti.js
@@ -140,6 +140,7 @@ export default function withMulti(options) {
             // results = Utils.convertDates(collection, props.data[listResolverName]),
             results = props.data[resolverName] && props.data[resolverName].results,
             totalCount = props.data[resolverName] && props.data[resolverName].totalCount,
+            beforeAccessFilterCount = props.data[resolverName] && props.data[resolverName].beforeAccessFilterCount,
             networkStatus = props.data.networkStatus,
             loadingInitial = props.data.networkStatus === 1,
             loading = props.data.networkStatus === 1,
@@ -151,6 +152,7 @@ export default function withMulti(options) {
             // eslint-disable-next-line no-console
             console.log(error);
           }
+          console.log(props.data[resolverName], props.data)
 
           return {
             // see https://github.com/apollostack/apollo-client/blob/master/src/queries/store.ts#L28-L36
@@ -160,6 +162,7 @@ export default function withMulti(options) {
             loadingMore,
             [propertyName]: results,
             totalCount,
+            beforeAccessFilterCount,
             refetch,
             networkStatus,
             error,
@@ -323,6 +326,7 @@ const queryReducer = (typeName, previousResults, action, collection, mergedTerms
     [resolverName]: {
       results: [...newResults[resolverName].results],
       totalCount: newResults[resolverName].totalCount,
+      beforeAccessFilterCount: newResults[resolverName].beforeAccessFilterCount,
       __typename: `Multi${typeName}Output`
     }
   };

--- a/packages/vulcan-core/lib/modules/default_resolvers.js
+++ b/packages/vulcan-core/lib/modules/default_resolvers.js
@@ -26,7 +26,7 @@ export function getDefaultResolvers(options) {
     typeName = getTypeName(collectionName);
     resolverOptions = { ...defaultOptions, ...arguments[1] };
   }
-  
+
   return {
     // resolver for returning a list of documents based on a set of query terms
 
@@ -48,7 +48,7 @@ export function getDefaultResolvers(options) {
 
         // get currentUser and Users collection from context
         const { currentUser, Users } = context;
-        
+
         // get collection based on collectionName argument
         const collection = context[collectionName];
 
@@ -77,11 +77,13 @@ export function getDefaultResolvers(options) {
         debug('');
 
         const data = { results: restrictedDocs };
-        
+
         if (enableTotal) {
           // get total count of documents matching the selector
           data.totalCount = await Connectors.count(collection, selector);
+          data.beforeAccessFilterCount = docs.length // count before filtering (for the "load more" buttons and pagination)
         }
+        console.log('returing results', data)
 
         // return results
         return data;

--- a/packages/vulcan-lib/lib/modules/graphql_templates.js
+++ b/packages/vulcan-lib/lib/modules/graphql_templates.js
@@ -1,7 +1,7 @@
 import { Utils } from './utils';
 
 export const convertToGraphQL = (fields, indentation) => {
-  return fields.length > 0 ? fields.map(f => fieldTemplate(f, indentation)).join(`\n`) : '';
+  return fields.length > 0 ? fields.map(f => fieldTemplate(f, indentation)).join('\n') : '';
 };
 
 export const arrayToGraphQL = fields => fields.map(f => `${f.name}: ${f.type}`).join(', ');
@@ -28,7 +28,7 @@ export const getArguments = args => {
 
 // version that does not make any fields required
 export const fieldTemplate = ({ name, type, args, directive, description, required }, indentation = '') =>
-`${description ?  `${indentation}# ${description}\n` : ''}${indentation}${name}${getArguments(args)}: ${type} ${directive ? directive : ''}`;
+  `${description ? `${indentation}# ${description}\n` : ''}${indentation}${name}${getArguments(args)}: ${type} ${directive ? directive : ''}`;
 
 /* ------------------------------------- Main Type ------------------------------------- */
 
@@ -45,8 +45,8 @@ type Movie{
 
 */
 export const mainTypeTemplate = ({ typeName, description, interfaces, fields }) =>
-`# ${description}
-type ${typeName} ${interfaces.length ? `implements ${interfaces.join(`, `)} ` : ''}{
+  `# ${description}
+type ${typeName} ${interfaces.length ? `implements ${interfaces.join(', ')} ` : ''}{
 ${convertToGraphQL(fields, '  ')}
 }
 `;
@@ -76,7 +76,7 @@ see https://www.opencrud.org/#sec-Data-types
 
 */
 export const selectorInputTemplate = ({ typeName, fields }) =>
-`input ${typeName}SelectorInput {
+  `input ${typeName}SelectorInput {
   AND: [${typeName}SelectorInput]
   OR: [${typeName}SelectorInput]
 ${convertToGraphQL(fields, '  ')}
@@ -93,7 +93,7 @@ type MovieSelectorUniqueInput {
 
 */
 export const selectorUniqueInputTemplate = ({ typeName, fields }) =>
-`input ${typeName}SelectorUniqueInput {
+  `input ${typeName}SelectorUniqueInput {
   _id: String
   documentId: String # OpenCRUD backwards compatibility
   slug: String
@@ -111,7 +111,7 @@ enum MovieOrderByInput {
 
 */
 export const orderByInputTemplate = ({ typeName, fields }) =>
-`enum ${typeName}OrderByInput {
+  `enum ${typeName}OrderByInput {
   foobar
   ${fields.join('\n  ')}
 }`;
@@ -154,7 +154,7 @@ type SingleMovieInput {
 
 */
 export const singleInputTemplate = ({ typeName }) =>
-`input Single${typeName}Input {
+  `input Single${typeName}Input {
   selector: ${typeName}SelectorUniqueInput
   # Whether to enable caching for this query
   enableCache: Boolean
@@ -175,7 +175,7 @@ type MultiMovieInput {
 
 */
 export const multiInputTemplate = ({ typeName }) =>
-`input Multi${typeName}Input {
+  `input Multi${typeName}Input {
   # A JSON object that contains the query terms used to fetch data
   terms: JSON,
   # How much to offset the results by
@@ -208,7 +208,7 @@ type SingleMovieOuput{
 
 */
 export const singleOutputTemplate = ({ typeName }) =>
-`type Single${typeName}Output{
+  `type Single${typeName}Output{
   result: ${typeName}
 }`;
 
@@ -223,7 +223,7 @@ type MultiMovieOuput{
 
 */
 export const multiOutputTemplate = ({ typeName }) =>
-`type Multi${typeName}Output{
+  `type Multi${typeName}Output{
   results: [${typeName}]
   totalCount: Int
 }`;
@@ -248,7 +248,7 @@ query singleMovieQuery($input: SingleMovieInput) {
 
 */
 export const singleClientTemplate = ({ typeName, fragmentName, extraQueries }) =>
-`query single${typeName}Query($input: Single${typeName}Input) {
+  `query single${typeName}Query($input: Single${typeName}Input) {
   ${Utils.camelCaseify(typeName)}(input: $input) {
     result {
       ...${fragmentName}
@@ -277,12 +277,13 @@ mutation multiMovieQuery($input: MultiMovieInput) {
 
 */
 export const multiClientTemplate = ({ typeName, fragmentName, extraQueries }) =>
-`query multi${typeName}Query($input: Multi${typeName}Input) {
+  `query multi${typeName}Query($input: Multi${typeName}Input) {
   ${Utils.camelCaseify(Utils.pluralize(typeName))}(input: $input) {
     results {
       ...${fragmentName}
     }
     totalCount
+    beforeAccessFilterCount
     __typename
   }
   ${extraQueries ? extraQueries : ''}
@@ -298,7 +299,7 @@ createMovie(input: CreateMovieInput) : MovieOutput
 
 */
 export const createMutationTemplate = ({ typeName }) =>
-`create${typeName}(data: Create${typeName}DataInput!) : ${typeName}Output`;
+  `create${typeName}(data: Create${typeName}DataInput!) : ${typeName}Output`;
 
 /*
 
@@ -308,7 +309,7 @@ updateMovie(input: UpdateMovieInput) : MovieOutput
 
 */
 export const updateMutationTemplate = ({ typeName }) =>
-`update${typeName}(selector: ${typeName}SelectorUniqueInput!, data: Update${typeName}DataInput! ) : ${typeName}Output`;
+  `update${typeName}(selector: ${typeName}SelectorUniqueInput!, data: Update${typeName}DataInput! ) : ${typeName}Output`;
 
 /*
 
@@ -318,7 +319,7 @@ upsertMovie(input: UpsertMovieInput) : MovieOutput
 
 */
 export const upsertMutationTemplate = ({ typeName }) =>
-`upsert${typeName}(selector: ${typeName}SelectorUniqueInput!, data: Update${typeName}DataInput! ) : ${typeName}Output`;
+  `upsert${typeName}(selector: ${typeName}SelectorUniqueInput!, data: Update${typeName}DataInput! ) : ${typeName}Output`;
 
 /*
 
@@ -328,7 +329,7 @@ deleteMovie(input: DeleteMovieInput) : MovieOutput
 
 */
 export const deleteMutationTemplate = ({ typeName }) =>
-`delete${typeName}(selector: ${typeName}SelectorUniqueInput!) : ${typeName}Output`;
+  `delete${typeName}(selector: ${typeName}SelectorUniqueInput!) : ${typeName}Output`;
 
 /* ------------------------------------- Mutation Input Types ------------------------------------- */
 
@@ -344,7 +345,7 @@ type CreateMovieInput {
 
 */
 export const createInputTemplate = ({ typeName }) =>
-`input Create${typeName}Input{
+  `input Create${typeName}Input{
   data: Create${typeName}DataInput!
 }`;
 
@@ -359,7 +360,7 @@ type UpdateMovieInput {
 
 */
 export const updateInputTemplate = ({ typeName }) =>
-`input Update${typeName}Input{
+  `input Update${typeName}Input{
   selector: ${typeName}SelectorUniqueInput!
   data: Update${typeName}DataInput!
 }`;
@@ -377,7 +378,7 @@ type UpsertMovieInput {
 
 */
 export const upsertInputTemplate = ({ typeName }) =>
-`input Upsert${typeName}Input{
+  `input Upsert${typeName}Input{
   selector: ${typeName}SelectorUniqueInput!
   data: Update${typeName}DataInput!
 }`;
@@ -392,7 +393,7 @@ type DeleteMovieInput {
 
 */
 export const deleteInputTemplate = ({ typeName }) =>
-`input Delete${typeName}Input{
+  `input Delete${typeName}Input{
   selector: ${typeName}SelectorUniqueInput!
 }`;
 
@@ -407,7 +408,7 @@ type CreateMovieDataInput {
 
 */
 export const createDataInputTemplate = ({ typeName, fields }) =>
-`input Create${typeName}DataInput {
+  `input Create${typeName}DataInput {
 ${convertToGraphQL(fields, '  ')}
 }`;
 
@@ -422,7 +423,7 @@ type UpdateMovieDataInput {
 
 */
 export const updateDataInputTemplate = ({ typeName, fields }) =>
-`input Update${typeName}DataInput {
+  `input Update${typeName}DataInput {
 ${convertToGraphQL(fields, '  ')}
 }`;
 
@@ -438,7 +439,7 @@ type MovieOutput {
 
 */
 export const mutationOutputTemplate = ({ typeName }) =>
-`type ${typeName}Output{
+  `type ${typeName}Output{
   data: ${typeName}
 }`;
 
@@ -461,7 +462,7 @@ mutation createMovie($data: CreateMovieDataInput!) {
 
 */
 export const createClientTemplate = ({ typeName, fragmentName }) =>
-`mutation create${typeName}($data: Create${typeName}DataInput!) {
+  `mutation create${typeName}($data: Create${typeName}DataInput!) {
   create${typeName}(data: $data) {
     data {
       ...${fragmentName}
@@ -486,7 +487,7 @@ mutation updateMovie($selector: MovieSelectorUniqueInput!, $data: UpdateMovieDat
 
 */
 export const updateClientTemplate = ({ typeName, fragmentName }) =>
-`mutation update${typeName}($selector: ${typeName}SelectorUniqueInput!, $data: Update${typeName}DataInput!) {
+  `mutation update${typeName}($selector: ${typeName}SelectorUniqueInput!, $data: Update${typeName}DataInput!) {
   update${typeName}(selector: $selector, data: $data) {
     data {
       ...${fragmentName}
@@ -511,7 +512,7 @@ mutation upsertMovie($selector: MovieSelectorUniqueInput!, $data: UpdateMovieDat
 
 */
 export const upsertClientTemplate = ({ typeName, fragmentName }) =>
-`mutation upsert${typeName}($selector: ${typeName}SelectorUniqueInput!, $data: Update${typeName}DataInput!) {
+  `mutation upsert${typeName}($selector: ${typeName}SelectorUniqueInput!, $data: Update${typeName}DataInput!) {
   upsert${typeName}(selector: $selector, data: $data) {
     data {
       ...${fragmentName}
@@ -536,7 +537,7 @@ mutation deleteMovie($selector: MovieSelectorUniqueInput!) {
 
 */
 export const deleteClientTemplate = ({ typeName, fragmentName }) =>
-`mutation delete${typeName}($selector: ${typeName}SelectorUniqueInput!) {
+  `mutation delete${typeName}($selector: ${typeName}SelectorUniqueInput!) {
   delete${typeName}(selector: $selector) {
     data {
       ...${fragmentName}


### PR DESCRIPTION
See #2066 

I almost figured out how to add a `beforeAccessFilterCount` variable with the results. This count will allow to fix pagination/load more count (right now it does not consider filtered document, so "load more" will appear even when all data are loaded, with no way to fix it).