### PR TITLE
[BugFix] remove `document` from `canCreateField`

### DIFF
--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -259,7 +259,7 @@ Users.canCreateField = function (user, field) {
   if (canCreate) {
     if (typeof canCreate === 'function') {
       // if canCreate is a function, execute it with user and document passed. it must return a boolean
-      return canCreate(user, document);
+      return canCreate(user);
     } else if (typeof canCreate === 'string') {
       // if canCreate is just a string, we assume it's the name of a group and pass it to isMemberOf
       // note: if canCreate is 'guests' then anybody can create it


### PR DESCRIPTION
When you run Users.CanCreateField with a function in `canCreate` field prop, it's trying to call a `document` arg that is undefined, because obviously there is no initial document when you try to create a document. So now it's only calling canCreate(user) as defined in the docs. I should have spotted this in #2006, sorry! 