### PR TITLE
Pass locale as key to IntlProvider to force a rerender on locale change

### DIFF
--- a/packages/vulcan-core/lib/modules/components/App.jsx
+++ b/packages/vulcan-core/lib/modules/components/App.jsx
@@ -85,6 +85,7 @@ class App extends PureComponent {
     return (
       <IntlProvider
         locale={this.getLocale()}
+        key={this.getLocale()}
         messages={Strings[this.getLocale()]}
       >
         <div className={`locale-${this.getLocale()}`}>


### PR DESCRIPTION
See docs: https://github.com/yahoo/react-intl/wiki/Components#dynamic-language-selection

The main problem is that optimization with `shouldComponentUpdate` prevents nested components from updating through context, hence all components below a component that does not rerender won't rerender on locale change.