### PR TITLE
Users' slug is updated on displayname change

### DIFF
--- a/packages/vulcan-lib/lib/modules/utils.js
+++ b/packages/vulcan-lib/lib/modules/utils.js
@@ -169,11 +169,7 @@ Utils.slugify = function (s) {
   return slug;
 };
 
-Utils.getUnusedSlug = function (collection, unSureSlug) {
-  
-  //if the unSureSlug is falsy, replace it with '0'. This avoids the creation of an empty slug, which is bad in the urls.
-  const slug = unSureSlug ? unSureSlug : '0';
-  
+Utils.getUnusedSlug = function (collection, slug) {
   let suffix = '';
   let index = 0;
 

--- a/packages/vulcan-lib/lib/modules/utils.js
+++ b/packages/vulcan-lib/lib/modules/utils.js
@@ -169,19 +169,6 @@ Utils.slugify = function (s) {
   return slug;
 };
 
-Utils.getUnusedSlug = function (collection, slug) {
-  let suffix = '';
-  let index = 0;
-
-  // test if slug is already in use
-  while (!!collection.findOne({slug: slug+suffix})) {
-    index++;
-    suffix = '-'+index;
-  }
-
-  return slug+suffix;
-};
-
 Utils.getUnusedSlugByCollectionName = function (collectionName, slug) {
   return Utils.getUnusedSlug(getCollection(collectionName), slug);
 };

--- a/packages/vulcan-lib/lib/modules/utils.js
+++ b/packages/vulcan-lib/lib/modules/utils.js
@@ -169,7 +169,11 @@ Utils.slugify = function (s) {
   return slug;
 };
 
-Utils.getUnusedSlug = function (collection, slug) {
+Utils.getUnusedSlug = function (collection, unSureSlug) {
+  
+  //if the unSureSlug is falsy, replace it with '0'. This avoids the creation of an empty slug, which is bad in the urls.
+  const slug = unSureSlug ? unSureSlug : '0';
+  
   let suffix = '';
   let index = 0;
 

--- a/packages/vulcan-lib/lib/server/utils.js
+++ b/packages/vulcan-lib/lib/server/utils.js
@@ -1,5 +1,5 @@
 import sanitizeHtml from 'sanitize-html';
-
+import { Connectors } from './connectors';
 import { Utils } from '../modules';
 
 Utils.sanitize = function(s) {
@@ -11,6 +11,22 @@ Utils.sanitize = function(s) {
       'tbody', 'tr', 'th', 'td', 'pre', 'img'
     ]
   });
+};
+
+Utils.getUnusedSlug = async function (collection, slug) {
+  let suffix = '';
+  let index = 0;
+
+  const slugRegex = new RegExp('^' + slug + '-[0-9]+$');
+  // get all the slugs matching slug or slug-123 in that collection
+  const results = await Connectors.find( collection, { slug: { $in: [slug, slugRegex] } }, { fields: { slug: 1, _id: 0 } });
+  const usedSlugs = results.map(item => item.slug);
+  // increment the index at the end of the slug until we find an unused one
+  while (usedSlugs.indexOf(slug + suffix) !== -1) {
+    index++;
+    suffix = '-' + index;
+  }
+  return slug + suffix;
 };
 
 export { Utils };

--- a/packages/vulcan-users/lib/modules/schema.js
+++ b/packages/vulcan-users/lib/modules/schema.js
@@ -230,7 +230,8 @@ const schema = {
       // create a basic slug from display name and then modify it if this slugs already exists;
       const displayName = createDisplayName(user);
       const basicSlug = Utils.slugify(displayName);
-      return Utils.getUnusedSlugByCollectionName('Users', basicSlug);
+      //if the basic slug is falsy, use the user id instead to avoid empty slugs
+      return basicSlug ? Utils.getUnusedSlugByCollectionName('Users', basicSlug) : user._id;
     },
   },
   /**

--- a/packages/vulcan-users/lib/modules/schema.js
+++ b/packages/vulcan-users/lib/modules/schema.js
@@ -232,24 +232,6 @@ const schema = {
       const basicSlug = Utils.slugify(displayName);
       return Utils.getUnusedSlugByCollectionName('Users', basicSlug);
     },
-    onUpdate: ({ data, document, currentUser }) => {
-      // if the slug is updated in the query and different from the original one, format it and then modify it if this slugs already exists
-      if (data.slug && document.slug && data.slug !== document.slug) {
-        const formattedSlug = Utils.slugify(data.slug);
-        // we need to do check that it's different from the original one or getUnusedSlug will think it's used already
-        if (formattedSlug !== document.slug) {
-          return Utils.getUnusedSlugByCollectionName('Users', formattedSlug);
-        } else {
-          return document.slug;
-        }
-      } else if (data.displayName && data.displayName !== document.displayName) {
-        // when the display name is modified, update the slug
-        const slug = Utils.slugify(data.displayName);
-        if (slug !== document.slug) {
-          return Utils.getUnusedSlugByCollectionName('Users', slug);
-        } else return document.slug;
-      } else return document.slug;
-    },
   },
   /**
   The user's Twitter username


### PR DESCRIPTION
- The slug is updated when the displayname changes
- The `Utils.getUnusedSlug` helper function does not return empty slugs anymore (it's '0' if the `slug` argument is falsy)