### PR TITLE
SmartForm.getLabel() intl string fallback

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -423,7 +423,18 @@ class SmartForm extends Component {
    */
   getLabel = (fieldName, fieldLocale) => {
     const collectionName = this.getCollection().options.collectionName.toLowerCase();
-    const intlLabel = this.context.intl.formatMessage({ id: `${collectionName}.${fieldName}` });
+    const defaultMessage = '|*|*|';
+    let id = `${collectionName}.${fieldName}`;
+    let intlLabel;
+    intlLabel = this.context.intl.formatMessage({ id, defaultMessage });
+    if (intlLabel === defaultMessage) {
+      id = `global.${fieldName}`;
+      intlLabel = this.context.intl.formatMessage({ id });
+      if (intlLabel === defaultMessage) {
+        id = fieldName;
+        intlLabel = this.context.intl.formatMessage({ id });
+      }
+    }
     const schemaLabel = this.state.flatSchema[fieldName] && this.state.flatSchema[fieldName].label;
     const label = intlLabel || schemaLabel || fieldName;
     if (fieldLocale) {


### PR DESCRIPTION
SmartForm.getLabel() now falls back to a "global" namespace when a collection-specific intl string is not found; then it falls back to using no namespace.

This is implemented to reduce duplication of translations, especially for field labels common to multiple collections.