### PR TITLE
Override SmartForm Components

### DIFF
--- a/packages/vulcan-forms/lib/components/FormNestedArray.jsx
+++ b/packages/vulcan-forms/lib/components/FormNestedArray.jsx
@@ -37,7 +37,9 @@ class FormNestedArray extends PureComponent {
 
     return (
       <div className={`form-group row form-nested ${hasErrors ? 'input-error': ''}`}>
-        <label className="control-label col-sm-3">{this.props.label}</label>
+        
+        <Components.FormNestedHead label={this.props.label} addItem={this.addItem}/>
+        
         <div className="col-sm-9">
           {value.map(
             (subDocument, i) =>
@@ -55,10 +57,11 @@ class FormNestedArray extends PureComponent {
                 </React.Fragment>
               )
           )}
-          <Components.Button size="small" variant="success" onClick={this.addItem} className="form-nested-button">
-            <Components.IconAdd height={12} width={12} />
-          </Components.Button>
+  
+          <Components.FormNestedFoot label={this.props.label} addItem={this.addItem}/>
+
           {hasErrors ? <Components.FieldErrors errors={nestedArrayErrors} /> : null}
+          
         </div>
       </div>
     );

--- a/packages/vulcan-forms/lib/components/FormSubmit.jsx
+++ b/packages/vulcan-forms/lib/components/FormSubmit.jsx
@@ -60,10 +60,10 @@ const FormSubmit = ({
 );
 
 FormSubmit.propTypes = {
-  submitLabel: PropTypes.string,
-  cancelLabel: PropTypes.string,
+  submitLabel: PropTypes.node,
+  cancelLabel: PropTypes.node,
   cancelCallback: PropTypes.func,
-  revertLabel: PropTypes.string,
+  revertLabel: PropTypes.node,
   revertCallback: PropTypes.func,
   document: PropTypes.object,
   deleteDocument: PropTypes.func,

--- a/packages/vulcan-forms/lib/components/FormWrapper.jsx
+++ b/packages/vulcan-forms/lib/components/FormWrapper.jsx
@@ -295,9 +295,9 @@ FormWrapper.propTypes = {
   fields: PropTypes.arrayOf(PropTypes.string),
   hideFields: PropTypes.arrayOf(PropTypes.string),
   showRemove: PropTypes.bool,
-  submitLabel: PropTypes.string,
-  cancelLabel: PropTypes.string,
-  revertLabel: PropTypes.string,
+  submitLabel: PropTypes.node,
+  cancelLabel: PropTypes.node,
+  revertLabel: PropTypes.node,
   repeatErrors: PropTypes.bool,
   warnUnsavedChanges: PropTypes.bool,
 

--- a/packages/vulcan-forms/lib/modules/index.js
+++ b/packages/vulcan-forms/lib/modules/index.js
@@ -1,6 +1,9 @@
 import { registerComponent, registerSetting } from 'meteor/vulcan:core';
 
 registerSetting('forms.warnUnsavedChanges', false, 'Warn user about unsaved changes before leaving route', true);
+registerSetting('forms.components.FormGroup', 'FormGroup', 'The default component to use for form groups', true);
+registerSetting('forms.components.FormSubmit', 'FormSubmit', 'The default component to use for the form submit area', true);
+registerSetting('forms.components.FormErrors', 'FormErrors', 'The default component to use for the form errors area', true);
 
 import './components.js';
 


### PR DESCRIPTION
- You can now override which SmartForm components to use for a given form; currently `FormGroup`, `FormErrors` & `FormSubmit` can be overridden - more to come
- The default components to use can be chosen in settings
- `submitLabel`, `cancelLabel`, and `revertLabel` now take a node (which is backwards compatible with string) so that you can include a FormattedMessage, an icon, etc.