### PR TITLE
SubmitButtonLabels

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -941,9 +941,9 @@ SmartForm.propTypes = {
   removeFields: PropTypes.arrayOf(PropTypes.string),
   hideFields: PropTypes.arrayOf(PropTypes.string), // OpenCRUD backwards compatibility
   showRemove: PropTypes.bool,
-  submitLabel: PropTypes.string,
-  cancelLabel: PropTypes.string,
-  revertLabel: PropTypes.string,
+  submitLabel: PropTypes.node,
+  cancelLabel: PropTypes.node,
+  revertLabel: PropTypes.node,
   repeatErrors: PropTypes.bool,
   warnUnsavedChanges: PropTypes.bool,
 

--- a/packages/vulcan-forms/lib/components/FormSubmit.jsx
+++ b/packages/vulcan-forms/lib/components/FormSubmit.jsx
@@ -60,10 +60,10 @@ const FormSubmit = ({
 );
 
 FormSubmit.propTypes = {
-  submitLabel: PropTypes.string,
-  cancelLabel: PropTypes.string,
+  submitLabel: PropTypes.node,
+  cancelLabel: PropTypes.node,
   cancelCallback: PropTypes.func,
-  revertLabel: PropTypes.string,
+  revertLabel: PropTypes.node,
   revertCallback: PropTypes.func,
   document: PropTypes.object,
   deleteDocument: PropTypes.func,

--- a/packages/vulcan-forms/lib/components/FormWrapper.jsx
+++ b/packages/vulcan-forms/lib/components/FormWrapper.jsx
@@ -295,9 +295,9 @@ FormWrapper.propTypes = {
   fields: PropTypes.arrayOf(PropTypes.string),
   hideFields: PropTypes.arrayOf(PropTypes.string),
   showRemove: PropTypes.bool,
-  submitLabel: PropTypes.string,
-  cancelLabel: PropTypes.string,
-  revertLabel: PropTypes.string,
+  submitLabel: PropTypes.node,
+  cancelLabel: PropTypes.node,
+  revertLabel: PropTypes.node,
   repeatErrors: PropTypes.bool,
   warnUnsavedChanges: PropTypes.bool,
 


### PR DESCRIPTION
- `submitLabel`, `cancelLabel`, and `revertLabel` now take a node (which is backwards compatible with string) so that you can include a FormattedMessage, an icon, etc.