### PR TITLE
Don't merge schema in Vulcan, only do it with SimpleSchema

### DIFF
--- a/packages/vulcan-i18n-fr-fr/lib/fr_FR.js
+++ b/packages/vulcan-i18n-fr-fr/lib/fr_FR.js
@@ -33,7 +33,7 @@ addStrings('fr', {
   'accounts.sign_in': 'Connexion',
   'accounts.sign_out': 'Se déconnecter',
   'accounts.cancel': 'Annuler',
-  'accounts.or_use': 'ou utiliser',
+  'accounts.or_use': 'ou utilisez',
   'accounts.info_email_sent': 'Email envoyé.',
   'accounts.info_password_changed': 'Mot de passe changé.',
   'accounts.logging_in': 'Connexion en cours…',

--- a/packages/vulcan-lib/lib/modules/collections.js
+++ b/packages/vulcan-lib/lib/modules/collections.js
@@ -53,8 +53,7 @@ Mongo.Collection.prototype.addField = function (fieldOrFieldArray) {
 
   // loop over fields and add them to schema (or extend existing fields)
   fieldArray.forEach(function (field) {
-    const newField = {...schema[field.fieldName], ...field.fieldSchema};
-    fieldSchema[field.fieldName] = newField;
+    fieldSchema[field.fieldName] = field.fieldSchema;
   });
 
   // add field schema to collection schema


### PR DESCRIPTION
## The problem

When extending a collection's schema with `collection.addField`, and specifically when overwriting an existing field's schema definition, there are some inconsistencies regarding simpl-schema's embedded validation properties : 
See the problem in action by adding this to example-movies : 
```js
import Movies from './movies/collection';
Movies.addField([
  {
    fieldName: 'name',
    fieldSchema: {
      max: 5, // ignored
    },
  },
  {
    fieldName: 'review',
    fieldSchema: {
      type: String,
      max: 5, // not ignored
    },
  },
]);
```
Here we add `max` to the two existing fields `name` and `review`, but if you try creating a movie with a name longer than 5 characters it will be validated, the rule `max : 5` is ignored for it. 
This comes from the fact that Vulcan merges the previous schema with the one you extend it with : https://github.com/VulcanJS/Vulcan/blob/devel/packages/vulcan-lib/lib/modules/collections.js#L54L58
Then, it is called to the `extend` function of simple-schema, that merges it in the previous schema too.
When you don't add `type` in your extended schema, Vulcan adds the type from the previous schema. The problem is that SimpleSchema stores rules like min, max, regex, minCount, maxCount directly inside the type. So when Vulcan merges the old schema, it forces simpl-shema to use the old type, that ignores the new rules for min, max etc. 
## The solution
A quick workaround is to always add the type in the schema extension (see `review` above), but the real fix is to stop merging schemas in Vulcan, and to let simpl-schema do it for us via `extend` (see their docs: https://github.com/aldeed/simple-schema-js#extending-schemas ). This function is already what we use under the hood in attachSchema, and already has the merging and overriding included.
No need to change the API of `collection.addField`.

PS : I also added a small correction to one of the translations in i18n-fr-fr
