### PR TITLE
Email subjects shouldn't be coupled with sitename

### DIFF
--- a/packages/vulcan-email/lib/server/email.js
+++ b/packages/vulcan-email/lib/server/email.js
@@ -69,7 +69,7 @@ VulcanEmail.send = (to, subject, html, text, throwErrors, cc, bcc, replyTo, head
 
   const from = getSetting('defaultEmail', 'noreply@example.com');
   const siteName = getSetting('title', 'Vulcan');
-  subject = '[' + siteName + '] ' + subject;
+  subject = subject || '[' + siteName + ']';
 
   if (typeof text === 'undefined') {
     // Auto-generate text version if it doesn't exist. Has bugs, but should be good enough.


### PR DESCRIPTION
I think it's fine to have reasonable defaults, but the user should be able to override entirely.

The new behavior is as follows:
* email subject is `subject` if set
* otherwise - if no `subject` is set, the email subject becomes `[siteName]`

Tested both scenarios.