### PR TITLE
Add /i18n debug page

### DIFF
--- a/packages/vulcan-debug/lib/components/I18n.jsx
+++ b/packages/vulcan-debug/lib/components/I18n.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { registerComponent, Components, Strings, Locales } from 'meteor/vulcan:lib';
+import PropTypes from 'prop-types';
+import sortedUniq from 'lodash/sortedUniq';
+
+/**
+ * Internationalization debugging page
+ *
+ *
+ **/
+function LocaleSwitcher(props, context) {
+  return (
+    <div>
+      <span>Switch locales :</span>
+      {Locales.map(localeObj => (
+        <Components.Button key={localeObj.id} onClick={() => context.setLocale(localeObj.id)}>
+          {localeObj.label}
+        </Components.Button>
+      ))}
+    </div>
+  );
+}
+LocaleSwitcher.contextTypes = {
+  getLocale: PropTypes.func,
+  setLocale: PropTypes.func,
+};
+
+export const I18n = (props, context) => {
+  // translations holds all the translations ids
+  let translations = [];
+  let columns = [
+    {
+      name: 'id',
+      component: function({ document }) {
+        return document;
+      },
+    },
+  ];
+
+  // reunite all the ids in a single array (translations) and create the columns for each language
+  Object.keys(Strings).forEach(language => {
+    translations.push(...Object.keys(Strings[language]));
+    columns.push({
+      name: language,
+      component: function({ document }) {
+        return Strings[language][document] || null;
+      },
+    });
+  });
+
+  //sort the array
+  translations.sort();
+  //remove duplicates
+  let translationsUniq = sortedUniq(translations);
+
+  return (
+    <div>
+      <h3>{'Your current locale: ' + context.getLocale()}</h3>
+      <LocaleSwitcher />
+      <Components.Datatable showSearch={false} showNew={false} showEdit={false} data={translationsUniq} columns={columns} />
+    </div>
+  );
+};
+
+I18n.contextTypes = {
+  getLocale: PropTypes.func,
+  setLocale: PropTypes.func,
+};
+
+registerComponent({ name: 'I18n', component: I18n, hocs: [] });

--- a/packages/vulcan-debug/lib/modules/components.js
+++ b/packages/vulcan-debug/lib/modules/components.js
@@ -6,3 +6,4 @@ import '../components/Settings.jsx';
 import '../components/Callbacks.jsx';
 import '../components/Routes.jsx';
 import '../components/Components.jsx';
+import '../components/I18n.jsx';

--- a/packages/vulcan-debug/lib/modules/routes.js
+++ b/packages/vulcan-debug/lib/modules/routes.js
@@ -9,4 +9,5 @@ addRoute([
   {name: 'emails', path: '/emails', componentName: 'Emails', layoutName: 'AdminLayout'},
   {name: 'routes', path: '/routes', componentName: 'Routes', layoutName: 'AdminLayout'},
   {name: 'components', path: '/components', componentName: 'Components', layoutName: 'AdminLayout'},
+  {name: 'I18n', path: '/i18n', componentName: 'I18n', layoutName: 'AdminLayout'},
 ]);


### PR DESCRIPTION
I created a debug page for i18n strings. The route for it is `/i18n`
The features are : 
- Tells your current locale
- Allows you to switch locale based on the registered locales
- Shows all the strings registered for every locale and their related Ids in a `Components.datatable`

Tell me if there are any additional features you can imagine and would like to be added. 

If I can add a proposition about the debug package : all the routes should be renamed to `/debug/i18n` or `debugi18n`, or `i18ndebug` (which is my favorite) to avoid conflicts with the routes set for the app. I don't think anyone will set a route called `/i18n`, but a `/settings` route is pretty common in any app. So if someone was to add it to their app, they would be unable to see the settings debug page. @SachaG if you like the idea I'll add this to the PR.

If this gets merged I'll update the docs