### PR TITLE
Restore Edge support

### DIFF
--- a/packages/vulcan-core/lib/modules/components/App.jsx
+++ b/packages/vulcan-core/lib/modules/components/App.jsx
@@ -42,7 +42,7 @@ class App extends PureComponent {
     return availableLocale ? availableLocale : getSetting('locale', 'en-US');
   };
 
-  getLocale = (truncate = false) => {
+  getLocale = (truncate) => {
     return truncate ? this.state.locale.slice(0,2) : this.state.locale;
   };
 


### PR DESCRIPTION
TLDR: default value in arrow functions that are child to a class breaks MS Edge support 
It seems that babel has an issue with polyfilling arrow functions that have a default value for their arguments.
I found out my site did not support Edge since I updated it to Vulcan 1.12.8.
After a bit of research, I found @Discordius and @jimrandomh from LessWrong had the same issue : https://github.com/LessWrong2/Lesswrong2/issues/783 and found where this was introduced and fixed it in their version of Vulcan : https://github.com/LessWrong2/Vulcan/pull/8
So I just copied what they did, which is delete a default value on an arrow function in the core package: 
```js
  getLocale = (truncate = false) => {	 
    return truncate ? this.state.locale.slice(0,2) : this.state.locale;	  
  };
```
This was introduced with Vulcan 1.11, and it's part of the new i18n feature.
I think the default value was unnecesary because the value is tested right after, so I think this version is fine. 

I tested running my app with this fix and it seems to work.