### PR TITLE
Add graphql-voyager

### DIFF
--- a/packages/vulcan-lib/lib/server/apollo-server/apollo_server2.js
+++ b/packages/vulcan-lib/lib/server/apollo-server/apollo_server2.js
@@ -19,6 +19,8 @@ import { ApolloServer } from 'apollo-server-express';
 //import { makeExecutableSchema } from 'graphql-tools';
 import { Meteor } from 'meteor/meteor';
 // import { Accounts } from 'meteor/accounts-base';
+import express from 'express';
+import { express as voyagerMiddleware } from 'graphql-voyager';
 
 import { GraphQLSchema } from '../../modules/graphql.js';
 import { WebApp } from 'meteor/webapp';
@@ -71,6 +73,16 @@ const createApolloServer = ({ options: givenOptions = {}, config: givenConfig = 
     app: WebApp.connectHandlers,
     path: config.path
   });
+  
+  //add graphql-voyager 
+  //// TODO: add conditions depending on config
+  // applyMiddleware: https://www.apollographql.com/docs/apollo-server/v2/api/apollo-server.html#Usage
+  // graphql-voyager : https://github.com/APIs-guru/graphql-voyager#express
+  if (Meteor.isDevelopment) {
+    const app = express();
+    app.use('*', voyagerMiddleware({ endpointUrl: '/graphql' }));
+    apolloServer.applyMiddleware({ app, path: '/voyager' });
+  }
 
   // connect the meteor app with Express
   // @see http://www.mhurwi.com/meteor-with-express/


### PR DESCRIPTION
available at `/voyager` in dev mode only
Disclaimer : I don't know if I'm breaking things here, since I don't know the advancement of the update to apollo v2. When I tested this, the client was not rendering at all because of some missing exports from `vulcan:core` (the ones 'redirected' from `vulcan:lib`), but the apollo server was running and also the `voyager`. 
