### PR TITLE
Revert changes made to getUnusedSlug in #2075

### DIFF
--- a/packages/vulcan-lib/lib/modules/utils.js
+++ b/packages/vulcan-lib/lib/modules/utils.js
@@ -168,6 +168,35 @@ Utils.slugify = function (s) {
 
   return slug;
 };
+Utils.getUnusedSlug = function (collection, slug) {
+  let suffix = "";
+  let index = 0;
+
+  // test if slug is already in use
+  while (!!collection.findOne({slug: slug+suffix})) {
+    index++;
+    suffix = "-"+index;
+  }
+
+  return slug+suffix;
+};
+
+// Different version, less calls to the db but it cannot be used until we figure out how to use async for onCreate functions
+// Utils.getUnusedSlug = async function (collection, slug) {
+//   let suffix = '';
+//   let index = 0;
+// 
+//   const slugRegex = new RegExp('^' + slug + '-[0-9]+$');
+//   // get all the slugs matching slug or slug-123 in that collection
+//   const results = await collection.find( { slug: { $in: [slug, slugRegex] } }, { fields: { slug: 1, _id: 0 } });
+//   const usedSlugs = results.map(item => item.slug);
+//   // increment the index at the end of the slug until we find an unused one
+//   while (usedSlugs.indexOf(slug + suffix) !== -1) {
+//     index++;
+//     suffix = '-' + index;
+//   }
+//   return slug + suffix;
+// };
 
 Utils.getUnusedSlugByCollectionName = function (collectionName, slug) {
   return Utils.getUnusedSlug(getCollection(collectionName), slug);

--- a/packages/vulcan-lib/lib/server/utils.js
+++ b/packages/vulcan-lib/lib/server/utils.js
@@ -13,20 +13,4 @@ Utils.sanitize = function(s) {
   });
 };
 
-Utils.getUnusedSlug = async function (collection, slug) {
-  let suffix = '';
-  let index = 0;
-
-  const slugRegex = new RegExp('^' + slug + '-[0-9]+$');
-  // get all the slugs matching slug or slug-123 in that collection
-  const results = await Connectors.find( collection, { slug: { $in: [slug, slugRegex] } }, { fields: { slug: 1, _id: 0 } });
-  const usedSlugs = results.map(item => item.slug);
-  // increment the index at the end of the slug until we find an unused one
-  while (usedSlugs.indexOf(slug + suffix) !== -1) {
-    index++;
-    suffix = '-' + index;
-  }
-  return slug + suffix;
-};
-
 export { Utils };


### PR DESCRIPTION
In #2075 I made the mistake of thinking that `onCreate` functions were always exectued in async, which is [not the case for the `Users` collection](https://github.com/VulcanJS/Vulcan/blob/66b1aa467f30a0f3025f022f52bdac5981fbaed7/packages/vulcan-users/lib/server/on_create_user.js#L5). Thus, the slugs would be `[ Object object ]` because `getUnusedSlug` returned a pending promise.
So I reverted to the previous way we did things, using `collection.findOne`. I don't really understand why this is fine in terms of async, but at least it works. I let the version I implemented but it's commented, this way it's not lost and can be reused when we refactor or move out of meteor for example.
