### PR TITLE
set default email and siteName for Accounts related emails

### DIFF
--- a/packages/vulcan-accounts/imports/emailTemplates.js
+++ b/packages/vulcan-accounts/imports/emailTemplates.js
@@ -1,0 +1,5 @@
+import { Accounts } from 'meteor/accounts-base';
+import { getSetting } from 'meteor/vulcan:core';
+
+Accounts.emailTemplates.siteName = getSetting('public.title', '');
+Accounts.emailTemplates.from = getSetting('public.title', '')+ ' <' + getSetting('defaultEmail', 'no-reply@example.com') +'>';

--- a/packages/vulcan-accounts/main_server.js
+++ b/packages/vulcan-accounts/main_server.js
@@ -4,6 +4,7 @@ import './imports/components.js';
 import './imports/login_session.js';
 import './imports/routes.js';
 import './imports/oauth_config.js';
+import './imports/emailTemplates.js'
 import { redirect, STATES } from './imports/helpers.js';
 import './imports/api/server/servicesListPublication.js';
 


### PR DESCRIPTION
Related to #480 
Meteor docs: https://docs.meteor.com/api/passwords.html#Accounts-emailTemplates
Set the email address for:
- resetPassword
- forgotPassword
- verifyEmail

Questions remaining: 
- Is it right to set the `siteName` from the `title` setting, and what is it used for ?
- Can `siteName` and `from` still be overwritten from other packages?