### PR TITLE
Don't reset forms to default with spurious prop changes

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -635,15 +635,13 @@ class SmartForm extends Component {
   // --------------------------------------------------------------------- //
 
   /*
-  
-  When props change, reinitialize state
-  
-  // TODO: only need to check nextProps.prefilledProps?
-  // TODO: see https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html
-   
+
+  When prefilled props change, reinitialize state, resetting form contents
+  to default
+
   */
   UNSAFE_componentWillReceiveProps(nextProps) {
-    if (!isEqual(this.props, nextProps)) {
+    if (!isEqual(this.props.prefilledProps, nextProps.prefilledProps)) {
       this.setState(getInitialStateFromProps(nextProps));
     }
   }


### PR DESCRIPTION
Currently, when any props of a Form change, it reinitializes the form, resetting all values to defaults. Unfortunately, it's pretty easy to accidentally end up with some spurious property changes. Due to some ugly hacks in the LessWrong codebase's form components, most fields ended up ignoring the change, leaving a subtle bug in those components which didn't.