### PR TITLE
wrap source_version git cmd in a try catch

### DIFF
--- a/packages/vulcan-lib/lib/server/source_version.js
+++ b/packages/vulcan-lib/lib/server/source_version.js
@@ -16,7 +16,7 @@ const getSourceVersionFromGit = () => {
       .toString()
       .trim();
   } catch (err) {
-    console.error(`Error: could not get source version from command ${cmd}`, err);
+    console.error(`Error: could not get source version from command ${cmd}. Message: ${err.message.toString()}`);
     return undefined;
   }
 };


### PR DESCRIPTION
@see https://github.com/zodern/meteor-up/issues/807
On my local machine (Ubuntu 18, terminator shell) the command fail because it does not seem to be triggered in the correct folder when running tests. This is just a quickfix to avoid failure