### PR TITLE
Allow user to customize apollo json parser options

### DIFF
--- a/packages/vulcan-lib/lib/server/apollo_server.js
+++ b/packages/vulcan-lib/lib/server/apollo_server.js
@@ -127,7 +127,7 @@ const createApolloServer = (givenOptions = {}, givenConfig = {}) => {
   graphQLServer.use(compression());
 
   // GraphQL endpoint
-  graphQLServer.use(config.path, bodyParser.json(), graphqlExpress(async (req) => {
+  graphQLServer.use(config.path, bodyParser.json({ limit: getSetting('apolloServer.jsonParserOptions.limit') }), graphqlExpress(async (req) => {
     let options;
     let user = null;
 


### PR DESCRIPTION
In particular, the functionality is currently scoped to the maximum request body size (`limit`), which helps avoid errors like `PayloadTooLargeError: request entity too large`

Keys defined here:
https://www.npmjs.com/package/body-parser#bodyparserjsonoptions