### PR TITLE
Go back to using FormNestedFoot in Nested Array Fields

### DIFF
--- a/packages/vulcan-forms/lib/components/FormNestedArray.jsx
+++ b/packages/vulcan-forms/lib/components/FormNestedArray.jsx
@@ -97,15 +97,12 @@ class FormNestedArray extends PureComponent {
               )
           ),
           (!maxCount || arrayLength < maxCount) && (
-            <Components.Button
+            <Components.FormNestedFoot
               key="add-button"
-              size="small"
-              variant="success"
-              onClick={this.addItem}
-              className="form-nested-button"
-            >
-            <Components.IconAdd height={12} width={12} />
-          </Components.Button>
+              addItem={this.addItem}
+              label={this.props.label}
+              className="form-nested-foot"
+            />
           ),
           hasErrors ? (
             <FormComponents.FieldErrors

--- a/packages/vulcan-forms/lib/components/FormNestedFoot.jsx
+++ b/packages/vulcan-forms/lib/components/FormNestedFoot.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Components, registerComponent } from 'meteor/vulcan:core';
 
-const FormNestedFoot = ({ label, addItem }) => (
-  <Components.Button size="small" variant="success" iconButton onClick={addItem} className="form-nested-button">
+const FormNestedFoot = ({ addItem }) => (
+  <Components.Button size="small" variant="success" onClick={addItem} className="form-nested-button">
     <Components.IconAdd height={12} width={12} />
   </Components.Button>
 );


### PR DESCRIPTION
I just saw that we had double the code in the SmartForm for nested array fields. So i'm proposing that we go back to using the previous layout that was better in terms of component separation and customizability.
I'm adding this as a PR for visibility, I think we stopped using FormNestedFoot when @eric-burel made the change for the component API. If this gets no answers in a week I'll consider it ok to merge.