### PR TITLE
Add script to update package.json dependencies

### DIFF
--- a/.vulcan/.gitignore
+++ b/.vulcan/.gitignore
@@ -1,0 +1,2 @@
+bkp
+package.json

--- a/.vulcan/update_package.js
+++ b/.vulcan/update_package.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+
+var fs = require('fs');
+var mergePackages = require('@userfrosting/merge-package-dependencies');
+var jsdiff = require('diff');
+require('colors');
+
+function diffPartReducer(accumulator, part) {
+  // green for additions, red for deletions
+  // grey for common parts
+  var color = part.added ? 'green' : (part.removed ? 'red' : 'grey');
+
+  return {
+    text: (accumulator.text || '') + part.value[color],
+    count: (accumulator.count || 0) + (part.added || part.removed ? 1 : 0),
+  };
+}
+
+// copied from sort-object-keys package
+function sortObjectByKeyNameList(object, sortWith) {
+  var keys;
+  var sortFn;
+
+  if (typeof sortWith === 'function') {
+    sortFn = sortWith;
+  } else {
+    keys = sortWith;
+  }
+  return (keys || []).concat(Object.keys(object).sort(sortFn)).reduce(function(total, key) {
+    total[key] = object[key];
+    return total;
+  }, Object.create({}));
+}
+
+
+var appDirPath = './';
+var vulcanDirPath = './.vulcan/';
+
+if (!fs.existsSync(vulcanDirPath + 'package.json')) {
+  console.log('Could not find \'' + vulcanDirPath + 'package.json\'');
+} else if (!fs.existsSync(appDirPath + 'package.json')) {
+  console.log('Could not find \'' + appDirPath + 'package.json\'');
+} else {
+  var appPackageFile = fs.readFileSync(appDirPath + '/package.json');
+  var appPackageJson = JSON.parse(appPackageFile);
+  var vulcanPackageFile = fs.readFileSync(vulcanDirPath + 'package.json');
+  var vulcanPackageJson = JSON.parse(vulcanPackageFile);
+
+  console.log(appPackageJson.name + '@' + appPackageJson.version + ' \'package.json\' will be updated with Vulcan@' + vulcanPackageJson.version + ' dependencies.');
+
+  var backupDirPath = vulcanDirPath + 'bkp/';
+  if (!fs.existsSync(backupDirPath)) {
+    fs.mkdirSync(backupDirPath);
+  }
+  var backupFilePath = backupDirPath + 'package-' + Date.now() + '.json';
+  console.log('Saving a backup of \'' + appDirPath + 'package.json\' in \'' + backupFilePath + '\'');
+  fs.writeFileSync(backupFilePath, appPackageFile);
+
+  var updatedAppPackageJson = mergePackages.npm(
+    // IMPORTANT: parse again because mergePackages.npm mutates json
+    JSON.parse(appPackageFile),
+    [vulcanDirPath]
+  );
+
+  [
+    'dependencies',
+    'devDependencies',
+    'peerDependencies'
+  ].forEach(function(key) {
+    if (updatedAppPackageJson[key]) {
+      updatedAppPackageJson[key] = sortObjectByKeyNameList(updatedAppPackageJson[key]);
+    }
+
+    const diff = jsdiff.diffJson(
+      sortObjectByKeyNameList(appPackageJson[key] || {}),
+      updatedAppPackageJson[key] || {}
+    ).reduce(diffPartReducer, {});
+    if (diff.count) {
+      console.log('Changes in "' + key + '":');
+      console.log(diff.text);
+    } else {
+      console.log('No changes in "' + key + '".');
+    }
+  });
+
+  fs.writeFileSync(appDirPath + 'package.json', JSON.stringify(updatedAppPackageJson, null, '  '));
+}

--- a/.vulcan/update_package.js
+++ b/.vulcan/update_package.js
@@ -47,7 +47,16 @@ if (!fs.existsSync(vulcanDirPath + 'package.json')) {
   var vulcanPackageFile = fs.readFileSync(vulcanDirPath + 'package.json');
   var vulcanPackageJson = JSON.parse(vulcanPackageFile);
 
-  console.log(appPackageJson.name + '@' + appPackageJson.version + ' \'package.json\' will be updated with Vulcan@' + vulcanPackageJson.version + ' dependencies.');
+  if (appPackageJson.vulcanVersion) {
+    console.log(appPackageJson.name + '@' + appPackageJson.version +
+      ' \'package.json\' will be updated from Vulcan@' + appPackageJson.vulcanVersion +
+      ' to Vulcan@' + vulcanPackageJson.version +
+      ' dependencies.');
+  } else {
+    console.log(appPackageJson.name + '@' + appPackageJson.version +
+      ' \'package.json\' will be updated with Vulcan@' + vulcanPackageJson.version +
+      ' dependencies.');
+  }
 
   var backupDirPath = vulcanDirPath + 'bkp/';
   if (!fs.existsSync(backupDirPath)) {
@@ -62,6 +71,8 @@ if (!fs.existsSync(vulcanDirPath + 'package.json')) {
     JSON.parse(appPackageFile),
     [vulcanDirPath]
   );
+
+  updatedAppPackageJson.vulcanVersion = vulcanPackageJson.version;
 
   [
     'dependencies',

--- a/package.json
+++ b/package.json
@@ -96,10 +96,13 @@
   },
   "private": true,
   "devDependencies": {
+    "@userfrosting/merge-package-dependencies": "^1.2.0",
     "autoprefixer": "^6.3.6",
     "babel-eslint": "^7.0.0",
     "babylon": "^6.18.0",
+    "colors": "^1.3.2",
     "chromedriver": "^2.40.0",
+    "diff": "^3.5.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16.3": "^1.4.0",
     "eslint": "^3.19.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test-unit": "TEST_WATCH=1 meteor test-packages ./packages/* --port 3002 --driver-package meteortesting:mocha --raw-logs",
     "test": "npm run test-unit",
     "prettier": "node ./.vulcan/prettier/index.js write-changed",
-    "prettier-all": "node ./.vulcan/prettier/index.js write"
+    "prettier-all": "node ./.vulcan/prettier/index.js write",
+    "update-package-json": "node ./.vulcan/update_package.js"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
As explained in first comment of https://github.com/VulcanJS/Vulcan/issues/2173.

### Usage

Place Vulcan's `package.json` in `.vulcan/package.json` and run `meteor npm run update-package-json` form your project's folder.

You'll have to manually manage breaking updates (example, from `^2.0.1` to `^3.0.2`).

### Features

- makes a backup of the project's `package.json`
- only merges `dependencies`, `devDependencies` and `peerDependencies`
- if full merge is successful, shows a list of updated versions
- will store `vulcanVersion` in `package.json` for future updates

Here's a screenshot of the update process run from `1.12.6` to `1.12.10` in a custom project (result may vary depending on the installed versions):

![vulcan update](https://user-images.githubusercontent.com/16188653/50723838-515a3e00-10e3-11e9-8d37-730253836155.png)

