### PR TITLE
vulcan-lib - validation - update dataToModifier to handle modifier as well

### DIFF
--- a/packages/vulcan-lib/lib/modules/validation.js
+++ b/packages/vulcan-lib/lib/modules/validation.js
@@ -1,9 +1,9 @@
 import pickBy from 'lodash/pickBy';
 import mapValues from 'lodash/mapValues';
 
-export const dataToModifier = data => ({ 
-  $set: pickBy(data, f => f !== null), 
-  $unset: mapValues(pickBy(data, f => f === null), () => true),
+export const dataToModifier = data => ({
+  $set: pickBy(data.$set || data, f => f !== null),
+  $unset: mapValues(pickBy(data.$unset || data, f => f === null), () => true),
 });
 
 export const modifierToData = modifier => ({


### PR DESCRIPTION
Amend to the dataToModifier function to handle a pre-existing modifier, rather than purely data, to avoid possible selector errors when passing in {$set: {$set: {...}}}