### PR TITLE
[WIP] I18n: formatLabel

### DIFF
--- a/packages/vulcan-core/lib/modules/components/Card.jsx
+++ b/packages/vulcan-core/lib/modules/components/Card.jsx
@@ -8,12 +8,7 @@ import { Link } from 'react-router';
 
 const getLabel = (field, fieldName, collection, intl) => {
   const schema = collection && collection.simpleSchema()._schema;
-  const fieldSchema = schema && schema[fieldName];
-  if (fieldSchema) {
-    return intl.formatMessage({id: `${collection._name}.${fieldName}`, defaultMessage: fieldSchema.label});
-  } else {
-    return fieldName;
-  }
+  return intl.formatLabel({ fieldName: fieldName, collectionName: collection._name, schema: schema });
 };
 
 const getTypeName = (field, fieldName, collection) => {

--- a/packages/vulcan-core/lib/modules/components/Datatable.jsx
+++ b/packages/vulcan-core/lib/modules/components/Datatable.jsx
@@ -194,13 +194,12 @@ const DatatableHeader = ({ collection, column, toggleSort, currentSort, Componen
 
     use either:
 
-    1. the column name translation
+    1. the column name translation : collectionName.columnName, global.columnName, columnName
     2. the column name label in the schema (if the column name matches a schema field)
     3. the raw column name.
 
     */
-    const defaultMessage = schema[columnName] ? schema[columnName].label : Utils.camelToSpaces(columnName);
-    const formattedLabel = intl.formatMessage({ id: `${collection._name}.${columnName}`, defaultMessage });
+    const formattedLabel = intl.formatLabel({fieldName: columnName, collectionName: collection._name, schema: schema})
 
     // if sortable is a string, use it as the name of the property to sort by. If it's just `true`, use column.name
     const sortPropertyName = typeof column.sortable === 'string' ? column.sortable : column.name;
@@ -461,4 +460,3 @@ const DatatableDefaultCell = ({ column, document }) =>
   <div>{typeof column === 'string' ? getFieldValue(document[column]) : getFieldValue(document[column.name])}</div>;
 
 registerComponent('DatatableDefaultCell', DatatableDefaultCell);
-

--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -522,7 +522,7 @@ class SmartForm extends Component {
     intlLabel = this.context.intl.formatMessage({ id, defaultMessage });
     if (intlLabel === defaultMessage) {
       id = `global.${fieldName}`;
-      intlLabel = this.context.intl.formatMessage({ id });
+      intlLabel = this.context.intl.formatMessage({ id, defaultMessage });
       if (intlLabel === defaultMessage) {
         id = fieldName;
         intlLabel = this.context.intl.formatMessage({ id });

--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -516,26 +516,15 @@ class SmartForm extends Component {
    */
   getLabel = (fieldName, fieldLocale) => {
     const collectionName = this.props.collectionName.toLowerCase();
-    const defaultMessage = '|*|*|';
-    let id = `${collectionName}.${fieldName}`;
-    let intlLabel;
-    intlLabel = this.context.intl.formatMessage({ id, defaultMessage });
-    if (intlLabel === defaultMessage) {
-      id = `global.${fieldName}`;
-      intlLabel = this.context.intl.formatMessage({ id, defaultMessage });
-      if (intlLabel === defaultMessage) {
-        id = fieldName;
-        intlLabel = this.context.intl.formatMessage({ id });
-      }
-    }
-    const schemaLabel =
-      this.state.flatSchema[fieldName] &&
-      this.state.flatSchema[fieldName].label;
-    const label = intlLabel || schemaLabel || fieldName;
+    const label = this.context.intl.formatLabel({
+      fieldName: fieldName,
+      collectionName: collectionName,
+      schema: this.state.flatSchema,
+    });
     if (fieldLocale) {
       const intlFieldLocale = this.context.intl.formatMessage({
         id: `locales.${fieldLocale}`,
-        defaultMessage: fieldLocale
+        defaultMessage: fieldLocale,
       });
       return `${label} (${intlFieldLocale})`;
     } else {

--- a/packages/vulcan-forms/test/components.test.js
+++ b/packages/vulcan-forms/test/components.test.js
@@ -158,6 +158,7 @@ const Addresses = createCollection({
 describe('vulcan-forms/components', function() {
   const context = {
     intl: {
+      formatLabel: () => '',
       formatMessage: () => '',
       formatDate: () => '',
       formatTime: () => '',

--- a/packages/vulcan-forms/test/components.test.js
+++ b/packages/vulcan-forms/test/components.test.js
@@ -22,39 +22,39 @@ import SimpleSchema from 'simpl-schema';
 const addressGroup = {
   name: 'addresses',
   label: 'Addresses',
-  order: 10
+  order: 10,
 };
 const permissions = {
   canRead: ['guests'],
   canUpdate: ['quests'],
-  canCreate: ['guests']
+  canCreate: ['guests'],
 };
 
 // just 1 input for state testing
 const fooSchema = {
   foo: {
     type: String,
-    ...permissions
-  }
+    ...permissions,
+  },
 };
 //
 const addressSchema = {
   street: {
     type: String,
     optional: true,
-    ...permissions
-  }
+    ...permissions,
+  },
 };
 // [{street, city,...}, {street, city, ...}]
 const arrayOfObjectSchema = {
   addresses: {
     type: Array,
     group: addressGroup,
-    ...permissions
+    ...permissions,
   },
   'addresses.$': {
-    type: new SimpleSchema(addressSchema)
-  }
+    type: new SimpleSchema(addressSchema),
+  },
 };
 // example with custom inputs for the children
 // ["http://maps/XYZ", "http://maps/foobar"]
@@ -62,12 +62,12 @@ const arrayOfUrlSchema = {
   addresses: {
     type: Array,
     group: addressGroup,
-    ...permissions
+    ...permissions,
   },
   'addresses.$': {
     type: String,
-    input: 'url'
-  }
+    input: 'url',
+  },
 };
 // example with array and custom input
 const CustomObjectInput = () => 'OBJECT INPUT';
@@ -75,12 +75,12 @@ const arrayOfCustomObjectSchema = {
   addresses: {
     type: Array,
     group: addressGroup,
-    ...permissions
+    ...permissions,
   },
   'addresses.$': {
     type: new SimpleSchema(addressSchema),
-    input: CustomObjectInput
-  }
+    input: CustomObjectInput,
+  },
 };
 // example with a fully custom input for both the array and its children
 const ArrayInput = () => 'ARRAY INPUT';
@@ -89,12 +89,12 @@ const arrayFullCustomSchema = {
     type: Array,
     group: addressGroup,
     ...permissions,
-    input: ArrayInput
+    input: ArrayInput,
   },
   'addresses.$': {
     type: String,
-    input: 'url'
-  }
+    input: 'url',
+  },
 };
 // example with a native type
 // ["20 rue du Moulin PARIS", "16 rue de la poste PARIS"]
@@ -104,26 +104,26 @@ const arrayOfStringSchema = {
   addresses: {
     type: Array,
     group: addressGroup,
-    ...permissions
+    ...permissions,
   },
   'addresses.$': {
-    type: String
-  }
+    type: String,
+  },
 };
 // object (not in an array): {street, city}
 const objectSchema = {
   addresses: {
     type: new SimpleSchema(addressSchema),
-    ...permissions
-  }
+    ...permissions,
+  },
 };
 // without calling SimpleSchema
 // eslint-disable-next-line no-unused-vars
 const bareObjectSchema = {
   addresses: {
     type: addressSchema,
-    ...permissions
-  }
+    ...permissions,
+  },
 };
 
 // stub collection
@@ -134,13 +134,16 @@ const createDummyCollection = (typeName, schema) =>
     typeName,
     schema,
     resolvers: getDefaultResolvers(typeName + 's'),
-    mutations: getDefaultMutations(typeName + 's')
+    mutations: getDefaultMutations(typeName + 's'),
   });
 const Foos = createDummyCollection('Foo', fooSchema);
 const ArrayOfObjects = createDummyCollection('ArrayOfObject', arrayOfObjectSchema);
 const Objects = createDummyCollection('Object', objectSchema);
 const ArrayOfUrls = createDummyCollection('ArrayOfUrl', arrayOfUrlSchema);
-const ArrayOfCustomObjects = createDummyCollection('ArrayOfCustomObject', arrayOfCustomObjectSchema);
+const ArrayOfCustomObjects = createDummyCollection(
+  'ArrayOfCustomObject',
+  arrayOfCustomObjectSchema
+);
 const ArrayFullCustom = createDummyCollection('ArrayFullCustom', arrayFullCustomSchema);
 // eslint-disable-next-line no-unused-vars
 const ArrayOfStrings = createDummyCollection('ArrayOfString', arrayOfStringSchema);
@@ -150,7 +153,7 @@ const Addresses = createCollection({
   typeName: 'Address',
   schema: addressSchema,
   resolvers: getDefaultResolvers('Addresses'),
-  mutations: getDefaultMutations('Addresses')
+  mutations: getDefaultMutations('Addresses'),
 });
 
 // helpers
@@ -166,24 +169,24 @@ describe('vulcan-forms/components', function() {
       formatNumber: () => '',
       formatPlural: () => '',
       formatHTMLMessage: () => '',
-      now: () => ''
-    }
+      now: () => '',
+    },
   };
   // eslint-disable-next-line no-unused-vars
   const mountWithContext = C =>
     mount(C, {
-      context
+      context,
     });
   const shallowWithContext = C =>
     shallow(C, {
-      context
+      context,
     });
 
   describe('Form collectionName="" (handle fields computation)', function() {
     // since some props are now handled by HOC we need to provide them manually
     const defaultProps = {
       collectionName: '',
-      typeName: ''
+      typeName: '',
     };
 
     describe('Form generation', function() {
@@ -225,17 +228,23 @@ describe('vulcan-forms/components', function() {
       });
       describe('array of objects', function() {
         it('shallow render', () => {
-          const wrapper = shallowWithContext(<Form collectionName="" collection={ArrayOfObjects} />);
+          const wrapper = shallowWithContext(
+            <Form collectionName="" collection={ArrayOfObjects} />
+          );
           expect(wrapper).toBeDefined();
         });
         it('render a FormGroup for addresses', function() {
-          const wrapper = shallowWithContext(<Form collectionName="" collection={ArrayOfObjects} />);
+          const wrapper = shallowWithContext(
+            <Form collectionName="" collection={ArrayOfObjects} />
+          );
           const formGroup = wrapper.find('FormGroup').find({ name: 'addresses' });
           expect(formGroup).toBeDefined();
           expect(formGroup).toHaveLength(1);
         });
         it('passes down the array child fields', function() {
-          const wrapper = shallowWithContext(<Form collectionName="" collection={ArrayOfObjects} />);
+          const wrapper = shallowWithContext(
+            <Form collectionName="" collection={ArrayOfObjects} />
+          );
           const formGroup = getArrayFormGroup(wrapper);
           const fields = getFields(formGroup);
           const arrayField = fields[0];
@@ -258,12 +267,16 @@ describe('vulcan-forms/components', function() {
       });
       describe('array of objects with custom children inputs', function() {
         it('shallow render', function() {
-          const wrapper = shallowWithContext(<Form collectionName="" collection={ArrayOfCustomObjects} />);
+          const wrapper = shallowWithContext(
+            <Form collectionName="" collection={ArrayOfCustomObjects} />
+          );
           expect(wrapper).toBeDefined();
         });
         // TODO: does not work, schema_utils needs an update
         it.skip('passes down the custom input', function() {
-          const wrapper = shallowWithContext(<Form collectionName="" collection={ArrayOfCustomObjects} />);
+          const wrapper = shallowWithContext(
+            <Form collectionName="" collection={ArrayOfCustomObjects} />
+          );
           const formGroup = getArrayFormGroup(wrapper);
           const fields = getFields(formGroup);
           const arrayField = fields[0];
@@ -272,11 +285,15 @@ describe('vulcan-forms/components', function() {
       });
       describe('array with a fully custom input (array itself and children)', function() {
         it('shallow render', function() {
-          const wrapper = shallowWithContext(<Form collectionName="" collection={ArrayFullCustom} />);
+          const wrapper = shallowWithContext(
+            <Form collectionName="" collection={ArrayFullCustom} />
+          );
           expect(wrapper).toBeDefined();
         });
         it('passes down the custom input', function() {
-          const wrapper = shallowWithContext(<Form collectionName="" collection={ArrayFullCustom} />);
+          const wrapper = shallowWithContext(
+            <Form collectionName="" collection={ArrayFullCustom} />
+          );
           const formGroup = getArrayFormGroup(wrapper);
           const fields = getFields(formGroup);
           const arrayField = fields[0];
@@ -294,29 +311,38 @@ describe('vulcan-forms/components', function() {
         wrapper
           .find('input')
           .first()
-          .simulate('change', { target:{value:'bar'} });
+          .simulate('change', { target: { value: 'bar' } });
         // eslint-disable-next-line no-console
-        console.log(wrapper.find('input').first().html());
+        console.log(
+          wrapper
+            .find('input')
+            .first()
+            .html()
+        );
         // eslint-disable-next-line no-console
         console.log(wrapper.state());
-        expect(wrapper.state().currentValues).toEqual({foo:'bar'});
+        expect(wrapper.state().currentValues).toEqual({ foo: 'bar' });
       });
       it('reset state when relevant props change', function() {
-        const wrapper = shallowWithContext(<Form {...defaultProps} collectionName="Foos" collection={Foos} />);
+        const wrapper = shallowWithContext(
+          <Form {...defaultProps} collectionName="Foos" collection={Foos} />
+        );
         wrapper.setState({ currentValues: { foo: 'bar' } });
-        expect(wrapper.state('currentValues')).toEqual({foo:'bar'});
+        expect(wrapper.state('currentValues')).toEqual({ foo: 'bar' });
         wrapper.setProps({ collectionName: 'Bars' });
         expect(wrapper.state('currentValues')).toEqual({});
       });
-      it('does not reset state when external prop change', function(){
+      it('does not reset state when external prop change', function() {
         //const prefilledProps = { bar: 'foo' } // TODO
-        const changeCallback= () => 'CHANGE';
-        const wrapper = shallowWithContext(<Form {...defaultProps} collection={Foos} changeCallback={changeCallback} />);
+        const changeCallback = () => 'CHANGE';
+        const wrapper = shallowWithContext(
+          <Form {...defaultProps} collection={Foos} changeCallback={changeCallback} />
+        );
         wrapper.setState({ currentValues: { foo: 'bar' } });
-        expect(wrapper.state('currentValues')).toEqual({foo:'bar'});
+        expect(wrapper.state('currentValues')).toEqual({ foo: 'bar' });
         const newChangeCallback = () => 'NEW';
         wrapper.setProps({ changeCallback: newChangeCallback });
-        expect(wrapper.state('currentValues')).toEqual({ foo:'bar'});
+        expect(wrapper.state('currentValues')).toEqual({ foo: 'bar' });
       });
     });
   });
@@ -325,8 +351,8 @@ describe('vulcan-forms/components', function() {
     const shallowWithContext = C =>
       shallow(C, {
         context: {
-          getDocument: () => {}
-        }
+          getDocument: () => {},
+        },
       });
     const defaultProps = {
       disabled: false,
@@ -343,7 +369,7 @@ describe('vulcan-forms/components', function() {
       throwError: () => {},
       updateCurrentValues: () => {},
       errors: [],
-      clearFieldErrors: () => {}
+      clearFieldErrors: () => {},
     };
     it('shallow render', function() {
       const wrapper = shallowWithContext(<FormComponent {...defaultProps} />);
@@ -356,11 +382,11 @@ describe('vulcan-forms/components', function() {
         nestedSchema: {
           street: {},
           country: {},
-          zipCode: {}
+          zipCode: {},
         },
         nestedInput: true,
         nestedFields: [{}, {}, {}],
-        currentValues: {}
+        currentValues: {},
       };
       it('render a FormNestedArray', function() {
         const wrapper = shallowWithContext(<FormComponent {...props} />);
@@ -375,11 +401,11 @@ describe('vulcan-forms/components', function() {
         nestedSchema: {
           street: {},
           country: {},
-          zipCode: {}
+          zipCode: {},
         },
         nestedInput: true,
         nestedFields: [{}, {}, {}],
-        currentValues: {}
+        currentValues: {},
       };
       it('shallow render', function() {
         const wrapper = shallowWithContext(<FormComponent {...props} />);
@@ -401,7 +427,7 @@ describe('vulcan-forms/components', function() {
       errors: [],
       deletedValues: [],
       path: 'foobar',
-      formComponents: Components
+      formComponents: Components,
     };
     it('shallow render', function() {
       const wrapper = shallow(<Components.FormNestedArray {...defaultProps} currentValues={{}} />);
@@ -414,12 +440,16 @@ describe('vulcan-forms/components', function() {
       expect(addButton).toHaveLength(1);
     });
     it.skip('shows 3 items', function() {
-      const wrapper = mount(<Components.FormNestedArray {...defaultProps} currentValues={{}} value={[1, 2, 3]} />);
+      const wrapper = mount(
+        <Components.FormNestedArray {...defaultProps} currentValues={{}} value={[1, 2, 3]} />
+      );
       const nestedItem = wrapper.find('FormNestedItem');
       expect(nestedItem).toHaveLength(3);
     });
     it.skip('pass the correct path and itemIndex to each form', function() {
-      const wrapper = mount(<Components.FormNestedArray {...defaultProps} currentValues={{}} value={[1, 2]} />);
+      const wrapper = mount(
+        <Components.FormNestedArray {...defaultProps} currentValues={{}} value={[1, 2]} />
+      );
       const nestedItem = wrapper.find('FormNestedItem');
       const item0 = nestedItem.at(0);
       const item1 = nestedItem.at(1);
@@ -433,7 +463,7 @@ describe('vulcan-forms/components', function() {
     const defaultProps = {
       errors: [],
       path: 'foobar',
-      formComponents: Components
+      formComponents: Components,
     };
     it('shallow render', function() {
       const wrapper = shallow(<Components.FormNestedObject {...defaultProps} currentValues={{}} />);

--- a/packages/vulcan-i18n/lib/modules/provider.js
+++ b/packages/vulcan-i18n/lib/modules/provider.js
@@ -1,16 +1,58 @@
-import React, { Component } from 'react';
-import { getString } from 'meteor/vulcan:lib';
-import { intlShape } from './shape.js';
+import React, {Component} from 'react';
+import {getString} from 'meteor/vulcan:lib';
+import {intlShape} from './shape.js';
 
-export default class IntlProvider extends Component{
+export default class IntlProvider extends Component {
+  formatMessage = ({id, defaultMessage}, values) => {
+    return getString({id, defaultMessage, values, locale: this.props.locale});
+  };
 
-  formatMessage = ({ id, defaultMessage }, values) => {
-    return getString({ id, defaultMessage, values, locale: this.props.locale });
-  }
+  /**
+   * formatLabel - Get a label for a field, for a given collection, in the current language. The evaluation is as follows : i18n(collectioName.fieldName) > i18n(global.fieldName) > i18n(fieldName) > schema.fieldName.label > fieldName
+   *
+   * @param  {object} options
+   * @param  {string} options.fieldName          The name of the field to evaluate (required)
+   * @param  {string} options.collectionName     The name of the collection the field belongs to
+   * @param  {object} options.schema             The schema of the collection
+   * @param  {object} values                     The values to pass to format the i18n string
+   * @return {string}                            The translated label
+   */
 
-  formatStuff = (something) => {
+  formatLabel = ({fieldName, collectionName, schema}, values) => {
+    if (!fieldName) {
+      throw new Error(
+        'fieldName option passed to formatLabel cannot be empty or undefined'
+      );
+    }
+    const defaultMessage = '|*|*|';
+    // Get the intl label
+    let intlLabel = defaultMessage;
+    // try collectionName.fieldName as intl id
+    if (collectionName) {
+      intlLabel = this.formatMessage(
+        {id: `${collectionName.toLowerCase()}.${fieldName}`, defaultMessage},
+        values
+      );
+    }
+    // try global.fieldName then just fieldName as intl id
+    if (intlLabel === defaultMessage) {
+      intlLabel = this.formatMessage(
+        {id: `global.${fieldName}`, defaultMessage},
+        values
+      );
+      if (intlLabel === defaultMessage) {
+        intlLabel = this.formatMessage({id: fieldName}, values);
+      }
+    }
+    // define the schemaLabel. If the schema has been initialized with SimpleSchema, the label should be here even if it has not been declared https://github.com/aldeed/simple-schema-js#label
+    let schemaLabel =
+      schema && schema[fieldName] ? schema[fieldName].label : null;
+    return intlLabel || schemaLabel || fieldName;
+  };
+
+  formatStuff = something => {
     return something;
-  }
+  };
 
   getChildContext() {
     return {
@@ -19,20 +61,20 @@ export default class IntlProvider extends Component{
         formatTime: this.formatStuff,
         formatRelative: this.formatStuff,
         formatNumber: this.formatStuff,
-        formatPlural: this.formatStuff, 
+        formatPlural: this.formatStuff,
         formatMessage: this.formatMessage,
+        formatLabel: this.formatLabel,
         formatHTMLMessage: this.formatStuff,
         now: this.formatStuff,
-      }
+      },
     };
   }
-  
-  render(){
+
+  render() {
     return this.props.children;
   }
-
 }
 
 IntlProvider.childContextTypes = {
-  intl: intlShape
+  intl: intlShape,
 };

--- a/packages/vulcan-i18n/lib/modules/provider.js
+++ b/packages/vulcan-i18n/lib/modules/provider.js
@@ -8,7 +8,7 @@ export default class IntlProvider extends Component {
   };
 
   /**
-   * formatLabel - Get a label for a field, for a given collection, in the current language. The evaluation is as follows : i18n(collectioName.fieldName) > i18n(global.fieldName) > i18n(fieldName) > schema.fieldName.label > fieldName
+   * formatLabel - Get a label for a field, for a given collection, in the current language. The evaluation is as follows : i18n(collectionName.fieldName) > i18n(global.fieldName) > i18n(fieldName) > schema.fieldName.label > fieldName
    *
    * @param  {object} options
    * @param  {string} options.fieldName          The name of the field to evaluate (required)

--- a/packages/vulcan-i18n/lib/modules/provider.js
+++ b/packages/vulcan-i18n/lib/modules/provider.js
@@ -10,10 +10,10 @@ export default class IntlProvider extends Component {
   /**
    * formatLabel - Get a label for a field, for a given collection, in the current language. The evaluation is as follows : i18n(collectionName.fieldName) > i18n(global.fieldName) > i18n(fieldName) > schema.fieldName.label > fieldName
    *
-   * @param  {object} options
-   * @param  {string} options.fieldName          The name of the field to evaluate (required)
-   * @param  {string} options.collectionName     The name of the collection the field belongs to
-   * @param  {object} options.schema             The schema of the collection
+   * @param  {object} params
+   * @param  {string} params.fieldName          The name of the field to evaluate (required)
+   * @param  {string} params.collectionName     The name of the collection the field belongs to
+   * @param  {object} params.schema             The schema of the collection
    * @param  {object} values                     The values to pass to format the i18n string
    * @return {string}                            The translated label
    */

--- a/packages/vulcan-i18n/lib/modules/provider.js
+++ b/packages/vulcan-i18n/lib/modules/provider.js
@@ -44,10 +44,14 @@ export default class IntlProvider extends Component {
         intlLabel = this.formatMessage({id: fieldName}, values);
       }
     }
+    if (intlLabel) {
+      return intlLabel;
+    }
+
     // define the schemaLabel. If the schema has been initialized with SimpleSchema, the label should be here even if it has not been declared https://github.com/aldeed/simple-schema-js#label
     let schemaLabel =
       schema && schema[fieldName] ? schema[fieldName].label : null;
-    return intlLabel || schemaLabel || fieldName;
+    return schemaLabel || fieldName;
   };
 
   formatStuff = something => {

--- a/packages/vulcan-i18n/lib/modules/provider.js
+++ b/packages/vulcan-i18n/lib/modules/provider.js
@@ -1,6 +1,6 @@
-import React, {Component} from 'react';
-import {getString} from 'meteor/vulcan:lib';
-import {intlShape} from './shape.js';
+import React, { Component } from 'react';
+import { getString, Utils } from 'meteor/vulcan:lib';
+import { intlShape } from './shape.js';
 
 export default class IntlProvider extends Component {
   formatMessage = ({id, defaultMessage}, values) => {
@@ -51,7 +51,7 @@ export default class IntlProvider extends Component {
     // define the schemaLabel. If the schema has been initialized with SimpleSchema, the label should be here even if it has not been declared https://github.com/aldeed/simple-schema-js#label
     let schemaLabel =
       schema && schema[fieldName] ? schema[fieldName].label : null;
-    return schemaLabel || fieldName;
+    return schemaLabel || Utils.camelToSpaces(fieldName);
   };
 
   formatStuff = something => {

--- a/packages/vulcan-i18n/lib/modules/provider.js
+++ b/packages/vulcan-i18n/lib/modules/provider.js
@@ -3,8 +3,8 @@ import { getString, Utils } from 'meteor/vulcan:lib';
 import { intlShape } from './shape.js';
 
 export default class IntlProvider extends Component {
-  formatMessage = ({id, defaultMessage}, values) => {
-    return getString({id, defaultMessage, values, locale: this.props.locale});
+  formatMessage = ({ id, defaultMessage }, values) => {
+    return getString({ id, defaultMessage, values, locale: this.props.locale });
   };
 
   /**
@@ -18,11 +18,9 @@ export default class IntlProvider extends Component {
    * @return {string}                            The translated label
    */
 
-  formatLabel = ({fieldName, collectionName, schema}, values) => {
+  formatLabel = ({ fieldName, collectionName, schema }, values) => {
     if (!fieldName) {
-      throw new Error(
-        'fieldName option passed to formatLabel cannot be empty or undefined'
-      );
+      throw new Error('fieldName option passed to formatLabel cannot be empty or undefined');
     }
     const defaultMessage = '|*|*|';
     // Get the intl label
@@ -30,18 +28,15 @@ export default class IntlProvider extends Component {
     // try collectionName.fieldName as intl id
     if (collectionName) {
       intlLabel = this.formatMessage(
-        {id: `${collectionName.toLowerCase()}.${fieldName}`, defaultMessage},
+        { id: `${collectionName.toLowerCase()}.${fieldName}`, defaultMessage },
         values
       );
     }
     // try global.fieldName then just fieldName as intl id
     if (intlLabel === defaultMessage) {
-      intlLabel = this.formatMessage(
-        {id: `global.${fieldName}`, defaultMessage},
-        values
-      );
+      intlLabel = this.formatMessage({ id: `global.${fieldName}`, defaultMessage }, values);
       if (intlLabel === defaultMessage) {
-        intlLabel = this.formatMessage({id: fieldName}, values);
+        intlLabel = this.formatMessage({ id: fieldName }, values);
       }
     }
     if (intlLabel) {
@@ -49,8 +44,7 @@ export default class IntlProvider extends Component {
     }
 
     // define the schemaLabel. If the schema has been initialized with SimpleSchema, the label should be here even if it has not been declared https://github.com/aldeed/simple-schema-js#label
-    let schemaLabel =
-      schema && schema[fieldName] ? schema[fieldName].label : null;
+    let schemaLabel = schema && schema[fieldName] ? schema[fieldName].label : null;
     return schemaLabel || Utils.camelToSpaces(fieldName);
   };
 

--- a/packages/vulcan-i18n/lib/modules/shape.js
+++ b/packages/vulcan-i18n/lib/modules/shape.js
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 
-const {bool, number, string, func, object, oneOf, shape, any} = PropTypes;
+const { bool, number, string, func, object, oneOf, shape, any } = PropTypes;
 const localeMatcher = oneOf(['best fit', 'lookup']);
 const narrowShortLong = oneOf(['narrow', 'short', 'long']);
 const numeric2digit = oneOf(['numeric', '2-digit']);

--- a/packages/vulcan-i18n/lib/modules/shape.js
+++ b/packages/vulcan-i18n/lib/modules/shape.js
@@ -1,8 +1,8 @@
 /*
-* Copyright 2015, Yahoo Inc.
-* Copyrights licensed under the New BSD License.
-* See the accompanying LICENSE file for terms.
-*/
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
 
 import PropTypes from 'prop-types';
 
@@ -13,22 +13,23 @@ const numeric2digit = oneOf(['numeric', '2-digit']);
 const funcReq = func.isRequired;
 
 export const intlConfigPropTypes = {
-  locale       : string,
-  formats      : object,
-  messages     : object,
+  locale: string,
+  formats: object,
+  messages: object,
   textComponent: any,
 
-  defaultLocale : string,
+  defaultLocale: string,
   defaultFormats: object,
 };
 
 export const intlFormatPropTypes = {
-  formatDate       : funcReq,
-  formatTime       : funcReq,
-  formatRelative   : funcReq,
-  formatNumber     : funcReq,
-  formatPlural     : funcReq,
-  formatMessage    : funcReq,
+  formatDate: funcReq,
+  formatTime: funcReq,
+  formatRelative: funcReq,
+  formatNumber: funcReq,
+  formatPlural: funcReq,
+  formatMessage: funcReq,
+  formatLabel: funcReq,
   formatHTMLMessage: funcReq,
 };
 
@@ -40,8 +41,8 @@ export const intlShape = shape({
 });
 
 export const messageDescriptorPropTypes = {
-  id            : string.isRequired,
-  description   : string,
+  id: string.isRequired,
+  description: string,
   defaultMessage: string,
 };
 
@@ -50,30 +51,30 @@ export const dateTimeFormatPropTypes = {
   formatMatcher: oneOf(['basic', 'best fit']),
 
   timeZone: string,
-  hour12  : bool,
+  hour12: bool,
 
-  weekday     : narrowShortLong,
-  era         : narrowShortLong,
-  year        : numeric2digit,
-  month       : oneOf(['numeric', '2-digit', 'narrow', 'short', 'long']),
-  day         : numeric2digit,
-  hour        : numeric2digit,
-  minute      : numeric2digit,
-  second      : numeric2digit,
+  weekday: narrowShortLong,
+  era: narrowShortLong,
+  year: numeric2digit,
+  month: oneOf(['numeric', '2-digit', 'narrow', 'short', 'long']),
+  day: numeric2digit,
+  hour: numeric2digit,
+  minute: numeric2digit,
+  second: numeric2digit,
   timeZoneName: oneOf(['short', 'long']),
 };
 
 export const numberFormatPropTypes = {
   localeMatcher,
 
-  style          : oneOf(['decimal', 'currency', 'percent']),
-  currency       : string,
+  style: oneOf(['decimal', 'currency', 'percent']),
+  currency: string,
   currencyDisplay: oneOf(['symbol', 'code', 'name']),
-  useGrouping    : bool,
+  useGrouping: bool,
 
-  minimumIntegerDigits    : number,
-  minimumFractionDigits   : number,
-  maximumFractionDigits   : number,
+  minimumIntegerDigits: number,
+  minimumFractionDigits: number,
+  maximumFractionDigits: number,
   minimumSignificantDigits: number,
   maximumSignificantDigits: number,
 };

--- a/packages/vulcan-i18n/package.js
+++ b/packages/vulcan-i18n/package.js
@@ -2,18 +2,19 @@ Package.describe({
   name: 'vulcan:i18n',
   summary: 'i18n client polyfill',
   version: '1.12.13',
-  git: 'https://github.com/VulcanJS/Vulcan'
+  git: 'https://github.com/VulcanJS/Vulcan',
 });
 
-Package.onUse(function (api) {
-
+Package.onUse(function(api) {
   api.versionsFrom('1.6.1');
 
-  api.use([
-    'vulcan:lib@1.12.13',
-  ]);
+  api.use(['vulcan:lib@1.12.13']);
 
   api.mainModule('lib/server/main.js', 'server');
   api.mainModule('lib/client/main.js', 'client');
+});
 
+Package.onTest(function(api) {
+  api.use(['ecmascript', 'meteortesting:mocha', 'vulcan:test', 'vulcan:i18n']);
+  api.mainModule('./test/index.js');
 });

--- a/packages/vulcan-i18n/test/index.js
+++ b/packages/vulcan-i18n/test/index.js
@@ -1,0 +1,1 @@
+import './provider.test.js'

--- a/packages/vulcan-i18n/test/index.js
+++ b/packages/vulcan-i18n/test/index.js
@@ -1,1 +1,1 @@
-import './provider.test.js'
+import './provider.test.js';

--- a/packages/vulcan-i18n/test/provider.test.js
+++ b/packages/vulcan-i18n/test/provider.test.js
@@ -1,0 +1,127 @@
+import IntlProvider from '../lib/modules/provider';
+import React from 'react';
+import expect from 'expect';
+import { shallow } from 'enzyme';
+import { addStrings, Utils } from 'meteor/vulcan:core';
+
+// constants for formatMessage
+const defaultMessage = 'default';
+const stringId = 'test_string';
+const ENTestString = 'English test string';
+const FRTestString = 'Phrase test en Français';
+const valueStringId = 'valueStringId';
+const valueStringValue = 'Vulcan';
+const valueTestStringStatic = 'the value is ';
+const valueTestStringDynamic = 'testValue';
+const valueTestString = `${valueTestStringStatic}{${valueTestStringDynamic}}`;
+
+// constants for formatLabel
+const fieldName = 'testFieldName';
+const fieldNameForSchema = 'fieldNameForSchema';
+const fieldNameForGlobal = 'testFieldNameGlobal';
+const fieldNameForCollection = 'testFieldNameCollection';
+const unknownFieldName = 'unknownFieldName';
+const collectionName = 'Tests';
+const labelFromCollection = 'label from collection';
+const labelFromGlobal = 'label from global';
+const labelFromSchema = 'label from schema';
+const labelFromFieldName = 'label from fieldName';
+// add the schema entries for all fields to test respect of the order too
+const schema = {
+  [fieldName]: {
+    label: labelFromSchema,
+  },
+  [fieldNameForSchema]: {
+    label: labelFromSchema,
+  },
+  [fieldNameForGlobal]: {
+    label: labelFromSchema,
+  },
+  [fieldNameForCollection]: {
+    label: labelFromSchema,
+  },
+};
+// add the strings for formatMessage
+addStrings('en', {
+  [stringId]: ENTestString,
+  [valueStringId]: valueTestString,
+});
+addStrings('fr', {
+  [stringId]: FRTestString,
+});
+
+// add the strings for formatLabel
+addStrings('en', {
+  // fieldName only
+  [fieldName]: labelFromFieldName,
+  // fieldName + global - we expect labelFromGlobal
+  [fieldNameForGlobal]: labelFromFieldName,
+  [`global.${fieldNameForGlobal}`]: labelFromGlobal,
+  // fieldName + global + collectionName - we expect labelFromCollection
+  [fieldNameForCollection]: labelFromFieldName,
+  [`global.${fieldNameForCollection}`]: labelFromGlobal,
+  [`${collectionName.toLowerCase()}.${fieldNameForCollection}`]: labelFromCollection,
+});
+
+describe('vulcan:i18n/IntlProvider', function() {
+  it('shallow render', function() {
+    const wrapper = shallow(<IntlProvider />);
+    expect(wrapper).toBeDefined();
+  });
+  describe('formatMessage', function() {
+    it('format a message according to locale', function() {
+      const wrapper = shallow(<IntlProvider locale="en" />);
+      const ENString = wrapper.instance().formatMessage({ id: stringId });
+      expect(ENString).toEqual(ENTestString);
+      wrapper.setProps({ locale: 'fr' });
+      const FRString = wrapper.instance().formatMessage({ id: stringId });
+      expect(FRString).toEqual(FRTestString);
+    });
+    it('format a message according to a value', function() {
+      const wrapper = shallow(<IntlProvider locale="en" />);
+      const dynamicString = wrapper
+        .instance()
+        .formatMessage({ id: valueStringId }, { [valueTestStringDynamic]: valueStringValue });
+      expect(dynamicString).toEqual(valueTestStringStatic + valueStringValue);
+    });
+    it('return a default message when no string is found', function() {
+      const wrapper = shallow(<IntlProvider locale="en" />);
+      const ENString = wrapper.instance().formatMessage({
+        id: 'unknownStringId',
+        defaultMessage: defaultMessage,
+      });
+      expect(ENString).toEqual(defaultMessage);
+    });
+  });
+  describe('formatLabel', function() {
+    const wrapper = shallow(<IntlProvider locale="en" />);
+    it('return the fieldName when there is no matching string or label', function() {
+      const ENString = wrapper
+        .instance()
+        .formatLabel({ fieldName: unknownFieldName, schema, collectionName });
+      expect(ENString).toEqual(Utils.camelToSpaces(unknownFieldName));
+    });
+    it('return the matching schema label when there is no matching string', function() {
+      const ENString = wrapper
+        .instance()
+        .formatLabel({ fieldName: fieldNameForSchema, schema, collectionName });
+      expect(ENString).toEqual(schema[fieldName].label);
+    });
+    it('return the label from a matched `fieldName`', function() {
+      const ENString = wrapper.instance().formatLabel({ fieldName, schema, collectionName });
+      expect(ENString).toEqual(labelFromFieldName);
+    });
+    it('return the label from a matched `global.fieldName`', function() {
+      const ENString = wrapper
+        .instance()
+        .formatLabel({ fieldName: fieldNameForGlobal, schema, collectionName });
+      expect(ENString).toEqual(labelFromGlobal);
+    });
+    it('return the label from a matched `collectionName.fieldName`', function() {
+      const ENString = wrapper
+        .instance()
+        .formatLabel({ fieldName: fieldNameForCollection, schema, collectionName });
+      expect(ENString).toEqual(labelFromCollection);
+    });
+  });
+});

--- a/packages/vulcan-lib/lib/modules/dynamic_loader.js
+++ b/packages/vulcan-lib/lib/modules/dynamic_loader.js
@@ -29,13 +29,12 @@ import { delayedComponent } from './components';
  * @return {React.Component}
  *  Component that will load the dynamic import on mount
  */
-export const dynamicLoader = importComponent => loadable({
-  loader: isFunction(importComponent)
-    ? importComponent
-    : () => importComponent, // backwards compatibility,
-  // use delayedComponent, as this function can be used when Components is not populated yet
-  loading: delayedComponent('DynamicLoading'),
-});
+export const dynamicLoader = importComponent =>
+  loadable({
+    loader: isFunction(importComponent) ? importComponent : () => importComponent, // backwards compatibility,
+    // use delayedComponent, as this function can be used when Components is not populated yet
+    loading: delayedComponent('DynamicLoading'),
+  });
 
 /**
  * Renders a dynamic component with the given props.
@@ -51,7 +50,7 @@ export const getDynamicComponent = componentImport => {
   console.warn(
     'getDynamicComponent is deprecated, use renderDynamicComponent instead.',
     'If you want to retrieve the component instead that of just rendering it,',
-    'use dynamicLoader. See this issue to know how to do it: https://github.com/VulcanJS/Vulcan/issues/1997',
+    'use dynamicLoader. See this issue to know how to do it: https://github.com/VulcanJS/Vulcan/issues/1997'
   );
   return renderDynamicComponent(componentImport);
 };

--- a/packages/vulcan-lib/lib/server/mutators.js
+++ b/packages/vulcan-lib/lib/server/mutators.js
@@ -32,7 +32,12 @@ to the client.
 */
 
 import { runCallbacks, runCallbacksAsync } from '../modules/index.js';
-import { validateDocument, validateData, dataToModifier, modifierToData } from '../modules/validation.js';
+import {
+  validateDocument,
+  validateData,
+  dataToModifier,
+  modifierToData,
+} from '../modules/validation.js';
 import { registerSetting } from '../modules/settings.js';
 import { debug, debugGroup, debugGroupEnd } from '../modules/debug.js';
 import { throwError } from '../modules/errors.js';
@@ -48,8 +53,14 @@ registerSetting('database', 'mongo', 'Which database to use for your back-end');
 Create
 
 */
-export const createMutator = async ({ collection, document, data, currentUser, validate, context }) => {
-
+export const createMutator = async ({
+  collection,
+  document,
+  data,
+  currentUser,
+  validate,
+  context,
+}) => {
   // OpenCRUD backwards compatibility: accept either data or document
   // we don't want to modify the original document
   document = data || document;
@@ -75,10 +86,23 @@ export const createMutator = async ({ collection, document, data, currentUser, v
     let validationErrors = [];
     validationErrors = validationErrors.concat(validateDocument(document, collection, context));
     // run validation callbacks
-    validationErrors = await runCallbacks({ name: `${typeName.toLowerCase()}.create.validate`, iterator: validationErrors, properties });
-    validationErrors = await runCallbacks({ name: '*.create.validate', iterator: validationErrors, properties });
+    validationErrors = await runCallbacks({
+      name: `${typeName.toLowerCase()}.create.validate`,
+      iterator: validationErrors,
+      properties,
+    });
+    validationErrors = await runCallbacks({
+      name: '*.create.validate',
+      iterator: validationErrors,
+      properties,
+    });
     // OpenCRUD backwards compatibility
-    document = await runCallbacks(`${collectionName.toLowerCase()}.new.validate`, document, currentUser, validationErrors);
+    document = await runCallbacks(
+      `${collectionName.toLowerCase()}.new.validate`,
+      document,
+      currentUser,
+      validationErrors
+    );
     if (validationErrors.length) {
       console.log(validationErrors); // eslint-disable-line no-console
       throwError({ id: 'app.validation_error', data: { break: true, errors: validationErrors } });
@@ -132,10 +156,18 @@ export const createMutator = async ({ collection, document, data, currentUser, v
   Before
   
   */
-  document = await runCallbacks({ name: `${typeName.toLowerCase()}.create.before`, iterator: document, properties });
+  document = await runCallbacks({
+    name: `${typeName.toLowerCase()}.create.before`,
+    iterator: document,
+    properties,
+  });
   document = await runCallbacks({ name: '*.create.before', iterator: document, properties });
   // OpenCRUD backwards compatibility
-  document = await runCallbacks(`${collectionName.toLowerCase()}.new.before`, document, currentUser);
+  document = await runCallbacks(
+    `${collectionName.toLowerCase()}.new.before`,
+    document,
+    currentUser
+  );
   document = await runCallbacks(`${collectionName.toLowerCase()}.new.sync`, document, currentUser);
 
   /*
@@ -151,7 +183,11 @@ export const createMutator = async ({ collection, document, data, currentUser, v
 
   */
   // run any post-operation sync callbacks
-  document = await runCallbacks({ name: `${typeName.toLowerCase()}.create.after`, iterator: document, properties });
+  document = await runCallbacks({
+    name: `${typeName.toLowerCase()}.create.after`,
+    iterator: document,
+    properties,
+  });
   document = await runCallbacks({ name: '*.create.after', iterator: document, properties });
   // OpenCRUD backwards compatibility
   document = await runCallbacks(`${collectionName.toLowerCase()}.new.after`, document, currentUser);
@@ -165,10 +201,18 @@ export const createMutator = async ({ collection, document, data, currentUser, v
 
   */
   // note: make sure properties.document is up to date
-  await runCallbacksAsync({ name: `${typeName.toLowerCase()}.create.async`, properties: { ...properties, document: document } });
+  await runCallbacksAsync({
+    name: `${typeName.toLowerCase()}.create.async`,
+    properties: { ...properties, document: document },
+  });
   await runCallbacksAsync({ name: '*.create.async', properties });
   // OpenCRUD backwards compatibility
-  await runCallbacksAsync(`${collectionName.toLowerCase()}.new.async`, document, currentUser, collection);
+  await runCallbacksAsync(
+    `${collectionName.toLowerCase()}.new.async`,
+    document,
+    currentUser,
+    collection
+  );
 
   endDebugMutator(collectionName, 'Create', { document });
 
@@ -180,8 +224,18 @@ export const createMutator = async ({ collection, document, data, currentUser, v
 Update
 
 */
-export const updateMutator = async ({ collection, documentId, selector, data, set = {}, unset = {}, currentUser, validate, context, document: oldDocument }) => {
-  
+export const updateMutator = async ({
+  collection,
+  documentId,
+  selector,
+  data,
+  set = {},
+  unset = {},
+  currentUser,
+  validate,
+  context,
+  document: oldDocument,
+}) => {
   const { collectionName, typeName } = collection.options;
   const schema = collection.simpleSchema()._schema;
 
@@ -223,10 +277,26 @@ export const updateMutator = async ({ collection, documentId, selector, data, se
 
     validationErrors = validationErrors.concat(validateData(data, document, collection, context));
 
-    validationErrors = await runCallbacks({ name: `${typeName.toLowerCase()}.update.validate`, iterator: validationErrors, properties });
-    validationErrors = await runCallbacks({ name: '*.update.validate', iterator: validationErrors, properties });
+    validationErrors = await runCallbacks({
+      name: `${typeName.toLowerCase()}.update.validate`,
+      iterator: validationErrors,
+      properties,
+    });
+    validationErrors = await runCallbacks({
+      name: '*.update.validate',
+      iterator: validationErrors,
+      properties,
+    });
     // OpenCRUD backwards compatibility
-    data = modifierToData(await runCallbacks(`${collectionName.toLowerCase()}.edit.validate`, dataToModifier(data), document, currentUser, validationErrors));
+    data = modifierToData(
+      await runCallbacks(
+        `${collectionName.toLowerCase()}.edit.validate`,
+        dataToModifier(data),
+        document,
+        currentUser,
+        validationErrors
+      )
+    );
 
     if (validationErrors.length) {
       console.log(validationErrors); // eslint-disable-line no-console
@@ -245,7 +315,12 @@ export const updateMutator = async ({ collection, documentId, selector, data, se
       autoValue = await schema[fieldName].onUpdate(properties); // eslint-disable-line no-await-in-loop
     } else if (schema[fieldName].onEdit) {
       // OpenCRUD backwards compatibility
-      autoValue = await schema[fieldName].onEdit(dataToModifier(clone(data)), document, currentUser, document); // eslint-disable-line no-await-in-loop
+      autoValue = await schema[fieldName].onEdit(
+        dataToModifier(clone(data)),
+        document,
+        currentUser,
+        document
+      ); // eslint-disable-line no-await-in-loop
     }
     if (typeof autoValue !== 'undefined') {
       data[fieldName] = autoValue;
@@ -257,11 +332,31 @@ export const updateMutator = async ({ collection, documentId, selector, data, se
   Before
 
   */
-  data = await runCallbacks({ name: `${typeName.toLowerCase()}.update.before`, iterator: data, properties });
+  data = await runCallbacks({
+    name: `${typeName.toLowerCase()}.update.before`,
+    iterator: data,
+    properties,
+  });
   data = await runCallbacks({ name: '*.update.before', iterator: data, properties });
   // OpenCRUD backwards compatibility
-  data = modifierToData(await runCallbacks(`${collectionName.toLowerCase()}.edit.before`, dataToModifier(data), document, currentUser, document));
-  data = modifierToData(await runCallbacks(`${collectionName.toLowerCase()}.edit.sync`, dataToModifier(data), document, currentUser, document));
+  data = modifierToData(
+    await runCallbacks(
+      `${collectionName.toLowerCase()}.edit.before`,
+      dataToModifier(data),
+      document,
+      currentUser,
+      document
+    )
+  );
+  data = modifierToData(
+    await runCallbacks(
+      `${collectionName.toLowerCase()}.edit.sync`,
+      dataToModifier(data),
+      document,
+      currentUser,
+      document
+    )
+  );
 
   // update connector requires a modifier, so get it from data
   const modifier = dataToModifier(data);
@@ -299,10 +394,19 @@ export const updateMutator = async ({ collection, documentId, selector, data, se
   After
 
   */
-  document = await runCallbacks({ name: `${typeName.toLowerCase()}.update.after`, iterator: document, properties });
+  document = await runCallbacks({
+    name: `${typeName.toLowerCase()}.update.after`,
+    iterator: document,
+    properties,
+  });
   document = await runCallbacks({ name: '*.update.after', iterator: document, properties });
   // OpenCRUD backwards compatibility
-  document = await runCallbacks(`${collectionName.toLowerCase()}.edit.after`, document, oldDocument, currentUser);
+  document = await runCallbacks(
+    `${collectionName.toLowerCase()}.edit.after`,
+    document,
+    oldDocument,
+    currentUser
+  );
 
   /*
 
@@ -313,7 +417,13 @@ export const updateMutator = async ({ collection, documentId, selector, data, se
   await runCallbacksAsync({ name: `${typeName.toLowerCase()}.update.async`, properties });
   await runCallbacksAsync({ name: '*.update.async', properties });
   // OpenCRUD backwards compatibility
-  await runCallbacksAsync(`${collectionName.toLowerCase()}.edit.async`, document, oldDocument, currentUser, collection);
+  await runCallbacksAsync(
+    `${collectionName.toLowerCase()}.edit.async`,
+    document,
+    oldDocument,
+    currentUser,
+    collection
+  );
 
   endDebugMutator(collectionName, 'Update', { modifier });
 
@@ -325,7 +435,15 @@ export const updateMutator = async ({ collection, documentId, selector, data, se
 Delete
 
 */
-export const deleteMutator = async ({ collection, documentId, selector, currentUser, validate, context, document }) => {
+export const deleteMutator = async ({
+  collection,
+  documentId,
+  selector,
+  currentUser,
+  validate,
+  context,
+  document,
+}) => {
   const { collectionName, typeName } = collection.options;
   const schema = collection.simpleSchema()._schema;
   // OpenCRUD backwards compatibility
@@ -356,10 +474,22 @@ export const deleteMutator = async ({ collection, documentId, selector, currentU
   if (validate) {
     let validationErrors = [];
 
-    validationErrors = await runCallbacks({ name: `${typeName.toLowerCase()}.delete.validate`, iterator: validationErrors, properties });
-    validationErrors = await runCallbacks({ name: '*.delete.validate', iterator: validationErrors, properties });
+    validationErrors = await runCallbacks({
+      name: `${typeName.toLowerCase()}.delete.validate`,
+      iterator: validationErrors,
+      properties,
+    });
+    validationErrors = await runCallbacks({
+      name: '*.delete.validate',
+      iterator: validationErrors,
+      properties,
+    });
     // OpenCRUD backwards compatibility
-    document = await runCallbacks(`${collectionName.toLowerCase()}.remove.validate`, document, currentUser);
+    document = await runCallbacks(
+      `${collectionName.toLowerCase()}.remove.validate`,
+      document,
+      currentUser
+    );
 
     if (validationErrors.length) {
       console.log(validationErrors); // eslint-disable-line no-console
@@ -386,7 +516,11 @@ export const deleteMutator = async ({ collection, documentId, selector, currentU
   Before
 
   */
-  await runCallbacks({ name: `${typeName.toLowerCase()}.delete.before`, iterator: document, properties });
+  await runCallbacks({
+    name: `${typeName.toLowerCase()}.delete.before`,
+    iterator: document,
+    properties,
+  });
   await runCallbacks({ name: '*.delete.before', iterator: document, properties });
   // OpenCRUD backwards compatibility
   await runCallbacks(`${collectionName.toLowerCase()}.remove.before`, document, currentUser);
@@ -413,7 +547,12 @@ export const deleteMutator = async ({ collection, documentId, selector, currentU
   await runCallbacksAsync({ name: `${typeName.toLowerCase()}.delete.async`, properties });
   await runCallbacksAsync({ name: '*.delete.async', properties });
   // OpenCRUD backwards compatibility
-  await runCallbacksAsync(`${collectionName.toLowerCase()}.remove.async`, document, currentUser, collection);
+  await runCallbacksAsync(
+    `${collectionName.toLowerCase()}.remove.async`,
+    document,
+    currentUser,
+    collection
+  );
 
   endDebugMutator(collectionName, 'Delete');
 

--- a/packages/vulcan-ui-bootstrap/lib/modules/components.js
+++ b/packages/vulcan-ui-bootstrap/lib/modules/components.js
@@ -16,7 +16,7 @@ import '../components/forms/Url.jsx';
 import '../components/forms/StaticText.jsx';
 import '../components/forms/FormComponentInner.jsx';
 import '../components/forms/FormControl.jsx'; // note: only used by old accounts package, remove soon?
-import '../components/forms/FormItem.jsx'; 
+import '../components/forms/FormItem.jsx';
 
 import '../components/ui/Button.jsx';
 import '../components/ui/Alert.jsx';


### PR DESCRIPTION
This is related to issue #2140 : creating a function to centralize how we generate a label from the schema & the i18n fields. 
I've written a function `formatLabel` that lives in `vulcan:i18n`, is available from the i18n context and has the following API:

```js
formatLabel: function({ fieldName, collectionName, schema }, values) => String
```
NB: i've let collectionName because it was used in Forms, so I did not want to introduce a breaking change. However, in regards to openCRUD, it would be better to use the typeName instead. Should we change this? Should we do both to keep backwards compatibility?

The `values` are passed to `formatMessage` to be able to add values in the i18n text fields.

Here is the logic behind label generation: for example a field `year` in example-movies, collection `Movies`.

```
i18n('movies.year') > i18n('global.year') > i18n('year') > schema.year.label > "Year"
```

If we agree to make these changes, I'll rework the parts related to labels in SmartForm, Datatable, and Card. 

Advancement: 

- [X] write a `formatLabel` function
- [x] rework `getLabel` in Form.jsx
- [x] rework the labels generation in DatatableHeader
- [x] rework `getLabel` in Card.jsx
- [ ] add the function to the Internationalization page of the docs
- [x] write a test on the `formatLabel` function @Neobii