### PR TITLE
Default view sort doesn't take precedence over selected view

### DIFF
--- a/packages/vulcan-lib/lib/modules/collections.js
+++ b/packages/vulcan-lib/lib/modules/collections.js
@@ -205,8 +205,18 @@ export const createCollection = options => {
 
     // handle view option
     if (terms.view && collection.views[terms.view]) {
-      const view = collection.views[terms.view];
-      parameters = Utils.deepExtend(true, parameters, view(terms, apolloClient, context));
+      const viewFn = collection.views[terms.view];
+      const view = viewFn(terms, apolloClient, context)
+      let mergedParameters = Utils.deepExtend(true, parameters, view);
+      
+      if (mergedParameters.options && mergedParameters.options.sort && view.options && view.options.sort) {
+        // If both the default view and the selected view have sort options,
+        // don't merge them together; take the selected view's sort. (Otherwise
+        // they merge in the wrong order, so that the default-view's sort takes
+        // precedence over the selected view's sort.)
+        mergedParameters.options.sort = view.options.sort;
+      }
+      parameters = mergedParameters;
     }
 
     // iterate over posts.parameters callbacks


### PR DESCRIPTION
If a default view on a collection has an `options.sort` set, Vulcan currently deep-merges this with the `options.sort` on a view, which may also include a sort. Unfortunately, this merge isn't key-order-aware (and is in fact backwards), so this means that a default view can't have a sort specified without overriding the sort on all specific views.

Add a special case for `view.options.sort`, so tahat they don't merge.