### PR TITLE
vulcan-events: fix TypeError: Cannot redefine property: name

### DIFF
--- a/packages/vulcan-events/lib/modules/events.js
+++ b/packages/vulcan-events/lib/modules/events.js
@@ -37,12 +37,15 @@ export const addIdentifyFunction = f => {
 };
 
 export const addPageFunction = f => {
-  const f2 = ({ currentRoute }) => f(currentRoute);
+  let f2 = ({ currentRoute }) => f(currentRoute);
 
   // rename f2 to same name as f
   // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty
   const descriptor = Object.create(null); // no inherited properties
   descriptor.value = f.name;
+  f2 = {...f2};
+  //descriptor.configurable = true;
+  //descriptor.writable = true;
   Object.defineProperty(f2, 'name', descriptor);
 
   addCallback('router.onUpdate.async', f2);


### PR DESCRIPTION
google analitycs and vulcan-events get error so google bot from google search console can't load rest resource to render web page