### PR TITLE
add rootElement check on vulcan-core/lib/client/start.jsx

### DIFF
--- a/packages/vulcan-core/lib/client/start.jsx
+++ b/packages/vulcan-core/lib/client/start.jsx
@@ -18,10 +18,12 @@ Meteor.startup(() => {
   const apolloClient = createApolloClient();
 
   // Create the root element
-  const rootElement = document.createElement('div');
-  rootElement.id = 'react-app';
-  document.body.appendChild(rootElement);
-
+  if (!document.getElementById('react-app')) {
+    const rootElement = document.createElement('div');
+    rootElement.id = 'react-app';
+    document.body.appendChild(rootElement);
+  }
+  
   const Main = () => (
     <AppGenerator apolloClient={apolloClient} />
   );


### PR DESCRIPTION
in my app i got two rootElement on client. rootElement already exist from SSR, but start.jsx  append it again to body. i don't know why this doesn't happen before upgrade to Apollo 2