### PR TITLE
Add debug messages for missing strings and default locale on per-message level.

### DIFF
--- a/packages/vulcan-lib/lib/modules/intl.js
+++ b/packages/vulcan-lib/lib/modules/intl.js
@@ -1,5 +1,6 @@
 import SimpleSchema from 'simpl-schema';
 import { getSetting } from '../modules/settings';
+import { debug } from 'meteor/vulcan:lib';
 
 export const Strings = {};
 
@@ -16,8 +17,19 @@ export const addStrings = (language, strings) => {
 };
 
 export const getString = ({id, values, defaultMessage, locale}) => {
-  const messages = Strings[locale] || Strings[defaultLocale] || {};
-  let message = messages[id] || defaultMessage;
+  const messages = Strings[locale] || {};
+  let message = messages[id];
+
+  // use default locale
+  if(!message) {
+    debug(`\x1b[32m>> INTL: No string found for id "${id}" in locale "${locale}".\x1b[0m`);
+    message = Strings[defaultLocale] && Strings[defaultLocale][id];
+
+    // if default locale hasn't got the message too
+    if(!message && locale !== defaultLocale)
+      debug(`\x1b[32m>> INTL: No string found for id "${id}" in the default locale ("${defaultLocale}").\x1b[0m`);
+  }
+
   if (message && values) {
     Object.keys(values).forEach(key => {
       // note: see replaceAll definition in vulcan:lib/utils


### PR DESCRIPTION
The previous PR used the default locales only if the chosen locale wasn't defined.
Now the fallback happens on a per-message level.

I've added debug logging for missing locale strings too, as they are hard to spot.
We could modify the `FormattedMessage` component to show a red error message if no string is found...