### PR TITLE
Add locale on signup.

### DIFF
--- a/packages/vulcan-accounts/imports/ui/components/LoginFormInner.jsx
+++ b/packages/vulcan-accounts/imports/ui/components/LoginFormInner.jsx
@@ -804,6 +804,9 @@ export class AccountsLoginFormInner extends TrackerComponent {
       options.password = password;
     }
 
+    // set the signup locale
+    options.locale = this.context.intl.locale;
+
     const SignUp = function(_options) {
       Accounts.createUser(_options, (error) => {
         if (error) {


### PR DESCRIPTION
Adds the current locale to the user profile on signup.
This is useful for localizing the email confirmation.