### PR TITLE
Re-enable Switch component for Material UI

### DIFF
--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiSwitch.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiSwitch.jsx
@@ -24,7 +24,7 @@ const MuiSwitch = createReactClass({
     const value = target.checked;
     
     //this.setValue(value);
-    this.props.onChange(this.props.name, value);
+    this.props.onChange(value);
     
     setTimeout(() => {document.activeElement.blur();});
   },

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiSwitch.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiSwitch.jsx
@@ -23,7 +23,6 @@ const MuiSwitch = createReactClass({
     const target = event.target;
     const value = target.checked;
     
-    //this.setValue(value);
     this.props.onChange(value);
     
     setTimeout(() => {document.activeElement.blur();});


### PR DESCRIPTION
After testing the Switch component for Material UI I detected that doesn't change the state.

We detected that the issue was related to the parameters sent to the onChange function.

this small change do the magic.