### PR TITLE
Re-enable CheckboxGroup component for Material UI 

### DIFF
--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiCheckboxGroup.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiCheckboxGroup.jsx
@@ -82,8 +82,8 @@ const MuiCheckboxGroup = createReactClass({
         value.push(option.value);
       }
     }.bind(this));
-    //this.setValue(value);
-    this.props.onChange(this.props.name, value);
+
+    this.props.onChange(value);
   },
   
   validate: function () {


### PR DESCRIPTION
After testing the CheckboxGroup component for Material UI I detected that doesn't change the state.

We detected that the issue was related to the parameters sent to the onChange function.

this small change does the magic.