### PR TITLE
Re-enable Select component for Material UI

### DIFF
--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiSelect.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiSelect.jsx
@@ -86,7 +86,7 @@ const MuiSelect = createReactClass({
   },
 
   changeValue: function (value) {
-    this.props.onChange(this.props.name, value);
+    this.props.onChange(value);
   },
 
   render: function () {


### PR DESCRIPTION
After testing the Select component for Material UI I detected that doesn't change the state.

We detected that the issue was related to the parameters sent to the onChange function.

this small change does the magic.