### PR TITLE
Fix denormalization when bio set to empty

### DIFF
--- a/packages/vulcan-users/lib/server/callbacks.js
+++ b/packages/vulcan-users/lib/server/callbacks.js
@@ -39,7 +39,7 @@
   addCallback('users.new.sync', usersMakeAdmin);
 
   function usersEditGenerateHtmlBio (modifier) {
-    if (modifier.$set && modifier.$set.bio) {
+    if (modifier.$set && 'bio' in modifier.$set) {
       modifier.$set.htmlBio = Utils.sanitize(marked(modifier.$set.bio));
     }
     return modifier;


### PR DESCRIPTION
Currently, when a user sets their "bio" to an empty string, the denormalized `htmlBio` field doesn't get updated, because empty-string is falsy. Fix that.