### PR TITLE
Re-enable Search Input in DataTable

### DIFF
--- a/packages/vulcan-ui-material/lib/components/bonus/SearchInput.jsx
+++ b/packages/vulcan-ui-material/lib/components/bonus/SearchInput.jsx
@@ -15,15 +15,15 @@ const styles = theme => ({
 
   '@global': {
     'input[type=text]::-ms-clear, input[type=text]::-ms-reveal':
-        {
-          display: 'none',
-          width: 0,
-          height: 0,
-        },
+      {
+        display: 'none',
+        width: 0,
+        height: 0,
+      },
     'input[type="search"]::-webkit-search-decoration, input[type="search"]::-webkit-search-cancel-button':
-        { display: 'none' },
+      { display: 'none' },
     'input[type="search"]::-webkit-search-results-button, input[type="search"]::-webkit-search-results-decoration':
-        { display: 'none' },
+      { display: 'none' },
   },
 
   root: {
@@ -162,46 +162,46 @@ class SearchInput extends PureComponent {
     const searchIcon = <SearchIcon className={classes.icon} onClick={this.focusInput}/>;
 
     const clearButton = <Components.TooltipIntl
-        titleId="search.clear"
-        icon={<ClearIcon/>}
-        onClick={this.clearSearch}
-        classes={{
-          root: classNames(!this.state.value && classes.clearDisabled),
-          button: classNames('clear-button', classes.clear, dense && classes.clearDense),
-        }}
-        disabled={!this.state.value}
+      titleId="search.clear"
+      icon={<ClearIcon/>}
+      onClick={this.clearSearch}
+      classes={{
+        root: classNames(!this.state.value && classes.clearDisabled),
+        button: classNames('clear-button', classes.clear, dense && classes.clearDense),
+      }}
+      disabled={!this.state.value}
     />;
 
     return (
-        <React.Fragment>
-          <TextField
-              label="Search"
-              type="search"
-              id={`search-input-${name}`}
-              name={name}
-              title="Search"
-              value={this.state.value}
-              inputRef={input => this.input = input}
-              fullWidth
-              className={classNames('search-input', `search-input-${name}`, classes.root, dense && classes.inputTypeSearch, className, classes.textField)}
-              margin="normal"
-              variant="outlined"
-              onChange={this.updateSearch}
-              onFocus={this.handleFocus}
-              InputProps={{
-                startAdornment: searchIcon,
-                endAdornment: clearButton
-              }}
-          />
-          <NoSsr>
-            {
-              // KeyboardEventHandler is not valid on the server, where its name is undefined
-              typeof window !== 'undefined' && KeyboardEventHandler.name && !noShortcuts &&
+      <React.Fragment>
+        <TextField
+            label="Search"
+            type="search"
+            id={`search-input-${name}`}
+            name={name}
+            title="Search"
+            value={this.state.value}
+            inputRef={input => this.input = input}
+            fullWidth
+            className={classNames('search-input', `search-input-${name}`, classes.root, dense && classes.inputTypeSearch, className, classes.textField)}
+            margin="normal"
+            variant="outlined"
+            onChange={this.updateSearch}
+            onFocus={this.handleFocus}
+            InputProps={{
+              startAdornment: searchIcon,
+              endAdornment: clearButton
+            }}
+        />
+        <NoSsr>
+          {
+            // KeyboardEventHandler is not valid on the server, where its name is undefined
+            typeof window !== 'undefined' && KeyboardEventHandler.name && !noShortcuts &&
 
-              <KeyboardEventHandler handleKeys={['s', 'c', 'esc']} onKeyEvent={this.handleShortcutKeys}/>
-            }
-          </NoSsr>
-        </React.Fragment>
+            <KeyboardEventHandler handleKeys={['s', 'c', 'esc']} onKeyEvent={this.handleShortcutKeys}/>
+          }
+        </NoSsr>
+      </React.Fragment>
     );
   }
 

--- a/packages/vulcan-ui-material/lib/components/bonus/SearchInput.jsx
+++ b/packages/vulcan-ui-material/lib/components/bonus/SearchInput.jsx
@@ -5,34 +5,31 @@ import withStyles from '@material-ui/core/styles/withStyles';
 import SearchIcon from 'mdi-material-ui/Magnify';
 import ClearIcon from 'mdi-material-ui/CloseCircle';
 import Input from '@material-ui/core/Input';
+import TextField from '@material-ui/core/TextField';
 import NoSsr from '@material-ui/core/NoSsr';
 import classNames from 'classnames';
 import _debounce from 'lodash/debounce';
 import KeyboardEventHandler from 'react-keyboard-event-handler';
-import autosizeInput from 'autosize-input';
 
 const styles = theme => ({
-  
+
   '@global': {
     'input[type=text]::-ms-clear, input[type=text]::-ms-reveal':
-      {
-        display: 'none',
-        width: 0,
-        height: 0,
-      },
+        {
+          display: 'none',
+          width: 0,
+          height: 0,
+        },
     'input[type="search"]::-webkit-search-decoration, input[type="search"]::-webkit-search-cancel-button':
-      { display: 'none' },
+        { display: 'none' },
     'input[type="search"]::-webkit-search-results-button, input[type="search"]::-webkit-search-results-decoration':
-      { display: 'none' },
+        { display: 'none' },
   },
-  
+
   root: {
-    display: 'inline-flex',
-    backgroundColor: theme.palette.common.faintBlack,
-    borderRadius: 20,
-    padding: 6,
+    marginTop: 0
   },
-  
+
   clear: {
     transition: theme.transitions.create('opacity,transform', {
       duration: theme.transitions.duration.short,
@@ -48,29 +45,25 @@ const styles = theme => ({
     },
     flexDirection: 'column',
   },
-  
+
   clearDense: {
     width: 32,
     height: 32,
     margin: -4,
     marginLeft: 0,
   },
-  
+
   clearDisabled: {
     opacity: 0,
     pointerEvents: 'none',
   },
-  
-  dense: {
-    padding: 4,
-  },
-  
+
   icon: {
     color: theme.palette.common.lightBlack,
     marginLeft: theme.spacing.unit,
     marginRight: theme.spacing.unit,
   },
-  
+
   input: {
     lineHeight: 1,
     paddingTop: 2,
@@ -81,51 +74,41 @@ const styles = theme => ({
     }),*/
     minWidth: 130,
   },
-  
+
 });
 
 
 class SearchInput extends PureComponent {
-  
+
   constructor (props) {
     super(props);
-    
+
     this.state = {
       value: props.defaultValue || '',
     };
-    
+
     this.input = null;
-    this.removeAutosize = null;
-    this.triggerResize = null;
-    
+
     this.updateQuery = _debounce(this.updateQuery, 500);
   }
-  
+
   componentDidMount () {
     if (!document) return;
     const element = document.querySelector(`.search-input-${this.props.name} input[type=search]`);
-  
-    // We have to patch into addEventListener because autosizeInput provides no way to trigger resize
+
     element._addEventListener = element.addEventListener;
     element.addEventListener = function(type, listener, useCapture) {
       if(useCapture === undefined)
         useCapture = false;
       this._addEventListener(type, listener, useCapture);
-      this.triggerResize = listener;
     };
 
-    this.removeAutosize = autosizeInput(element);
-    
-    this.triggerResize = element.triggerResize;
     element.addEventListener = element._addEventListener;
   }
-  
+
   componentWillUnmount () {
-    if (this.removeAutosize) {
-      this.removeAutosize();
-    }
   }
-  
+
   handleShortcutKeys = (key, event) => {
     switch (key) {
       case 's':
@@ -139,34 +122,34 @@ class SearchInput extends PureComponent {
         break;
     }
   };
-  
+
   handleFocus = () => {
     this.input.select();
   };
-  
+
   focusInput = (event) => {
     this.input.focus();
   };
-  
+
   clearSearch = (event, dontFocus) => {
-    this.setState({ value: '' }, this.triggerResize);
+    this.setState({ value: '' });
     this.updateQuery('');
-  
+
     if (!dontFocus) {
       this.focusInput();
     }
   };
-  
+
   updateSearch = (event) => {
     const value = event.target.value;
     this.setState({ value: value });
     this.updateQuery(value);
   };
-  
+
   updateQuery = (value) => {
     this.props.updateQuery(value);
   };
-  
+
   render () {
     const {
       classes,
@@ -175,47 +158,53 @@ class SearchInput extends PureComponent {
       noShortcuts,
       name,
     } = this.props;
-    
+
     const searchIcon = <SearchIcon className={classes.icon} onClick={this.focusInput}/>;
-    
+
     const clearButton = <Components.TooltipIntl
-      titleId="search.clear"
-      icon={<ClearIcon/>}
-      onClick={this.clearSearch}
-      classes={{
-        root: classNames(!this.state.value && classes.clearDisabled),
-        button: classNames('clear-button', classes.clear, dense && classes.clearDense),
-      }}
-      disabled={!this.state.value}
+        titleId="search.clear"
+        icon={<ClearIcon/>}
+        onClick={this.clearSearch}
+        classes={{
+          root: classNames(!this.state.value && classes.clearDisabled),
+          button: classNames('clear-button', classes.clear, dense && classes.clearDense),
+        }}
+        disabled={!this.state.value}
     />;
-    
+
     return (
-      <React.Fragment>
-        <Input className={classNames('search-input', `search-input-${name}`, classes.root, dense && classes.dense, className)}
-               classes={{ input: classes.input }}
-               id={`search-input-${name}`}
-               name={name}
-               inputRef={input => this.input = input}
-               value={this.state.value}
-               type="search"
-               onChange={this.updateSearch}
-               onFocus={this.handleFocus}
-               disableUnderline={true}
-               startAdornment={searchIcon}
-               endAdornment={clearButton}
-        />
-        <NoSsr>
-          {
-            // KeyboardEventHandler is not valid on the server, where its name is undefined
-            typeof window !== 'undefined' && KeyboardEventHandler.name && !noShortcuts &&
-            
-            <KeyboardEventHandler handleKeys={['s', 'c', 'esc']} onKeyEvent={this.handleShortcutKeys}/>
-          }
-        </NoSsr>
-      </React.Fragment>
+        <React.Fragment>
+          <TextField
+              label="Search"
+              type="search"
+              id={`search-input-${name}`}
+              name={name}
+              title="Search"
+              value={this.state.value}
+              inputRef={input => this.input = input}
+              fullWidth
+              className={classNames('search-input', `search-input-${name}`, classes.root, dense && classes.inputTypeSearch, className, classes.textField)}
+              margin="normal"
+              variant="outlined"
+              onChange={this.updateSearch}
+              onFocus={this.handleFocus}
+              InputProps={{
+                startAdornment: searchIcon,
+                endAdornment: clearButton
+              }}
+          />
+          <NoSsr>
+            {
+              // KeyboardEventHandler is not valid on the server, where its name is undefined
+              typeof window !== 'undefined' && KeyboardEventHandler.name && !noShortcuts &&
+
+              <KeyboardEventHandler handleKeys={['s', 'c', 'esc']} onKeyEvent={this.handleShortcutKeys}/>
+            }
+          </NoSsr>
+        </React.Fragment>
     );
   }
-  
+
 }
 
 

--- a/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
+++ b/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
@@ -297,120 +297,120 @@ const DatatableContents = ({
   };
 
   return (
-      <React.Fragment>
+    <React.Fragment>
+      {
+        (title)?
+            <Toolbar>
+              <Typography variant="h6" id="tableTitle">
+                title
+              </Typography>
+            </Toolbar>
+            :null
+      }
+      <Table className={classNames(classes.table, denseClass)}>
         {
-          (title)?
-              <Toolbar>
-                <Typography variant="h6" id="tableTitle">
-                  title
-                </Typography>
-              </Toolbar>
-              :null
-        }
-        <Table className={classNames(classes.table, denseClass)}>
-          {
-            columns &&
-            <TableHead className={classes.tableHead}>
-              <TableRow className={classes.tableRow}>
-                {
-                  _.sortBy(columns, column => column.order).map(
-                      (column, index) =>
-                          <Components.DatatableHeader key={index}
-                                                      collection={collection}
-                                                      intlNamespace={intlNamespace}
-                                                      column={column}
-                                                      classes={classes}
-                                                      toggleSort={toggleSort}
-                                                      currentSort={currentSort}
-                          />
-                  )
-                }
-                {
-                  (showEdit || editComponent) &&
-
-                  <TableCell className={classes.tableCell}/>
-                }
-              </TableRow>
-            </TableHead>
-          }
-
-          {
-            results &&
-
-            <TableBody className={classes.tableBody}>
+          columns &&
+          <TableHead className={classes.tableHead}>
+            <TableRow className={classes.tableRow}>
               {
-                results.map(
-                    (document, index) =>
-                        <Components.DatatableRow collection={collection}
-                                                 columns={columns}
-                                                 document={document}
-                                                 refetch={refetch}
-                                                 key={index}
-                                                 showEdit={showEdit}
-                                                 editComponent={editComponent}
-                                                 currentUser={currentUser}
-                                                 classes={classes}
-                                                 rowClass={rowClass}
-                                                 handleRowClick={handleRowClick}
-                        />)
+                _.sortBy(columns, column => column.order).map(
+                    (column, index) =>
+                        <Components.DatatableHeader key={index}
+                                                    collection={collection}
+                                                    intlNamespace={intlNamespace}
+                                                    column={column}
+                                                    classes={classes}
+                                                    toggleSort={toggleSort}
+                                                    currentSort={currentSort}
+                        />
+                )
               }
-            </TableBody>
-          }
+              {
+                (showEdit || editComponent) &&
 
-          {
-            footerData &&
-
-            <TableFooter className={classes.tableFooter}>
-              <TableRow className={classes.tableRow}>
-                {
-                  _.sortBy(columns, column => column.order).map(
-                      (column, index) =>
-                          <TableCell key={index} className={classNames(classes.tableCell, column.footerClass)}>
-                            {footerData[index]}
-                          </TableCell>
-                  )
-                }
-                {
-                  (showEdit || editComponent) &&
-
-                  <TableCell className={classes.tableCell}/>
-                }
-              </TableRow>
-            </TableFooter>
-
-          }
-
-        </Table>
-        {
-          paginate &&
-
-          <TablePagination
-              component="div"
-              count={totalCount}
-              rowsPerPage={paginationTerms.itemsPerPage}
-              page={getPage(paginationTerms)}
-              backIconButtonProps={{
-                'aria-label': 'Previous Page',
-              }}
-              nextIconButtonProps={{
-                'aria-label': 'Next Page',
-              }}
-              onChangePage={onChangePage}
-              onChangeRowsPerPage={onChangeRowsPerPage}
-          />
+                <TableCell className={classes.tableCell}/>
+              }
+            </TableRow>
+          </TableHead>
         }
-        {
-          !paginate && loadMore &&
 
-          <Components.LoadMore className={classes.loadMore}
-                               count={count}
-                               totalCount={totalCount}
-                               loadMore={loadMore}
-                               networkStatus={networkStatus}
-          />
+        {
+          results &&
+
+          <TableBody className={classes.tableBody}>
+            {
+              results.map(
+                  (document, index) =>
+                      <Components.DatatableRow collection={collection}
+                                               columns={columns}
+                                               document={document}
+                                               refetch={refetch}
+                                               key={index}
+                                               showEdit={showEdit}
+                                               editComponent={editComponent}
+                                               currentUser={currentUser}
+                                               classes={classes}
+                                               rowClass={rowClass}
+                                               handleRowClick={handleRowClick}
+                      />)
+            }
+          </TableBody>
         }
-      </React.Fragment>
-  );
+
+        {
+          footerData &&
+
+          <TableFooter className={classes.tableFooter}>
+            <TableRow className={classes.tableRow}>
+              {
+                _.sortBy(columns, column => column.order).map(
+                    (column, index) =>
+                        <TableCell key={index} className={classNames(classes.tableCell, column.footerClass)}>
+                          {footerData[index]}
+                        </TableCell>
+                )
+              }
+              {
+                (showEdit || editComponent) &&
+
+                <TableCell className={classes.tableCell}/>
+              }
+            </TableRow>
+          </TableFooter>
+
+        }
+
+    </Table>
+    {
+      paginate &&
+
+      <TablePagination
+          component="div"
+          count={totalCount}
+          rowsPerPage={paginationTerms.itemsPerPage}
+          page={getPage(paginationTerms)}
+          backIconButtonProps={{
+            'aria-label': 'Previous Page',
+          }}
+          nextIconButtonProps={{
+            'aria-label': 'Next Page',
+          }}
+          onChangePage={onChangePage}
+          onChangeRowsPerPage={onChangeRowsPerPage}
+      />
+    }
+    {
+      !paginate && loadMore &&
+
+      <Components.LoadMore className={classes.loadMore}
+                           count={count}
+                           totalCount={totalCount}
+                           loadMore={loadMore}
+                           networkStatus={networkStatus}
+      />
+    }
+  </React.Fragment>
+);
 };
 
 
@@ -438,11 +438,11 @@ const DatatableHeader = ({ collection, intlNamespace, column, classes, toggleSor
     */
     const defaultMessage = schema[columnName] ? schema[columnName].label : Utils.camelToSpaces(columnName);
     formattedLabel = typeof columnName === 'string' ?
-        intl.formatMessage({
-          id: `${collection._name}.${columnName}`,
-          defaultMessage: defaultMessage
-        }) :
-        '';
+      intl.formatMessage({
+        id: `${collection._name}.${columnName}`,
+        defaultMessage: defaultMessage
+      }) :
+      '';
 
     // if sortable is a string, use it as the name of the property to sort by. If it's just `true`, use
     // column.name
@@ -458,17 +458,17 @@ const DatatableHeader = ({ collection, intlNamespace, column, classes, toggleSor
     }
   } else if (intlNamespace) {
     formattedLabel = typeof columnName === 'string' ?
-        intl.formatMessage({
-          id: `${intlNamespace}.${columnName}`,
-          defaultMessage: columnName
-        }) :
-        '';
+      intl.formatMessage({
+        id: `${intlNamespace}.${columnName}`,
+        defaultMessage: columnName
+      }) :
+      '';
   } else {
     formattedLabel = intl.formatMessage({ id: columnName, defaultMessage: columnName });
   }
 
   return <TableCell
-      className={classNames(classes.tableHeadCell, column.headerClass)}>{formattedLabel}</TableCell>;
+    className={classNames(classes.tableHeadCell, column.headerClass)}>{formattedLabel}</TableCell>;
 };
 
 
@@ -554,12 +554,12 @@ const DatatableRow = ({
       {
         _.sortBy(columns, column => column.order).map(
           (column, index) =>
-              <Components.DatatableCell key={index}
-                                        column={column}
-                                        document={document}
-                                        currentUser={currentUser}
-                                        classes={classes}
-              />)
+            <Components.DatatableCell key={index}
+                                      column={column}
+                                      document={document}
+                                      currentUser={currentUser}
+                                      classes={classes}
+            />)
       }
 
       {

--- a/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
+++ b/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
@@ -299,40 +299,40 @@ const DatatableContents = ({
   return (
     <React.Fragment>
       {
-        (title)?
-            <Toolbar>
-              <Typography variant="h6" id="tableTitle">
-                title
-              </Typography>
-            </Toolbar>
-            :null
+      (title)?
+          <Toolbar>
+            <Typography variant="h6" id="tableTitle">
+              title
+            </Typography>
+          </Toolbar>
+          :null
       }
       <Table className={classNames(classes.table, denseClass)}>
-        {
-          columns &&
-          <TableHead className={classes.tableHead}>
-            <TableRow className={classes.tableRow}>
-              {
-                _.sortBy(columns, column => column.order).map(
-                    (column, index) =>
-                        <Components.DatatableHeader key={index}
-                                                    collection={collection}
-                                                    intlNamespace={intlNamespace}
-                                                    column={column}
-                                                    classes={classes}
-                                                    toggleSort={toggleSort}
-                                                    currentSort={currentSort}
-                        />
-                )
-              }
-              {
-                (showEdit || editComponent) &&
+      {
+        columns &&
+        <TableHead className={classes.tableHead}>
+          <TableRow className={classes.tableRow}>
+            {
+              _.sortBy(columns, column => column.order).map(
+                  (column, index) =>
+                      <Components.DatatableHeader key={index}
+                                                  collection={collection}
+                                                  intlNamespace={intlNamespace}
+                                                  column={column}
+                                                  classes={classes}
+                                                  toggleSort={toggleSort}
+                                                  currentSort={currentSort}
+                      />
+              )
+            }
+            {
+              (showEdit || editComponent) &&
 
-                <TableCell className={classes.tableCell}/>
-              }
-            </TableRow>
-          </TableHead>
-        }
+              <TableCell className={classes.tableCell}/>
+            }
+          </TableRow>
+        </TableHead>
+      }
 
         {
           results &&
@@ -340,19 +340,19 @@ const DatatableContents = ({
           <TableBody className={classes.tableBody}>
             {
               results.map(
-                  (document, index) =>
-                      <Components.DatatableRow collection={collection}
-                                               columns={columns}
-                                               document={document}
-                                               refetch={refetch}
-                                               key={index}
-                                               showEdit={showEdit}
-                                               editComponent={editComponent}
-                                               currentUser={currentUser}
-                                               classes={classes}
-                                               rowClass={rowClass}
-                                               handleRowClick={handleRowClick}
-                      />)
+                (document, index) =>
+                    <Components.DatatableRow collection={collection}
+                                             columns={columns}
+                                             document={document}
+                                             refetch={refetch}
+                                             key={index}
+                                             showEdit={showEdit}
+                                             editComponent={editComponent}
+                                             currentUser={currentUser}
+                                             classes={classes}
+                                             rowClass={rowClass}
+                                             handleRowClick={handleRowClick}
+                    />)
             }
           </TableBody>
         }
@@ -364,10 +364,10 @@ const DatatableContents = ({
             <TableRow className={classes.tableRow}>
               {
                 _.sortBy(columns, column => column.order).map(
-                    (column, index) =>
-                        <TableCell key={index} className={classNames(classes.tableCell, column.footerClass)}>
-                          {footerData[index]}
-                        </TableCell>
+                  (column, index) =>
+                      <TableCell key={index} className={classNames(classes.tableCell, column.footerClass)}>
+                        {footerData[index]}
+                      </TableCell>
                 )
               }
               {

--- a/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
+++ b/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
@@ -299,13 +299,13 @@ const DatatableContents = ({
   return (
     <React.Fragment>
       {
-      (title)?
-          <Toolbar>
-            <Typography variant="h6" id="tableTitle">
-              title
-            </Typography>
-          </Toolbar>
-          :null
+        (title)?
+            <Toolbar>
+              <Typography variant="h6" id="tableTitle">
+                title
+              </Typography>
+            </Toolbar>
+            :null
       }
       <Table className={classNames(classes.table, denseClass)}>
       {
@@ -314,15 +314,15 @@ const DatatableContents = ({
           <TableRow className={classes.tableRow}>
             {
               _.sortBy(columns, column => column.order).map(
-                  (column, index) =>
-                      <Components.DatatableHeader key={index}
-                                                  collection={collection}
-                                                  intlNamespace={intlNamespace}
-                                                  column={column}
-                                                  classes={classes}
-                                                  toggleSort={toggleSort}
-                                                  currentSort={currentSort}
-                      />
+                (column, index) =>
+                    <Components.DatatableHeader key={index}
+                                                collection={collection}
+                                                intlNamespace={intlNamespace}
+                                                column={column}
+                                                classes={classes}
+                                                toggleSort={toggleSort}
+                                                currentSort={currentSort}
+                    />
               )
             }
             {
@@ -341,18 +341,18 @@ const DatatableContents = ({
             {
               results.map(
                 (document, index) =>
-                    <Components.DatatableRow collection={collection}
-                                             columns={columns}
-                                             document={document}
-                                             refetch={refetch}
-                                             key={index}
-                                             showEdit={showEdit}
-                                             editComponent={editComponent}
-                                             currentUser={currentUser}
-                                             classes={classes}
-                                             rowClass={rowClass}
-                                             handleRowClick={handleRowClick}
-                    />)
+                  <Components.DatatableRow collection={collection}
+                                           columns={columns}
+                                           document={document}
+                                           refetch={refetch}
+                                           key={index}
+                                           showEdit={showEdit}
+                                           editComponent={editComponent}
+                                           currentUser={currentUser}
+                                           classes={classes}
+                                           rowClass={rowClass}
+                                           handleRowClick={handleRowClick}
+                  />)
             }
           </TableBody>
         }
@@ -365,9 +365,9 @@ const DatatableContents = ({
               {
                 _.sortBy(columns, column => column.order).map(
                   (column, index) =>
-                      <TableCell key={index} className={classNames(classes.tableCell, column.footerClass)}>
-                        {footerData[index]}
-                      </TableCell>
+                    <TableCell key={index} className={classNames(classes.tableCell, column.footerClass)}>
+                      {footerData[index]}
+                    </TableCell>
                 )
               }
               {
@@ -380,11 +380,11 @@ const DatatableContents = ({
 
         }
 
-    </Table>
-    {
-      paginate &&
+      </Table>
+      {
+        paginate &&
 
-      <TablePagination
+        <TablePagination
           component="div"
           count={totalCount}
           rowsPerPage={paginationTerms.itemsPerPage}
@@ -397,20 +397,20 @@ const DatatableContents = ({
           }}
           onChangePage={onChangePage}
           onChangeRowsPerPage={onChangeRowsPerPage}
-      />
-    }
-    {
-      !paginate && loadMore &&
+        />
+      }
+      {
+        !paginate && loadMore &&
 
-      <Components.LoadMore className={classes.loadMore}
-                           count={count}
-                           totalCount={totalCount}
-                           loadMore={loadMore}
-                           networkStatus={networkStatus}
-      />
-    }
-  </React.Fragment>
-);
+        <Components.LoadMore className={classes.loadMore}
+                             count={count}
+                             totalCount={totalCount}
+                             loadMore={loadMore}
+                             networkStatus={networkStatus}
+        />
+      }
+    </React.Fragment>
+  );
 };
 
 

--- a/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
+++ b/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
@@ -39,14 +39,14 @@ const baseStyles = theme => ({
     alignItems: 'center',
   },
   addButton: {
-    position: 'absolute',
-    top: '-8px',
-    right: 0,
+    top: '9.5rem',
+    right: '2rem',
+    position: 'fixed',
+    bottom: 'auto',
   },
-  search: {
-    marginBottom: theme.spacing.unit * 8,
+  table: {
+    marginTop:0
   },
-  table: {},
   denseTable: {},
   denserTable: {},
   flatTable: {},
@@ -70,19 +70,19 @@ const delay = (function () {
 })();
 
 class Datatable extends PureComponent {
-  
+
   constructor (props) {
     super(props);
-    
+
     this.updateQuery = this.updateQuery.bind(this);
-    
+
     this.state = {
       value: '',
       query: '',
       currentSort: {},
     };
   }
-  
+
   toggleSort = column => {
     let currentSort;
     if (!this.state.currentSort[column]) {
@@ -94,7 +94,7 @@ class Datatable extends PureComponent {
     }
     this.setState({ currentSort });
   };
-  
+
   updateQuery (value) {
     this.setState({
       value: value
@@ -105,22 +105,22 @@ class Datatable extends PureComponent {
       });
     }, 700);
   }
-  
+
   render () {
     if (this.props.data) {
-      
+
       return <Components.DatatableContents
-        columns={this.props.data.length ? Object.keys(this.props.data[0]) : undefined}
-        {...this.props}
-        results={this.props.data}
-        count={this.props.data.length}
-        totalCount={this.props.data.length}
-        showEdit={false}
-        showNew={false}
+          columns={this.props.data.length ? Object.keys(this.props.data[0]) : undefined}
+          {...this.props}
+          results={this.props.data}
+          count={this.props.data.length}
+          totalCount={this.props.data.length}
+          showEdit={false}
+          showNew={false}
       />;
-      
+
     } else {
-      
+
       const {
         className,
         collection,
@@ -130,51 +130,52 @@ class Datatable extends PureComponent {
         currentUser,
         classes,
       } = this.props;
-      
+
       const listOptions = {
         collection: collection,
         ...options,
       };
-      
+
       const DatatableWithMulti = withMulti(listOptions)(Components.DatatableContents);
-      
+
       // add _id to orderBy when we want to sort a column, to avoid breaking the graphql() hoc;
       // see https://github.com/VulcanJS/Vulcan/issues/2090#issuecomment-433860782
       // this.state.currentSort !== {} is always false, even when console.log(this.state.currentSort) displays
       // {}. So we test on the length of keys for this object.
       const orderBy = Object.keys(this.state.currentSort).length == 0 ? {} :
-        { ...this.state.currentSort, _id: -1 };
-      
+          { ...this.state.currentSort, _id: -1 };
+
       return (
-        <div className={classNames('datatable', `datatable-${collection._name}`, classes.root,
-          className)}>
-          {/* DatatableAbove Component part*/}
-          {
-            showSearch &&
-            
-            <Components.SearchInput value={this.state.query}
-                                    updateQuery={this.updateQuery}
-                                    className={classes.search}
+          <div className={classNames('datatable', `datatable-${collection._name}`, classes.root,
+              className)}>
+            {/* DatatableAbove Component part*/}
+            {
+              showSearch &&
+
+              <Components.SearchInput value={this.state.query}
+                                      updateQuery={this.updateQuery}
+                                      className={classes.search}
+                                      labelId={'datatable.search'}
+              />
+            }
+            {
+              showNew &&
+
+              <Components.NewButton collection={collection}
+                                    variant="fab"
+                                    color="primary"
+                                    className={classes.addButton}
+              />
+            }
+
+            <DatatableWithMulti {...this.props}
+                                collection={collection}
+                                terms={{ query: this.state.query, orderBy: orderBy }}
+                                currentUser={this.props.currentUser}
+                                toggleSort={this.toggleSort}
+                                currentSort={this.state.currentSort}
             />
-          }
-          {
-            showNew &&
-            
-            <Components.NewButton collection={collection}
-                                  variant="fab"
-                                  color="primary"
-                                  className={classes.addButton}
-            />
-          }
-          
-          <DatatableWithMulti {...this.props}
-                              collection={collection}
-                              terms={{ query: this.state.query, orderBy: orderBy }}
-                              currentUser={this.props.currentUser}
-                              toggleSort={this.toggleSort}
-                              currentSort={this.state.currentSort}
-          />
-        </div>
+          </div>
       );
     }
   }
@@ -262,20 +263,20 @@ const DatatableContents = ({
                              paginationTerms,
                              setPaginationTerms
                            }) => {
-  
+
   if (loading) {
     return <Components.Loading/>;
   } else if (!results || !results.length) {
     return emptyState || null;
   }
-  
+
   if (queryDataRef) queryDataRef(this.props);
-  
+
   const denseClass = dense && classes[dense + 'Table'];
-  
+
   // Pagination functions
   const getPage = (paginationTerms) => (parseInt((paginationTerms.limit - 1) / paginationTerms.itemsPerPage));
-  
+
   const onChangePage = (event, page) => {
     setPaginationTerms({
       itemsPerPage: paginationTerms.itemsPerPage,
@@ -283,7 +284,7 @@ const DatatableContents = ({
       offset: page * paginationTerms.itemsPerPage
     });
   };
-  
+
   const onChangeRowsPerPage = (event) => {
     let value = event.target.value;
     let offset = Math.max(0, parseInt((paginationTerms.limit - paginationTerms.itemsPerPage) / value) * value);
@@ -294,117 +295,121 @@ const DatatableContents = ({
       offset: offset
     });
   };
-  
+
   return (
-    <React.Fragment>
-      {
-        title &&
-        <Toolbar>
-          <Typography variant="h6" id="tableTitle">
-            title
-          </Typography>
-        </Toolbar>
-      }
-      <Table className={classNames(classes.table, denseClass)}>
-        <TableHead className={classes.tableHead}>
-          <TableRow className={classes.tableRow}>
-            {
-              _.sortBy(columns, column => column.order).map(
-                (column, index) =>
-                  <Components.DatatableHeader key={index}
-                                              collection={collection}
-                                              intlNamespace={intlNamespace}
-                                              column={column}
-                                              classes={classes}
-                                              toggleSort={toggleSort}
-                                              currentSort={currentSort}
-                  />
-              )
-            }
-            {
-              (showEdit || editComponent) &&
-              
-              <TableCell className={classes.tableCell}/>
-            }
-          </TableRow>
-        </TableHead>
-        
+      <React.Fragment>
         {
-          results &&
-          
-          <TableBody className={classes.tableBody}>
-            {
-              results.map(
-                (document, index) =>
-                  <Components.DatatableRow collection={collection}
-                                           columns={columns}
-                                           document={document}
-                                           refetch={refetch}
-                                           key={index}
-                                           showEdit={showEdit}
-                                           editComponent={editComponent}
-                                           currentUser={currentUser}
-                                           classes={classes}
-                                           rowClass={rowClass}
-                                           handleRowClick={handleRowClick}
-                  />)
-            }
-          </TableBody>
+          (title)?
+              <Toolbar>
+                <Typography variant="h6" id="tableTitle">
+                  title
+                </Typography>
+              </Toolbar>
+              :null
         }
-        
+        <Table className={classNames(classes.table, denseClass)}>
+          {
+            columns &&
+            <TableHead className={classes.tableHead}>
+              <TableRow className={classes.tableRow}>
+                {
+                  _.sortBy(columns, column => column.order).map(
+                      (column, index) =>
+                          <Components.DatatableHeader key={index}
+                                                      collection={collection}
+                                                      intlNamespace={intlNamespace}
+                                                      column={column}
+                                                      classes={classes}
+                                                      toggleSort={toggleSort}
+                                                      currentSort={currentSort}
+                          />
+                  )
+                }
+                {
+                  (showEdit || editComponent) &&
+
+                  <TableCell className={classes.tableCell}/>
+                }
+              </TableRow>
+            </TableHead>
+          }
+
+          {
+            results &&
+
+            <TableBody className={classes.tableBody}>
+              {
+                results.map(
+                    (document, index) =>
+                        <Components.DatatableRow collection={collection}
+                                                 columns={columns}
+                                                 document={document}
+                                                 refetch={refetch}
+                                                 key={index}
+                                                 showEdit={showEdit}
+                                                 editComponent={editComponent}
+                                                 currentUser={currentUser}
+                                                 classes={classes}
+                                                 rowClass={rowClass}
+                                                 handleRowClick={handleRowClick}
+                        />)
+              }
+            </TableBody>
+          }
+
+          {
+            footerData &&
+
+            <TableFooter className={classes.tableFooter}>
+              <TableRow className={classes.tableRow}>
+                {
+                  _.sortBy(columns, column => column.order).map(
+                      (column, index) =>
+                          <TableCell key={index} className={classNames(classes.tableCell, column.footerClass)}>
+                            {footerData[index]}
+                          </TableCell>
+                  )
+                }
+                {
+                  (showEdit || editComponent) &&
+
+                  <TableCell className={classes.tableCell}/>
+                }
+              </TableRow>
+            </TableFooter>
+
+          }
+
+        </Table>
         {
-          footerData &&
-          
-          <TableFooter className={classes.tableFooter}>
-            <TableRow className={classes.tableRow}>
-              {
-                _.sortBy(columns, column => column.order).map(
-                  (column, index) =>
-                    <TableCell key={index} className={classNames(classes.tableCell, column.footerClass)}>
-                      {footerData[index]}
-                    </TableCell>
-                )
-              }
-              {
-                (showEdit || editComponent) &&
-                
-                <TableCell className={classes.tableCell}/>
-              }
-            </TableRow>
-          </TableFooter>
-          
+          paginate &&
+
+          <TablePagination
+              component="div"
+              count={totalCount}
+              rowsPerPage={paginationTerms.itemsPerPage}
+              page={getPage(paginationTerms)}
+              backIconButtonProps={{
+                'aria-label': 'Previous Page',
+              }}
+              nextIconButtonProps={{
+                'aria-label': 'Next Page',
+              }}
+              onChangePage={onChangePage}
+              onChangeRowsPerPage={onChangeRowsPerPage}
+          />
         }
-      
-      </Table>
-      {
-        paginate &&
-        
-        <TablePagination
-          component="div"
-          count={totalCount}
-          rowsPerPage={paginationTerms.itemsPerPage}
-          page={getPage(paginationTerms)}
-          backIconButtonProps={{
-            'aria-label': 'Previous Page',
-          }}
-          nextIconButtonProps={{
-            'aria-label': 'Next Page',
-          }}
-          onChangePage={onChangePage}
-          onChangeRowsPerPage={onChangeRowsPerPage}
-        />
-      }
-      {
-        !paginate && loadMore &&
-        
-        <Components.LoadMore className={classes.loadMore}
-                             count={count}
-                             totalCount={totalCount}
-                             loadMore={loadMore}
-                             networkStatus={networkStatus}
-        />
-      }
-    </React.Fragment>
+        {
+          !paginate && loadMore &&
+
+          <Components.LoadMore className={classes.loadMore}
+                               count={count}
+                               totalCount={totalCount}
+                               loadMore={loadMore}
+                               networkStatus={networkStatus}
+          />
+        }
+      </React.Fragment>
   );
 };
 
@@ -420,10 +425,10 @@ DatatableHeader Component
 const DatatableHeader = ({ collection, intlNamespace, column, classes, toggleSort, currentSort }, { intl }) => {
   const columnName = typeof column === 'string' ? column : column.name || column.label;
   let formattedLabel = '';
-  
+
   if (collection) {
     const schema = collection.simpleSchema()._schema;
-    
+
     /*
     use either:
 
@@ -433,16 +438,16 @@ const DatatableHeader = ({ collection, intlNamespace, column, classes, toggleSor
     */
     const defaultMessage = schema[columnName] ? schema[columnName].label : Utils.camelToSpaces(columnName);
     formattedLabel = typeof columnName === 'string' ?
-      intl.formatMessage({
-        id: `${collection._name}.${columnName}`,
-        defaultMessage: defaultMessage
-      }) :
-      '';
-    
+        intl.formatMessage({
+          id: `${collection._name}.${columnName}`,
+          defaultMessage: defaultMessage
+        }) :
+        '';
+
     // if sortable is a string, use it as the name of the property to sort by. If it's just `true`, use
     // column.name
     const sortPropertyName = typeof column.sortable === 'string' ? column.sortable : column.name;
-    
+
     if (column.sortable) {
       return <Components.DatatableSorter name={sortPropertyName}
                                          label={formattedLabel}
@@ -453,17 +458,17 @@ const DatatableHeader = ({ collection, intlNamespace, column, classes, toggleSor
     }
   } else if (intlNamespace) {
     formattedLabel = typeof columnName === 'string' ?
-      intl.formatMessage({
-        id: `${intlNamespace}.${columnName}`,
-        defaultMessage: columnName
-      }) :
-      '';
+        intl.formatMessage({
+          id: `${intlNamespace}.${columnName}`,
+          defaultMessage: columnName
+        }) :
+        '';
   } else {
     formattedLabel = intl.formatMessage({ id: columnName, defaultMessage: columnName });
   }
-  
+
   return <TableCell
-    className={classNames(classes.tableHeadCell, column.headerClass)}>{formattedLabel}</TableCell>;
+      className={classNames(classes.tableHeadCell, column.headerClass)}>{formattedLabel}</TableCell>;
 };
 
 
@@ -482,23 +487,23 @@ DatatableSorter Component
 */
 
 const DatatableSorter = ({ name, label, toggleSort, currentSort, sortable }) =>
-  <TableCell className="datatable-sorter"
-             sortDirection={!currentSort[name] ? false : currentSort[name] === 1 ? 'asc' : 'desc'}
-  >
-    <Tooltip
-      title="Sort"
-      placement='bottom-start'
-      enterDelay={300}
+    <TableCell className="datatable-sorter"
+               sortDirection={!currentSort[name] ? false : currentSort[name] === 1 ? 'asc' : 'desc'}
     >
-      <TableSortLabel
-        active={!currentSort[name] ? false : true}
-        direction={currentSort[name] === 1 ? 'desc' : 'asc'}
-        onClick={() => toggleSort(name)}
+      <Tooltip
+          title="Sort"
+          placement='bottom-start'
+          enterDelay={300}
       >
-        {label}
-      </TableSortLabel>
-    </Tooltip>
-  </TableCell>;
+        <TableSortLabel
+            active={!currentSort[name] ? false : true}
+            direction={currentSort[name] === 1 ? 'desc' : 'asc'}
+            onClick={() => toggleSort(name)}
+        >
+          {label}
+        </TableSortLabel>
+      </Tooltip>
+    </TableCell>;
 
 replaceComponent('DatatableSorter', DatatableSorter);
 
@@ -532,52 +537,52 @@ const DatatableRow = ({
                         handleRowClick,
                         classes,
                       }, { intl }) => {
-  
+
   const EditComponent = editComponent;
-  
+
   if (typeof rowClass === 'function') {
     rowClass = rowClass(document);
   }
-  
+
   return (
-    <TableRow
-      className={classNames('datatable-item', classes.tableRow, rowClass, handleRowClick && classes.clickRow)}
-      onClick={handleRowClick && (event => handleRowClick(event, document))}
-      hover
-    >
-      
-      {
-        _.sortBy(columns, column => column.order).map(
-          (column, index) =>
-            <Components.DatatableCell key={index}
-                                      column={column}
-                                      document={document}
-                                      currentUser={currentUser}
-                                      classes={classes}
-            />)
-      }
-      
-      {
-        (showEdit || editComponent) &&
-        
-        <TableCell className={classes.editCell}>
-          {
-            EditComponent &&
-            
-            <EditComponent collection={collection} document={document} refetch={refetch}/>
-          }
-          {
-            showEdit &&
-            
-            <Components.EditButton collection={collection}
-                                   document={document}
-                                   buttonClasses={{ button: classes.editButton }}
-            />
-          }
-        </TableCell>
-      }
-    
-    </TableRow>
+      <TableRow
+          className={classNames('datatable-item', classes.tableRow, rowClass, handleRowClick && classes.clickRow)}
+          onClick={handleRowClick && (event => handleRowClick(event, document))}
+          hover
+      >
+
+        {
+          _.sortBy(columns, column => column.order).map(
+              (column, index) =>
+                  <Components.DatatableCell key={index}
+                                            column={column}
+                                            document={document}
+                                            currentUser={currentUser}
+                                            classes={classes}
+                  />)
+        }
+
+        {
+          (showEdit || editComponent) &&
+
+          <TableCell className={classes.editCell}>
+            {
+              EditComponent &&
+
+              <EditComponent collection={collection} document={document} refetch={refetch}/>
+            }
+            {
+              showEdit &&
+
+              <Components.EditButton collection={collection}
+                                     document={document}
+                                     buttonClasses={{ button: classes.editButton }}
+              />
+            }
+          </TableCell>
+        }
+
+      </TableRow>
   );
 };
 
@@ -597,26 +602,26 @@ DatatableCell Component
 */
 const DatatableCell = ({ column, document, currentUser, classes }) => {
   const Component = column.component ||
-    Components[column.componentName] ||
-    Components.DatatableDefaultCell;
-  
+      Components[column.componentName] ||
+      Components.DatatableDefaultCell;
+
   const columnName = typeof column === 'string' ? column : column.name;
   const className = typeof columnName === 'string' ?
-    `datatable-item-${columnName.toLowerCase()}` :
-    '';
+      `datatable-item-${columnName.toLowerCase()}` :
+      '';
   const cellClass = typeof column.cellClass === 'function' ?
-    column.cellClass({ column, document, currentUser }) :
-    typeof column.cellClass === 'string' ?
-      column.cellClass :
-      null;
-  
+      column.cellClass({ column, document, currentUser }) :
+      typeof column.cellClass === 'string' ?
+          column.cellClass :
+          null;
+
   return (
-    <TableCell className={classNames(classes.tableCell, cellClass, className)}>
-      <Component column={column}
-                 document={document}
-                 currentUser={currentUser}
-      />
-    </TableCell>
+      <TableCell className={classNames(classes.tableCell, cellClass, className)}>
+        <Component column={column}
+                   document={document}
+                   currentUser={currentUser}
+        />
+      </TableCell>
   );
 };
 
@@ -630,15 +635,15 @@ DatatableDefaultCell Component
 
 */
 const DatatableDefaultCell = ({ column, document }) =>
-  <div>
-    {
-      typeof column === 'string'
-        ?
-        getFieldValue(document[column])
-        :
-        getFieldValue(document[column.name])
-    }
-  </div>;
+    <div>
+      {
+        typeof column === 'string'
+            ?
+            getFieldValue(document[column])
+            :
+            getFieldValue(document[column.name])
+      }
+    </div>;
 
 
 replaceComponent('DatatableDefaultCell', DatatableDefaultCell);

--- a/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
+++ b/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
@@ -110,13 +110,13 @@ class Datatable extends PureComponent {
     if (this.props.data) {
 
       return <Components.DatatableContents
-          columns={this.props.data.length ? Object.keys(this.props.data[0]) : undefined}
-          {...this.props}
-          results={this.props.data}
-          count={this.props.data.length}
-          totalCount={this.props.data.length}
-          showEdit={false}
-          showNew={false}
+        columns={this.props.data.length ? Object.keys(this.props.data[0]) : undefined}
+        {...this.props}
+        results={this.props.data}
+        count={this.props.data.length}
+        totalCount={this.props.data.length}
+        showEdit={false}
+        showNew={false}
       />;
 
     } else {
@@ -146,36 +146,36 @@ class Datatable extends PureComponent {
           { ...this.state.currentSort, _id: -1 };
 
       return (
-          <div className={classNames('datatable', `datatable-${collection._name}`, classes.root,
-              className)}>
-            {/* DatatableAbove Component part*/}
-            {
-              showSearch &&
+        <div className={classNames('datatable', `datatable-${collection._name}`, classes.root,
+            className)}>
+          {/* DatatableAbove Component part*/}
+          {
+            showSearch &&
 
-              <Components.SearchInput value={this.state.query}
-                                      updateQuery={this.updateQuery}
-                                      className={classes.search}
-                                      labelId={'datatable.search'}
-              />
-            }
-            {
-              showNew &&
-
-              <Components.NewButton collection={collection}
-                                    variant="fab"
-                                    color="primary"
-                                    className={classes.addButton}
-              />
-            }
-
-            <DatatableWithMulti {...this.props}
-                                collection={collection}
-                                terms={{ query: this.state.query, orderBy: orderBy }}
-                                currentUser={this.props.currentUser}
-                                toggleSort={this.toggleSort}
-                                currentSort={this.state.currentSort}
+            <Components.SearchInput value={this.state.query}
+                                    updateQuery={this.updateQuery}
+                                    className={classes.search}
+                                    labelId={'datatable.search'}
             />
-          </div>
+          }
+          {
+            showNew &&
+
+            <Components.NewButton collection={collection}
+                                  variant="fab"
+                                  color="primary"
+                                  className={classes.addButton}
+            />
+          }
+
+          <DatatableWithMulti {...this.props}
+                              collection={collection}
+                              terms={{ query: this.state.query, orderBy: orderBy }}
+                              currentUser={this.props.currentUser}
+                              toggleSort={this.toggleSort}
+                              currentSort={this.state.currentSort}
+          />
+        </div>
       );
     }
   }

--- a/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
+++ b/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
@@ -300,12 +300,12 @@ const DatatableContents = ({
     <React.Fragment>
       {
         (title)?
-            <Toolbar>
-              <Typography variant="h6" id="tableTitle">
-                title
-              </Typography>
-            </Toolbar>
-            :null
+          <Toolbar>
+            <Typography variant="h6" id="tableTitle">
+              title
+            </Typography>
+          </Toolbar>
+          :null
       }
       <Table className={classNames(classes.table, denseClass)}>
       {
@@ -315,14 +315,14 @@ const DatatableContents = ({
             {
               _.sortBy(columns, column => column.order).map(
                 (column, index) =>
-                    <Components.DatatableHeader key={index}
-                                                collection={collection}
-                                                intlNamespace={intlNamespace}
-                                                column={column}
-                                                classes={classes}
-                                                toggleSort={toggleSort}
-                                                currentSort={currentSort}
-                    />
+                  <Components.DatatableHeader key={index}
+                                              collection={collection}
+                                              intlNamespace={intlNamespace}
+                                              column={column}
+                                              classes={classes}
+                                              toggleSort={toggleSort}
+                                              currentSort={currentSort}
+                  />
               )
             }
             {

--- a/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
+++ b/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
@@ -487,23 +487,23 @@ DatatableSorter Component
 */
 
 const DatatableSorter = ({ name, label, toggleSort, currentSort, sortable }) =>
-    <TableCell className="datatable-sorter"
-               sortDirection={!currentSort[name] ? false : currentSort[name] === 1 ? 'asc' : 'desc'}
+  <TableCell className="datatable-sorter"
+             sortDirection={!currentSort[name] ? false : currentSort[name] === 1 ? 'asc' : 'desc'}
+  >
+    <Tooltip
+        title="Sort"
+        placement='bottom-start'
+        enterDelay={300}
     >
-      <Tooltip
-          title="Sort"
-          placement='bottom-start'
-          enterDelay={300}
+      <TableSortLabel
+          active={!currentSort[name] ? false : true}
+          direction={currentSort[name] === 1 ? 'desc' : 'asc'}
+          onClick={() => toggleSort(name)}
       >
-        <TableSortLabel
-            active={!currentSort[name] ? false : true}
-            direction={currentSort[name] === 1 ? 'desc' : 'asc'}
-            onClick={() => toggleSort(name)}
-        >
-          {label}
-        </TableSortLabel>
-      </Tooltip>
-    </TableCell>;
+        {label}
+      </TableSortLabel>
+    </Tooltip>
+  </TableCell>;
 
 replaceComponent('DatatableSorter', DatatableSorter);
 
@@ -545,44 +545,44 @@ const DatatableRow = ({
   }
 
   return (
-      <TableRow
-          className={classNames('datatable-item', classes.tableRow, rowClass, handleRowClick && classes.clickRow)}
-          onClick={handleRowClick && (event => handleRowClick(event, document))}
-          hover
-      >
+    <TableRow
+        className={classNames('datatable-item', classes.tableRow, rowClass, handleRowClick && classes.clickRow)}
+        onClick={handleRowClick && (event => handleRowClick(event, document))}
+        hover
+    >
 
-        {
-          _.sortBy(columns, column => column.order).map(
-              (column, index) =>
-                  <Components.DatatableCell key={index}
-                                            column={column}
-                                            document={document}
-                                            currentUser={currentUser}
-                                            classes={classes}
-                  />)
-        }
+      {
+        _.sortBy(columns, column => column.order).map(
+            (column, index) =>
+                <Components.DatatableCell key={index}
+                                          column={column}
+                                          document={document}
+                                          currentUser={currentUser}
+                                          classes={classes}
+                />)
+      }
 
-        {
-          (showEdit || editComponent) &&
+      {
+        (showEdit || editComponent) &&
 
-          <TableCell className={classes.editCell}>
-            {
-              EditComponent &&
+        <TableCell className={classes.editCell}>
+          {
+            EditComponent &&
 
-              <EditComponent collection={collection} document={document} refetch={refetch}/>
-            }
-            {
-              showEdit &&
+            <EditComponent collection={collection} document={document} refetch={refetch}/>
+          }
+          {
+            showEdit &&
 
-              <Components.EditButton collection={collection}
-                                     document={document}
-                                     buttonClasses={{ button: classes.editButton }}
-              />
-            }
-          </TableCell>
-        }
+            <Components.EditButton collection={collection}
+                                   document={document}
+                                   buttonClasses={{ button: classes.editButton }}
+            />
+          }
+        </TableCell>
+      }
 
-      </TableRow>
+    </TableRow>
   );
 };
 
@@ -602,26 +602,26 @@ DatatableCell Component
 */
 const DatatableCell = ({ column, document, currentUser, classes }) => {
   const Component = column.component ||
-      Components[column.componentName] ||
-      Components.DatatableDefaultCell;
+    Components[column.componentName] ||
+    Components.DatatableDefaultCell;
 
   const columnName = typeof column === 'string' ? column : column.name;
   const className = typeof columnName === 'string' ?
       `datatable-item-${columnName.toLowerCase()}` :
       '';
   const cellClass = typeof column.cellClass === 'function' ?
-      column.cellClass({ column, document, currentUser }) :
-      typeof column.cellClass === 'string' ?
-          column.cellClass :
-          null;
+    column.cellClass({ column, document, currentUser }) :
+    typeof column.cellClass === 'string' ?
+        column.cellClass :
+        null;
 
   return (
-      <TableCell className={classNames(classes.tableCell, cellClass, className)}>
-        <Component column={column}
-                   document={document}
-                   currentUser={currentUser}
-        />
-      </TableCell>
+    <TableCell className={classNames(classes.tableCell, cellClass, className)}>
+      <Component column={column}
+                 document={document}
+                 currentUser={currentUser}
+      />
+    </TableCell>
   );
 };
 
@@ -635,15 +635,15 @@ DatatableDefaultCell Component
 
 */
 const DatatableDefaultCell = ({ column, document }) =>
-    <div>
-      {
-        typeof column === 'string'
-            ?
-            getFieldValue(document[column])
-            :
-            getFieldValue(document[column.name])
-      }
-    </div>;
+  <div>
+    {
+      typeof column === 'string'
+          ?
+          getFieldValue(document[column])
+          :
+          getFieldValue(document[column.name])
+    }
+  </div>;
 
 
 replaceComponent('DatatableDefaultCell', DatatableDefaultCell);

--- a/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
+++ b/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
@@ -491,14 +491,14 @@ const DatatableSorter = ({ name, label, toggleSort, currentSort, sortable }) =>
              sortDirection={!currentSort[name] ? false : currentSort[name] === 1 ? 'asc' : 'desc'}
   >
     <Tooltip
-        title="Sort"
-        placement='bottom-start'
-        enterDelay={300}
+      title="Sort"
+      placement='bottom-start'
+      enterDelay={300}
     >
       <TableSortLabel
-          active={!currentSort[name] ? false : true}
-          direction={currentSort[name] === 1 ? 'desc' : 'asc'}
-          onClick={() => toggleSort(name)}
+        active={!currentSort[name] ? false : true}
+        direction={currentSort[name] === 1 ? 'desc' : 'asc'}
+        onClick={() => toggleSort(name)}
       >
         {label}
       </TableSortLabel>
@@ -546,20 +546,20 @@ const DatatableRow = ({
 
   return (
     <TableRow
-        className={classNames('datatable-item', classes.tableRow, rowClass, handleRowClick && classes.clickRow)}
-        onClick={handleRowClick && (event => handleRowClick(event, document))}
-        hover
+      className={classNames('datatable-item', classes.tableRow, rowClass, handleRowClick && classes.clickRow)}
+      onClick={handleRowClick && (event => handleRowClick(event, document))}
+      hover
     >
 
       {
         _.sortBy(columns, column => column.order).map(
-            (column, index) =>
-                <Components.DatatableCell key={index}
-                                          column={column}
-                                          document={document}
-                                          currentUser={currentUser}
-                                          classes={classes}
-                />)
+          (column, index) =>
+              <Components.DatatableCell key={index}
+                                        column={column}
+                                        document={document}
+                                        currentUser={currentUser}
+                                        classes={classes}
+              />)
       }
 
       {
@@ -607,13 +607,13 @@ const DatatableCell = ({ column, document, currentUser, classes }) => {
 
   const columnName = typeof column === 'string' ? column : column.name;
   const className = typeof columnName === 'string' ?
-      `datatable-item-${columnName.toLowerCase()}` :
-      '';
+    `datatable-item-${columnName.toLowerCase()}` :
+    '';
   const cellClass = typeof column.cellClass === 'function' ?
     column.cellClass({ column, document, currentUser }) :
     typeof column.cellClass === 'string' ?
-        column.cellClass :
-        null;
+      column.cellClass :
+      null;
 
   return (
     <TableCell className={classNames(classes.tableCell, cellClass, className)}>
@@ -638,10 +638,10 @@ const DatatableDefaultCell = ({ column, document }) =>
   <div>
     {
       typeof column === 'string'
-          ?
-          getFieldValue(document[column])
-          :
-          getFieldValue(document[column.name])
+        ?
+        getFieldValue(document[column])
+        :
+        getFieldValue(document[column.name])
     }
   </div>;
 

--- a/packages/vulcan-ui-material/lib/components/index.js
+++ b/packages/vulcan-ui-material/lib/components/index.js
@@ -7,7 +7,7 @@ import './accounts/AccountsPasswordOrService';
 import './accounts/AccountsSocialButtons';
 
 import './bonus/LoadMore';
-// import './bonus/SearchInput';
+import './bonus/SearchInput';
 import './bonus/TooltipIntl';
 import './bonus/TooltipIconButton';
 


### PR DESCRIPTION
After trying to use the DataTable component with the new Material UI Implementation, the DataTable wasn't rendered at all get the following error and

Uncaught (in promise) Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
After some debugging, I determine the error was related with the following component inside DataTable render

```
{
  showSearch &&
  
  <Components.SearchInput value={this.state.query}
                          updateQuery={this.updateQuery}
                          className={classes.search}
  />
}
```