### PR TITLE
Nested form field spec

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -217,13 +217,14 @@ class SmartForm extends Component {
   Get a list of children-fields for a nested field.
 
   */
-  getChildFields = fieldName => this.props.fields.reduce((filtered, field) => {
-    const child = field.replace(new RegExp(`^${fieldName}\\.`), '');
-    if(child !== field)
-      return filtered ? filtered.push(child) : [child];
+  getChildFields = fieldName => this.props.fields && 
+        this.props.fields.reduce((filtered, field) => {
+          const child = field.replace(new RegExp(`^${fieldName}\\.`), '');
+          if(child !== field)
+            return filtered ? filtered.push(child) : [child];
 
-    return filtered;
-  }, null);
+          return filtered;
+        }, null);
 
   /*
 

--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -214,6 +214,19 @@ class SmartForm extends Component {
 
   /*
 
+  Get a list of children-fields for a nested field.
+
+  */
+  getChildFields = fieldName => this.props.fields.reduce((filtered, field) => {
+    const child = field.replace(new RegExp(`^${fieldName}\\.`), '');
+    if(child !== field)
+      return filtered ? filtered.push(child) : [child];
+
+    return filtered;
+  }, null);
+
+  /*
+
   Like getDocument, but cross-reference with getFieldNames()
   to only return fields that actually need to be submitted
 
@@ -328,16 +341,18 @@ class SmartForm extends Component {
       excludeHiddenFields = true,
       excludeRemovedFields = true,
       replaceIntlFields = false,
-      addExtraFields = true
+      addExtraFields = true,      
     } = args0;
 
-    const { fields, addFields } = this.props;
+    let fields = args0.fields || this.props.fields;
+    
+    const { addFields } = this.props;
 
     // get all editable/insertable fields (depending on current form type)
     let relevantFields = this.getMutableFields(schema);
 
     // if "fields" prop is specified, restrict list of fields to it
-    if (typeof fields !== 'undefined' && fields.length > 0) {
+    if (fields !== '*' && typeof fields !== 'undefined' && fields.length > 0) {
       relevantFields = _.intersection(relevantFields, fields);
     }
 
@@ -477,7 +492,8 @@ class SmartForm extends Component {
       // get nested schema
       // for each nested field, get field object by calling createField recursively
       field.nestedFields = this.getFieldNames({
-        schema: field.nestedSchema
+        schema: field.nestedSchema,
+        fields: this.getChildFields(fieldName) || '*'
       }).map(subFieldName => {
         return this.createField(
           subFieldName,

--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -490,12 +490,15 @@ class SmartForm extends Component {
       field.nestedSchema = fieldSchema.schema;
       field.nestedInput = true;
 
+      // get all children by path (if any)
+      const children = this.getChildFields(fieldName);
+
       // get nested schema
       // for each nested field, get field object by calling createField recursively
       field.nestedFields = this.getFieldNames({
         schema: field.nestedSchema,
-        fields: this.getChildFields(fieldName) || '*'
-      }).map(subFieldName => {
+        fields: (this.props.fields.includes(fieldName) || !children) ? '*' : children
+       }).map(subFieldName => {
         return this.createField(
           subFieldName,
           field.nestedSchema,


### PR DESCRIPTION
Specifying fields for nested schemas did not work.
This PR should fix the issue relatively elegantly.

This is a dublicate of #2229 due to my not creating a feature branch in the first PR. 

### Examples:
```jsx
 <Components.SmartForm
                 collectionName="Users"
                 fields={['userProfile.title']}
                 documentId={this.props.currentUser._id} />;
```
Selects the `userPofile.title` field to be displayed in the form. 


```jsx
 <Components.SmartForm
                 collectionName="Users"
                 fields={['userProfile']}
                 documentId={this.props.currentUser._id} />;
```
Renders all the subfields of `userProfile`.