### PR TITLE
Additional tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Vulcan",
-  "version": "1.12.17",
+  "version": "1.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -352,6 +352,56 @@
         "component-type": "^1.2.1",
         "join-component": "^1.1.0"
       }
+    },
+    "@sinonjs/commons": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      },
+      "dependencies": {
+        "@sinonjs/samsam": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
+          "integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.0.2",
+            "array-from": "^2.1.1",
+            "lodash": "^4.17.11"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.3.tgz",
+      "integrity": "sha512-8zNeBkSKhU9a5cRNbpCKau2WWPfan+Q2zDlcXvXyhn9EsMqgYs4qzo0XHNVlXC6ABQL8fT6nV+zzo5RTHJzyXw==",
+      "dev": true
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "@types/accepts": {
       "version": "1.3.5",
@@ -1251,6 +1301,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
     },
     "array-union": {
       "version": "1.0.2",
@@ -5776,6 +5832,12 @@
         }
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "kew": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
@@ -6033,6 +6095,12 @@
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -6179,6 +6247,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
       "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
+    },
+    "lolex": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+      "dev": true
     },
     "long": {
       "version": "4.0.0",
@@ -6736,6 +6810,13 @@
             "safe-buffer": "^5.0.1",
             "string_decoder": "~1.0.0",
             "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+            }
           }
         },
         "rimraf": {
@@ -6988,6 +7069,36 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "nise": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
+      "integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-exceptions": {
       "version": "4.0.1",
@@ -9194,6 +9305,40 @@
         "mongo-object": "^0.1.2"
       }
     },
+    "sinon": {
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.3.5.tgz",
+      "integrity": "sha512-xgoZ2gKjyVRcF08RrIQc+srnSyY1JDJtxu3Nsz07j1ffjgXoY6uPLf/qja6nDBZgzYYEovVkFryw2+KiZz11xQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "@sinonjs/formatio": "^3.0.0",
+        "@sinonjs/samsam": "^2.1.2",
+        "diff": "^3.5.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.7.5",
+        "nise": "^1.4.5",
+        "supports-color": "^5.5.0",
+        "type-detect": "^4.0.8"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -9694,6 +9839,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,19 +38,13 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.55.tgz",
-      "integrity": "sha1-C8M6paasCwEvN+JbnmqqLkiakWs=",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.2.tgz",
+      "integrity": "sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==",
       "requires": {
-        "core-js": "^2.5.7",
         "regenerator-runtime": "^0.12.0"
       },
       "dependencies": {
-        "core-js": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
-          "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ=="
-        },
         "regenerator-runtime": {
           "version": "0.12.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
@@ -974,6 +968,15 @@
             "tslib": "^1.9.3"
           }
         }
+      }
+    },
+    "apollo-link-watched-mutation": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/apollo-link-watched-mutation/-/apollo-link-watched-mutation-0.1.0.tgz",
+      "integrity": "sha1-wFuJEllIHJzTu/KHZs4AloyYErM=",
+      "requires": {
+        "@babel/runtime": "^7.0.0-beta.32",
+        "apollo-utilities": "^1.0.0"
       }
     },
     "apollo-server": {
@@ -6733,13 +6736,6 @@
             "safe-buffer": "^5.0.1",
             "string_decoder": "~1.0.0",
             "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-            }
           }
         },
         "rimraf": {
@@ -7745,14 +7741,36 @@
       }
     },
     "react": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
-      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
+      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
       "requires": {
-        "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.6"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          },
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            }
+          }
+        }
       }
     },
     "react-addons-pure-render-mixin": {
@@ -7957,14 +7975,36 @@
       }
     },
     "react-dom": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
-      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
+      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
       "requires": {
-        "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.6"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          },
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            }
+          }
+        }
       }
     },
     "react-dropzone": {
@@ -8256,6 +8296,89 @@
         "lodash-es": "^4.2.0",
         "loose-envify": "^1.1.0",
         "prop-types": "^15.5.10"
+      }
+    },
+    "react-router": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
+      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+      "requires": {
+        "history": "^4.7.2",
+        "hoist-non-react-statics": "^2.5.0",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.3.1",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.1",
+        "warning": "^4.0.1"
+      },
+      "dependencies": {
+        "history": {
+          "version": "4.9.0",
+          "resolved": "https://registry.npmjs.org/history/-/history-4.9.0.tgz",
+          "integrity": "sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "loose-envify": "^1.2.0",
+            "resolve-pathname": "^2.2.0",
+            "tiny-invariant": "^1.0.2",
+            "tiny-warning": "^1.0.0",
+            "value-equal": "^0.4.0"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        },
+        "invariant": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+          "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          },
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            }
+          }
+        },
+        "warning": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
       }
     },
     "react-router-bootstrap": {
@@ -8906,6 +9029,15 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
+    "scheduler": {
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
     "scroll-behavior": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/scroll-behavior/-/scroll-behavior-0.9.5.tgz",
@@ -9458,6 +9590,16 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
       "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow=="
+    },
+    "tiny-invariant": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.4.tgz",
+      "integrity": "sha512-lMhRd/djQJ3MoaHEBrw8e2/uM4rs9YMNk0iOr8rHQ0QdbM7D4l0gFl3szKdeixrlyfm9Zqi4dxHCM2qVG8ND5g=="
+    },
+    "tiny-warning": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.2.tgz",
+      "integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q=="
     },
     "tmp": {
       "version": "0.0.30",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,8 @@
     "jsdom": "^11.11.0",
     "jsdom-global": "^3.0.2",
     "prettier": "^1.15.2",
-    "selenium-webdriver": "^4.0.0-alpha.1"
+    "selenium-webdriver": "^4.0.0-alpha.1",
+    "sinon": "^6.3.5"
   },
   "postcss": {
     "plugins": {

--- a/packages/vulcan-core/test/containers.test.js
+++ b/packages/vulcan-core/test/containers.test.js
@@ -26,48 +26,6 @@ describe('vulcan-core/containers', function() {
       expect(wrapper.html()).toEqual('FOO');
     });
   });
-  describe('handleOptions', function() {
-    const expectedCollectionName = 'COLLECTION_NAME';
-    const collectionNameOptions = { collectionName: expectedCollectionName };
-    const expectedCollection = { options: collectionNameOptions };
-    it('get collectionName from collection', function() {
-      const options = { collection: expectedCollection };
-      const { collection, collectionName } = extractCollectionInfo(options);
-      expect(collection).toEqual(expectedCollection);
-      expect(collectionName).toEqual(expectedCollectionName);
-    });
-    it('get collection from collectioName', function() {
-      // MOCK getCollection
-      const { collection, collectionName } = extractCollectionInfo(collectionNameOptions);
-      expect(collection).toEqual(expectedCollection);
-      expect(collectionName).toEqual(expectedCollectionName);
-    });
-    const expectedFragmentName = 'FRAGMENT_NAME';
-    const expectedFragment = {
-      definitions: [{ name: { value: expectedFragmentName } }],
-    };
-    it('get fragment from fragmentName', function() {
-      // MOCK getCollection
-      const options = { fragmentName: expectedFragmentName };
-      const { fragment, fragmentName } = extractFragmentInfo(options);
-      expect(fragment).toEqual(expectedFragment);
-      expect(fragmentName).toEqual(expectedFragmentName);
-    });
-    it('get fragmentName from fragment', function() {
-      const options = { fragment: expectedFragment };
-      const { fragment, fragmentName } = extractFragmentInfo(options);
-      expect(fragment).toEqual(expectedFragment);
-      expect(fragmentName).toEqual(expectedFragmentName);
-    });
-    it('get fragmentName and fragment from collectionName', function() {
-      // if options does not contain fragment, we get the collection default fragment based on its name
-      const options = {};
-      const { fragment, fragmentName } = extractFragmentInfo(options, expectedCollectionName);
-      expect(fragment).toEqual(expectedFragment);
-      expect(fragmentName).toEqual(expectedFragmentName);
-    });
-  });
-
   describe('withMessages', function() {
     const WrappedComponent = props => <div />;
     const apolloClient = null; // TODO: init an apolloClient, that must be available in the context

--- a/packages/vulcan-lib/lib/modules/callbacks.js
+++ b/packages/vulcan-lib/lib/modules/callbacks.js
@@ -53,14 +53,24 @@ export const addCallback = function (hook, callback) {
 
 /**
  * @summary Remove a callback from a hook
- * @param {string} hook - The name of the hook
- * @param {string} functionName - The name of the function to remove
+ * @param {string} hookName - The name of the hook
+ * @param {string} callbackName - The name of the function to remove
  */
 export const removeCallback = function (hookName, callbackName) {
   const formattedHook = formatHookName(hookName);
   Callbacks[formattedHook] = _.reject(Callbacks[formattedHook], function (callback) {
     return callback.name === callbackName;
   });
+};
+
+
+/**
+ * @summary Remove all callbacks from a hook (mostly for testing purposes)
+ * @param {string} hookName - The name of the hook
+ */
+export const removeAllCallbacks = function(hookName) {
+  const formattedHook = formatHookName(hookName);
+  Callbacks[formattedHook] = [];
 };
 
 /**

--- a/packages/vulcan-lib/lib/modules/collections.js
+++ b/packages/vulcan-lib/lib/modules/collections.js
@@ -1,6 +1,6 @@
 import { Mongo } from 'meteor/mongo';
 import SimpleSchema from 'simpl-schema';
-import { addGraphQLCollection, addToGraphQLContext } from './graphql.js';
+import { addGraphQLCollection, addToGraphQLContext } from './graphql';
 import { Utils } from './utils.js';
 import { runCallbacks, runCallbacksAsync, registerCallback, addCallback } from './callbacks.js';
 import { getSetting, registerSetting } from './settings.js';

--- a/packages/vulcan-lib/lib/modules/graphql/graphql.js
+++ b/packages/vulcan-lib/lib/modules/graphql/graphql.js
@@ -1,18 +1,17 @@
 // TODO: this should not be loaded on the client?
-
 /*
 
 Utilities to generate the app's GraphQL schema
+and register schema parts based on the application collections
 
 */
 
 import deepmerge from 'deepmerge';
 import GraphQLJSON from 'graphql-type-json';
 import GraphQLDate from 'graphql-date';
-import Vulcan from './config.js'; // used for global export
-import { Utils } from './utils.js';
+import Vulcan from '../config.js'; // used for global export
+import { Utils } from '../utils.js';
 import { disableFragmentWarnings } from 'graphql-tag';
-import { isIntlField } from './intl.js';
 import {
   selectorInputTemplate,
   mainTypeTemplate,
@@ -35,57 +34,31 @@ import {
   updateMutationTemplate,
   upsertMutationTemplate,
   deleteMutationTemplate,
-} from './graphql_templates.js';
+} from '../graphql_templates.js';
+
+import { 
+  getSchemaFields
+} from './schemaFields';
 
 disableFragmentWarnings();
 
-// get GraphQL type for a given schema and field name
-const getGraphQLType = (schema, fieldName, isInput = false) => {
-  const field = schema[fieldName];
-  const type = field.type.singleType;
-  const typeName =
-    typeof type === 'object' ? 'Object' : typeof type === 'function' ? type.name : type;
 
-  if (field.isIntlData) {
-    return isInput ? '[IntlValueInput]' : '[IntlValue]';
-  }
-
-  switch (typeName) {
-    case 'String':
-      return 'String';
-
-    case 'Boolean':
-      return 'Boolean';
-
-    case 'Number':
-      return 'Float';
-
-    case 'SimpleSchema.Integer':
-      return 'Int';
-
-    // for arrays, look for type of associated schema field or default to [String]
-    case 'Array':
-      const arrayItemFieldName = `${fieldName}.$`;
-      // note: make sure field has an associated array
-      if (schema[arrayItemFieldName]) {
-        // try to get array type from associated array
-        const arrayItemType = getGraphQLType(schema, arrayItemFieldName);
-        return arrayItemType ? `[${arrayItemType}]` : null;
-      }
-      return null;
-
-    case 'Object':
-      return 'JSON';
-
-    case 'Date':
-      return 'Date';
-
-    default:
-      return null;
-  }
+const defaultResolvers = {
+  JSON: GraphQLJSON,
+  Date: GraphQLDate,
 };
 
 export const GraphQLSchema = {
+  // reinit the schema (testing purposes only)
+  init(){
+    this.collections = [];
+    this.schemas = [];
+    this.queries = [];
+    this.mutations = [];
+    this.resolvers = defaultResolvers;
+    this.context = {};
+    this.directives = {};
+  },
 
   // used for schema stitching
   stitchedSchemas: [],
@@ -132,10 +105,7 @@ export const GraphQLSchema = {
   },
 
   // add resolvers
-  resolvers: {
-    JSON: GraphQLJSON,
-    Date: GraphQLDate,
-  },
+  resolvers: defaultResolvers,
   addResolvers(resolvers) {
     this.resolvers = deepmerge(this.resolvers, resolvers);
   },
@@ -154,150 +124,6 @@ export const GraphQLSchema = {
     this.directives = deepmerge(this.directives, directive);
   },
 
-  // for a given schema, return main type fields, selector fields,
-  // unique selector fields, orderBy fields, creatable fields, and updatable fields
-  getFields(schema, typeName) {
-    const fields = {
-      mainType: [],
-      create: [],
-      update: [],
-      selector: [],
-      selectorUnique: [],
-      orderBy: [],
-    };
-
-    Object.keys(schema).forEach(fieldName => {
-      const field = schema[fieldName];
-      const fieldType = getGraphQLType(schema, fieldName);
-      const inputFieldType = getGraphQLType(schema, fieldName, true);
-
-      // only include fields that are viewable/insertable/editable and don't contain "$" in their name
-      // note: insertable/editable fields must be included in main schema in case they're returned by a mutation
-      // OpenCRUD backwards compatibility
-      if (
-        (field.canRead ||
-          field.canCreate ||
-          field.canUpdate ||
-          field.viewableBy ||
-          field.insertableBy ||
-          field.editableBy) &&
-        fieldName.indexOf('$') === -1
-      ) {
-        const fieldDescription = field.description;
-        const fieldDirective = isIntlField(field) ? '@intl' : '';
-        const fieldArguments = isIntlField(field) ? [{ name: 'locale', type: 'String' }] : [];
-
-        // if field has a resolveAs, push it to schema
-        if (field.resolveAs) {
-          // get resolver name from resolveAs object, or else default to field name
-          const resolverName = field.resolveAs.fieldName || fieldName;
-
-          // use specified GraphQL type or else convert schema type
-          const fieldGraphQLType = field.resolveAs.type || fieldType;
-
-          // if resolveAs is an object, first push its type definition
-          // include arguments if there are any
-          // note: resolved fields are not internationalized
-          fields.mainType.push({
-            description: field.resolveAs.description,
-            name: resolverName,
-            args: field.resolveAs.arguments,
-            type: fieldGraphQLType,
-          });
-
-          // then build actual resolver object and pass it to addGraphQLResolvers
-          const resolver = {
-            [typeName]: {
-              [resolverName]: (document, args, context, info) => {
-                const { Users, currentUser } = context;
-                // check that current user has permission to access the original non-resolved field
-                const canReadField = Users.canReadField(currentUser, field, document);
-                return canReadField
-                  ? field.resolveAs.resolver(document, args, context, info)
-                  : null;
-              },
-            },
-          };
-          addGraphQLResolvers(resolver);
-
-          // if addOriginalField option is enabled, also add original field to schema
-          if (field.resolveAs.addOriginalField && fieldType) {
-            fields.mainType.push({
-              description: fieldDescription,
-              name: fieldName,
-              args: fieldArguments,
-              type: fieldType,
-              directive: fieldDirective,
-            });
-          }
-        } else {
-          // try to guess GraphQL type
-          if (fieldType) {
-            fields.mainType.push({
-              description: fieldDescription,
-              name: fieldName,
-              args: fieldArguments,
-              type: fieldType,
-              directive: fieldDirective,
-            });
-          }
-        }
-
-        // OpenCRUD backwards compatibility
-        if (field.canCreate || field.insertableBy) {
-          fields.create.push({
-            name: fieldName,
-            type: inputFieldType,
-            required: !field.optional,
-          });
-        }
-        // OpenCRUD backwards compatibility
-        if (field.canUpdate || field.editableBy) {
-          fields.update.push({
-            name: fieldName,
-            type: inputFieldType,
-          });
-        }
-
-        // if field is i18nized, add foo_intl field containing all languages
-        // NOTE: not necessary anymore because intl fields are added by addIntlFields() in collections.js
-        // TODO: delete if not needed
-        // if (isIntlField(field)) {
-        //   // fields.mainType.push({
-        //   //   name: `${fieldName}_intl`,
-        //   //   type: '[IntlValue]',
-        //   // });
-        //   fields.create.push({
-        //     name: `${fieldName}_intl`,
-        //     type: '[IntlValueInput]',
-        //   });
-        //   fields.update.push({
-        //     name: `${fieldName}_intl`,
-        //     type: '[IntlValueInput]',
-        //   });
-        // }
-
-        if (field.selectable) {
-          fields.selector.push({
-            name: fieldName,
-            type: inputFieldType,
-          });
-        }
-
-        if (field.selectable && field.unique) {
-          fields.selectorUnique.push({
-            name: fieldName,
-            type: inputFieldType,
-          });
-        }
-
-        if (field.orderable) {
-          fields.orderBy.push(fieldName);
-        }
-      }
-    });
-    return fields;
-  },
 
   // generate a GraphQL schema corresponding to a given collection
   generateSchema(collection) {
@@ -313,7 +139,9 @@ export const GraphQLSchema = {
 
     const schema = collection.simpleSchema()._schema;
 
-    const fields = this.getFields(schema, typeName);
+    const { fields, resolvers: schemaResolvers } = getSchemaFields(schema, typeName);
+    // register the generated resolvers
+    schemaResolvers.forEach(addGraphQLResolvers);
 
     const { interfaces = [], resolvers, mutations } = collection.options;
 
@@ -476,3 +304,4 @@ export const removeGraphQLResolver = GraphQLSchema.removeResolver.bind(GraphQLSc
 export const addToGraphQLContext = GraphQLSchema.addToContext.bind(GraphQLSchema);
 export const addGraphQLDirective = GraphQLSchema.addDirective.bind(GraphQLSchema);
 export const addStitchedSchema = GraphQLSchema.addStitchedSchema.bind(GraphQLSchema);
+

--- a/packages/vulcan-lib/lib/modules/graphql/index.js
+++ b/packages/vulcan-lib/lib/modules/graphql/index.js
@@ -1,0 +1,2 @@
+export * from './graphql';
+export * from './typedefs';

--- a/packages/vulcan-lib/lib/modules/graphql/schemaFields.js
+++ b/packages/vulcan-lib/lib/modules/graphql/schemaFields.js
@@ -1,0 +1,199 @@
+/**
+ * Generate graphQL for Vulcan schema fields
+ */
+import { isIntlField } from '../intl.js';
+
+// get GraphQL type for a given schema and field name
+const getGraphQLType = (schema, fieldName, isInput = false) => {
+  const field = schema[fieldName];
+  const type = field.type.singleType;
+  const typeName =
+    typeof type === 'object' ? 'Object' : typeof type === 'function' ? type.name : type;
+
+  if (field.isIntlData) {
+    return isInput ? '[IntlValueInput]' : '[IntlValue]';
+  }
+
+  switch (typeName) {
+    case 'String':
+      return 'String';
+
+    case 'Boolean':
+      return 'Boolean';
+
+    case 'Number':
+      return 'Float';
+
+    case 'SimpleSchema.Integer':
+      return 'Int';
+
+    // for arrays, look for type of associated schema field or default to [String]
+    case 'Array':
+      const arrayItemFieldName = `${fieldName}.$`;
+      // note: make sure field has an associated array
+      if (schema[arrayItemFieldName]) {
+        // try to get array type from associated array
+        const arrayItemType = getGraphQLType(schema, arrayItemFieldName);
+        return arrayItemType ? `[${arrayItemType}]` : null;
+      }
+      return null;
+
+    case 'Object':
+      return 'JSON';
+
+    case 'Date':
+      return 'Date';
+
+    default:
+      return null;
+  }
+};
+
+  // for a given schema, return main type fields, selector fields,
+  // unique selector fields, orderBy fields, creatable fields, and updatable fields
+export const getSchemaFields = (schema, typeName) => {
+    const fields = {
+      mainType: [],
+      create: [],
+      update: [],
+      selector: [],
+      selectorUnique: [],
+      orderBy: [],
+    };
+    const resolvers = [];
+
+    Object.keys(schema).forEach(fieldName => {
+      const field = schema[fieldName];
+      const fieldType = getGraphQLType(schema, fieldName);
+      const inputFieldType = getGraphQLType(schema, fieldName, true);
+
+      // only include fields that are viewable/insertable/editable and don't contain "$" in their name
+      // note: insertable/editable fields must be included in main schema in case they're returned by a mutation
+      // OpenCRUD backwards compatibility
+      if (
+        (field.canRead ||
+          field.canCreate ||
+          field.canUpdate ||
+          field.viewableBy ||
+          field.insertableBy ||
+          field.editableBy) &&
+        fieldName.indexOf('$') === -1
+      ) {
+        const fieldDescription = field.description;
+        const fieldDirective = isIntlField(field) ? '@intl' : '';
+        const fieldArguments = isIntlField(field) ? [{ name: 'locale', type: 'String' }] : [];
+
+        // if field has a resolveAs, push it to schema
+        if (field.resolveAs) {
+          // get resolver name from resolveAs object, or else default to field name
+          const resolverName = field.resolveAs.fieldName || fieldName;
+
+          // use specified GraphQL type or else convert schema type
+          const fieldGraphQLType = field.resolveAs.type || fieldType;
+
+          // if resolveAs is an object, first push its type definition
+          // include arguments if there are any
+          // note: resolved fields are not internationalized
+          fields.mainType.push({
+            description: field.resolveAs.description,
+            name: resolverName,
+            args: field.resolveAs.arguments,
+            type: fieldGraphQLType,
+          });
+
+          // then build actual resolver object and pass it to addGraphQLResolvers
+          const resolver = {
+            [typeName]: {
+              [resolverName]: (document, args, context, info) => {
+                const { Users, currentUser } = context;
+                // check that current user has permission to access the original non-resolved field
+                const canReadField = Users.canReadField(currentUser, field, document);
+                return canReadField
+                  ? field.resolveAs.resolver(document, args, context, info)
+                  : null;
+              },
+            },
+          };
+          resolvers.push(resolver);
+
+          // if addOriginalField option is enabled, also add original field to schema
+          if (field.resolveAs.addOriginalField && fieldType) {
+            fields.mainType.push({
+              description: fieldDescription,
+              name: fieldName,
+              args: fieldArguments,
+              type: fieldType,
+              directive: fieldDirective,
+            });
+          }
+        } else {
+          // try to guess GraphQL type
+          if (fieldType) {
+            fields.mainType.push({
+              description: fieldDescription,
+              name: fieldName,
+              args: fieldArguments,
+              type: fieldType,
+              directive: fieldDirective,
+            });
+          }
+        }
+
+        // OpenCRUD backwards compatibility
+        if (field.canCreate || field.insertableBy) {
+          fields.create.push({
+            name: fieldName,
+            type: inputFieldType,
+            required: !field.optional,
+          });
+        }
+        // OpenCRUD backwards compatibility
+        if (field.canUpdate || field.editableBy) {
+          fields.update.push({
+            name: fieldName,
+            type: inputFieldType,
+          });
+        }
+
+        // if field is i18nized, add foo_intl field containing all languages
+        // NOTE: not necessary anymore because intl fields are added by addIntlFields() in collections.js
+        // TODO: delete if not needed
+        // if (isIntlField(field)) {
+        //   // fields.mainType.push({
+        //   //   name: `${fieldName}_intl`,
+        //   //   type: '[IntlValue]',
+        //   // });
+        //   fields.create.push({
+        //     name: `${fieldName}_intl`,
+        //     type: '[IntlValueInput]',
+        //   });
+        //   fields.update.push({
+        //     name: `${fieldName}_intl`,
+        //     type: '[IntlValueInput]',
+        //   });
+        // }
+
+        if (field.selectable) {
+          fields.selector.push({
+            name: fieldName,
+            type: inputFieldType,
+          });
+        }
+
+        if (field.selectable && field.unique) {
+          fields.selectorUnique.push({
+            name: fieldName,
+            type: inputFieldType,
+          });
+        }
+
+        if (field.orderable) {
+          fields.orderBy.push(fieldName);
+        }
+      }
+    });
+    return {
+      fields,
+      resolvers
+    };
+  };

--- a/packages/vulcan-lib/lib/modules/graphql/typedefs.js
+++ b/packages/vulcan-lib/lib/modules/graphql/typedefs.js
@@ -1,0 +1,60 @@
+/**
+ * Generate GraphQL typedefs
+ */
+
+
+// schema generation
+const generateQueryType = (queries = []) => 
+  queries.length === 0
+  ? ''
+  : `type Query {
+${queries
+      .map(
+        q =>
+          `${
+          q.description
+            ? `  # ${q.description}
+`
+            : ''
+          }  ${q.query}
+  `
+      )
+      .join('\n')}
+}
+  `;
+
+const generateMutationType = (mutations = []) => 
+  mutations.length === 0
+  ? ''
+  : `type Mutation {
+${mutations
+              .map(
+                m =>
+                  `${
+                    m.description
+                      ? `  # ${m.description}
+`
+                      : ''
+                  }  ${m.mutation}
+`
+              )
+              .join('\n')}
+}
+`;
+
+// typeDefs
+export const generateTypeDefs = (GraphQLSchema) => [
+  `
+scalar JSON
+scalar Date
+
+${GraphQLSchema.getAdditionalSchemas()}
+
+${GraphQLSchema.getCollectionsSchemas()}
+
+${generateQueryType(GraphQLSchema.queries)}
+
+${generateMutationType(GraphQLSchema.mutations)}
+
+`,
+];

--- a/packages/vulcan-lib/lib/modules/index.js
+++ b/packages/vulcan-lib/lib/modules/index.js
@@ -11,7 +11,7 @@ import './icons.js';
 export * from './components.js';
 export * from './collections.js';
 export * from './callbacks.js';
-export * from './graphql.js';
+export * from './graphql';
 export * from './routes.js';
 export * from './utils.js';
 export * from './settings.js';

--- a/packages/vulcan-lib/lib/server/apollo-server/apollo_server.js
+++ b/packages/vulcan-lib/lib/server/apollo-server/apollo_server.js
@@ -89,7 +89,7 @@ export const setupToolsMiddlewares = config => {
  */
 export const createApolloServer = ({
   apolloServerOptions = {}, // apollo options
-  config = {}, // Vulcan options
+  config, // Vulcan options
 }) => {
   // given options contains the schema
   const apolloServer = new ApolloServer({
@@ -101,7 +101,9 @@ export const createApolloServer = ({
   });
 
   // default function does nothing
-  config.configServer(apolloServer);
+  if (config.configServer) {
+    config.configServer(apolloServer);
+  }
 
   return apolloServer;
 };

--- a/packages/vulcan-lib/lib/server/apollo-server/apollo_server.js
+++ b/packages/vulcan-lib/lib/server/apollo-server/apollo_server.js
@@ -25,7 +25,7 @@ import './settings';
 import { engineConfig } from './engine';
 import { initContext, computeContextFromReq } from './context.js';
 
-import { GraphQLSchema } from '../../modules/graphql.js';
+import { GraphQLSchema } from '../../modules/graphql';
 
 import { enableSSR } from '../apollo-ssr';
 

--- a/packages/vulcan-lib/lib/server/apollo-server/context.js
+++ b/packages/vulcan-lib/lib/server/apollo-server/context.js
@@ -15,7 +15,7 @@ import DataLoader from 'dataloader';
 import { Collections } from '../../modules/collections.js';
 import { runCallbacks } from '../../modules/callbacks.js';
 import findByIds from '../../modules/findbyids.js';
-import { GraphQLSchema } from '../../modules/graphql.js';
+import { GraphQLSchema } from '../../modules/graphql';
 import _merge from 'lodash/merge';
 import { getUser } from 'meteor/apollo';
 import { getHeaderLocale } from '../intl.js';

--- a/packages/vulcan-lib/lib/server/apollo-server/initGraphQL.js
+++ b/packages/vulcan-lib/lib/server/apollo-server/initGraphQL.js
@@ -4,72 +4,13 @@
 
 import { makeExecutableSchema } from 'apollo-server';
 import { mergeSchemas } from 'graphql-tools';
-import { GraphQLSchema } from '../../modules/graphql.js';
+import { GraphQLSchema, generateTypeDefs } from '../../modules/graphql';
 import { runCallbacks } from '../../modules/callbacks.js';
 
-const getQueries = () =>
-  `type Query {
-${GraphQLSchema.queries
-    .map(
-      q =>
-        `${
-          q.description
-            ? `  # ${q.description}
-`
-            : ''
-        }  ${q.query}
-  `
-    )
-    .join('\n')}
-}
-
-`;
-const getMutations = () =>
-  GraphQLSchema.mutations.length > 0
-    ? `
-${
-        GraphQLSchema.mutations.length > 0
-          ? `type Mutation {
-
-${GraphQLSchema.mutations
-              .map(
-                m =>
-                  `${
-                    m.description
-                      ? `  # ${m.description}
-`
-                      : ''
-                  }  ${m.mutation}
-`
-              )
-              .join('\n')}
-}
-`
-          : ''
-      }
-
-`
-    : '';
-// typeDefs
-const generateTypeDefs = () => [
-  `
-scalar JSON
-scalar Date
-
-${GraphQLSchema.getAdditionalSchemas()}
-
-${GraphQLSchema.getCollectionsSchemas()}
-
-${getQueries()}
-
-${getMutations()}
-
-`,
-];
 
 const initGraphQL = () => {
   runCallbacks('graphql.init.before');
-  const typeDefs = generateTypeDefs();
+  const typeDefs = generateTypeDefs(GraphQLSchema);
   const executableSchema = makeExecutableSchema({
     typeDefs,
     resolvers: GraphQLSchema.resolvers,

--- a/packages/vulcan-lib/lib/server/apollo-ssr/apolloClient.js
+++ b/packages/vulcan-lib/lib/server/apollo-ssr/apolloClient.js
@@ -9,7 +9,7 @@ import { ApolloClient } from 'apollo-client';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 
 import { SchemaLink } from 'apollo-link-schema';
-import { GraphQLSchema } from '../../modules/graphql.js';
+import { GraphQLSchema } from '../../modules/graphql';
 
 import { createStateLink } from '../../modules/apollo-common';
 import { ApolloLink } from 'apollo-link';

--- a/packages/vulcan-lib/lib/server/site.js
+++ b/packages/vulcan-lib/lib/server/site.js
@@ -1,4 +1,4 @@
-import { addGraphQLSchema, addGraphQLResolvers, addGraphQLQuery } from '../modules/graphql.js';
+import { addGraphQLSchema, addGraphQLResolvers, addGraphQLQuery } from '../modules/graphql';
 import { Utils } from '../modules/utils';
 import { getSetting } from '../modules/settings.js';
 import { getSourceVersion } from './source_version.js';

--- a/packages/vulcan-lib/test/server/graphql.test.js
+++ b/packages/vulcan-lib/test/server/graphql.test.js
@@ -12,10 +12,12 @@ describe('vulcan:lib/graphql', function() {
     expect(() => GraphQLSchema.getExecutableSchema()).toThrow();
   });
   it('can access the graphql schema', function() {
+    GraphQLSchema.init();
     initGraphQL();
     expect(GraphQLSchema.getSchema()).toBeDefined();
   });
   it('can access the executable graphql schema', function() {
+    GraphQLSchema.init();
     initGraphQL();
     expect(GraphQLSchema.getExecutableSchema()).toBeDefined();
   });

--- a/packages/vulcan-lib/test/server/index.js
+++ b/packages/vulcan-lib/test/server/index.js
@@ -1,2 +1,3 @@
 import './graphql.test';
 import './apollo-server.test';
+import './mutators.test';

--- a/packages/vulcan-lib/test/server/mutators.test.js
+++ b/packages/vulcan-lib/test/server/mutators.test.js
@@ -1,6 +1,5 @@
 import expect from 'expect';
 import sinon from 'sinon/pkg/sinon.js';
-console.log('sinon', sinon);
 
 import { createMutator } from '../../lib/server/mutators';
 //import StubCollections from 'meteor/hwillson:stub-collections';

--- a/packages/vulcan-test/lib/server/isoCreateCollection.js
+++ b/packages/vulcan-test/lib/server/isoCreateCollection.js
@@ -1,0 +1,30 @@
+/**
+ * Drop a collection if it already exists
+ * before creating it
+ * 
+ * Thus this function can be replayed indefinitely
+ * Note: this function is async contrary to createCollection
+ * 
+ * FIXME: does not work yet
+ */
+import {
+    createCollection,
+    getCollection
+} from 'meteor/vulcan:core';
+
+export default async (params) => {
+    const ExistingColl = getCollection(params.collectionName);
+    if (ExistingColl) {
+        try {
+            await ExistingColl.rawCollection().drop();
+        } catch (err) {
+            // if collection has been dropped already
+            // mongo will return "ns not found"
+            // can happen when tests are run in parallel
+            if (err.codeName !== 'NamespaceNotFound') {
+                throw err;
+            }
+        }
+    }
+    return createCollection(params);
+};

--- a/packages/vulcan-test/lib/server/main.js
+++ b/packages/vulcan-test/lib/server/main.js
@@ -1,1 +1,2 @@
 export * from '../modules';
+export { default as isoCreateCollection } from './isoCreateCollection';

--- a/packages/vulcan-test/package.js
+++ b/packages/vulcan-test/package.js
@@ -10,6 +10,7 @@ Package.onUse(function (api) {
   api.versionsFrom('1.6.1');
 
   api.use([
+    'vulcan:core@1.12.8',
     'vulcan:lib@1.12.8',
   ]);
   


### PR DESCRIPTION
Hi,

I've added a few tests and cleaned up GraphQL code generation. I've gathered a few remarks:

- `after` callbacks of the createMutation does not seem to be respected. This line `document = await Connectors.get(collection, document._id);` basically overrides them by fetching the document from the database. It thus ignore previously run callbacks. It should be placed before `after` callback are run, while now it is placed after.

- I splitted the code of the `graphql` generation, but actual modifications are minors. I just needed to be able to reset the state in order to write tests and I needed to refactor things a little to wrap my head around existing code.

- I could not drop a collection automatically. I tried to write an `isoCreateCollection` helpers for tests that deletes a collection if it exists already, before creating it. This way we can safely call all our test collections "Foo". More broadly even without this helper dropping collections is useful for cleaning up integration tests without dropping the whole db.

- IntlProvider tests are broken, it seems to be due to some API changes?