### PR TITLE
Update synced-cron across a maintainer change

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -60,7 +60,7 @@ mongo-id@1.0.7
 npm-bcrypt@0.9.3
 npm-mongo@3.1.1
 ordered-dict@1.1.0
-percolatestudio:synced-cron@1.1.0
+littledata:synced-cron@1.3.1
 promise@0.11.1
 random@1.1.0
 rate-limit@1.0.9

--- a/packages/vulcan-core/lib/server/start.js
+++ b/packages/vulcan-core/lib/server/start.js
@@ -1,5 +1,5 @@
 import {Inject} from 'meteor/meteorhacks:inject-initial';
-import { SyncedCron } from 'meteor/percolatestudio:synced-cron';
+import { SyncedCron } from 'meteor/littledata:synced-cron';
 import { getSetting, registerSetting } from 'meteor/vulcan:lib';
 
 registerSetting('mailUrl', null, 'The SMTP URL used to send out email');

--- a/packages/vulcan-lib/package.js
+++ b/packages/vulcan-lib/package.js
@@ -46,7 +46,7 @@ Package.onUse(function(api) {
 
     // 'aldeed:collection2-core@2.0.0',
     'meteorhacks:picker@1.0.3',
-    'percolatestudio:synced-cron@1.1.0',
+    'littledata:synced-cron@1.3.1',
     'meteorhacks:inject-initial@1.0.4',
   ];
 

--- a/packages/vulcan-newsletter/README.md
+++ b/packages/vulcan-newsletter/README.md
@@ -12,7 +12,7 @@ This package schedules an automatic newsletter digest.
 ### Dependencies
 
 - [meteor-mailchimp](https://github.com/MiroHibler/meteor-mailchimp/)
-- [synced-cron](https://github.com/percolatestudio/meteor-synced-cron)
+- [synced-cron](https://github.com/littledata/meteor-synced-cron)
 - [handlebars-server](https://github.com/EventedMind/meteor-handlebars-server)
 - [meteor-npm](https://github.com/arunoda/meteor-npm/)
 

--- a/packages/vulcan-newsletter/lib/server/cron.js
+++ b/packages/vulcan-newsletter/lib/server/cron.js
@@ -1,4 +1,4 @@
-import { SyncedCron } from 'meteor/percolatestudio:synced-cron';
+import { SyncedCron } from 'meteor/littledata:synced-cron';
 import moment from 'moment';
 import Newsletters from '../modules/collection.js';
 import { getSetting, registerSetting } from 'meteor/vulcan:core';

--- a/packages/vulcan-newsletter/lib/server/newsletters.js
+++ b/packages/vulcan-newsletter/lib/server/newsletters.js
@@ -1,6 +1,6 @@
 import Users from 'meteor/vulcan:users';
 import VulcanEmail from 'meteor/vulcan:email';
-import { SyncedCron } from 'meteor/percolatestudio:synced-cron';
+import { SyncedCron } from 'meteor/littledata:synced-cron';
 import Newsletters from '../modules/collection.js';
 import { Utils, getSetting, registerSetting, runCallbacksAsync, Connectors } from 'meteor/vulcan:core';
 

--- a/packages/vulcan-ui-material/.versions
+++ b/packages/vulcan-ui-material/.versions
@@ -54,7 +54,7 @@ mongo-dev-server@1.1.0
 mongo-id@1.0.7
 npm-mongo@3.1.1
 ordered-dict@1.1.0
-percolatestudio:synced-cron@1.1.0
+littledata:synced-cron@1.3.1
 promise@0.11.2
 random@1.1.0
 rate-limit@1.0.9


### PR DESCRIPTION
The `synced-cron` package was stuck on an old version (1.1.0, late 2014) because when it changed maintainers, it also changed package name. The newer versions include some somewhat important bug fixes; so, upgrade.

This is a breaking change! If you're using Vulcan, you will need to replace imports of `percolatestudio:synced-cron` with imports of `littledata:synced-cron`.