### PR TITLE
Fix punctuation of password-change message

### DIFF
--- a/packages/vulcan-accounts/imports/ui/components/EnrollAccount.jsx
+++ b/packages/vulcan-accounts/imports/ui/components/EnrollAccount.jsx
@@ -20,7 +20,7 @@ class AccountsEnrollAccount extends PureComponent {
     } else {
       return (
         <div className='password-reset-form'>
-          <div>{this.context.intl.formatMessage({id: 'accounts.info_password_changed'})}!</div>
+          <div>{this.context.intl.formatMessage({id: 'accounts.info_password_changed'})}</div>
         </div>
       );
     }

--- a/packages/vulcan-accounts/imports/ui/components/ResetPassword.jsx
+++ b/packages/vulcan-accounts/imports/ui/components/ResetPassword.jsx
@@ -20,7 +20,7 @@ class AccountsResetPassword extends PureComponent {
     } else {
       return (
         <div className='password-reset-form'>
-          <div>{this.context.intl.formatMessage({id: 'accounts.info_password_changed'})}!</div>
+          <div>{this.context.intl.formatMessage({id: 'accounts.info_password_changed'})}</div>
         </div>
       );
     }


### PR DESCRIPTION
The password change message was "Password changed.!" with irregular punctuation (`.!`). This is because the i18n messages ended with a period, while the component was adding an exclamation point. Take out the exclamation point, so that it's "Password changed.".