### PR TITLE
Add skipConversion option to mongo connectors

### DIFF
--- a/packages/vulcan-lib/lib/server/connectors/mongo.js
+++ b/packages/vulcan-lib/lib/server/connectors/mongo.js
@@ -15,22 +15,27 @@ const convertUniqueSelector = selector => {
 };
 
 DatabaseConnectors.mongo = {
-  get: async (collection, selector = {}, options = {}) => {
-    return await collection.findOne(convertUniqueSelector(selector), options);
+  get: async (collection, selector = {}, options = {}, skipConversion) => {
+    const convertedSelector = skipConversion ? selector : convertUniqueSelector(selector)
+    return await collection.findOne(convertedSelector, options);
   },
-  find: async (collection, selector = {}, options = {}) => {
-    return await collection.find(convertSelector(selector), options).fetch();
+  find: async (collection, selector = {}, options = {}, skipConversion) => {
+    const convertedSelector = skipConversion ? selector : convertUniqueSelector(selector)
+    return await collection.find(convertedSelector, options).fetch();
   },
-  count: async (collection, selector = {}, options = {}) => {
-    return await collection.find(convertSelector(selector), options).count();
+  count: async (collection, selector = {}, options = {}, skipConversion) => {
+    const convertedSelector = skipConversion ? selector : convertUniqueSelector(selector)
+    return await collection.find(convertedSelector, options).count();
   },
   create: async (collection, document, options = {}) => {
     return await collection.insert(document);
   },
-  update: async (collection, selector, modifier, options = {}) => {
-    return await collection.update(convertUniqueSelector(selector), modifier, options);
+  update: async (collection, selector, modifier, options = {}, skipConversion) => {
+    const convertedSelector = skipConversion ? selector : convertUniqueSelector(selector)
+    return await collection.update(convertedSelector, modifier, options);
   },
-  delete: async (collection, selector, options = {}) => {
-    return await collection.remove(convertUniqueSelector(selector));
+  delete: async (collection, selector, options = {}, skipConversion) => {
+    const convertedSelector = skipConversion ? selector : convertUniqueSelector(selector)
+    return await collection.remove(convertedSelector);
   },
 };


### PR DESCRIPTION
As part of the Vulcan 1.13/Apollo2 upgrade, I've been going through the places where LessWrong has diverged from mainline Vulcan and assessing/upstreaming things. I was on the fence about whether to upstream this one, and am on the fence about whether it should be merged, but, well, here it is.

An earlier Vulcan upgrade (1.12 I think) made it so that `documentId` had special meaning in queries, and would be replaced with `_id`. But LessWrong was already using `documentId` as a field name in a number of collections, identifying what object things refer to in some other table. For example, vote._id identifies a vote, vote.documentId identifies the thing voted on. (`vulcan-voting` still has this name conflict, though we have diverged from it heavily otherwise.)

Now that ID conversion is added, other projects may be relying on it so it may be hard to remove. So we added a safety valve, a `skipConversion` option on each of the Mongo connector operations, which makes `documentId` work as a regular field name, as it originally did.