### PR TITLE
Mutation HoCs give equality-comparison-stable props

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/withCreate.js
+++ b/packages/vulcan-core/lib/modules/containers/withCreate.js
@@ -31,6 +31,7 @@ import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
 import { createClientTemplate } from 'meteor/vulcan:core';
 import { extractCollectionInfo, extractFragmentInfo } from 'meteor/vulcan:lib';
+import { compose, withHandlers } from 'recompose';
 
 const withCreate = options => {
   const { collectionName, collection } = extractCollectionInfo(options);
@@ -42,25 +43,27 @@ const withCreate = options => {
     ${fragment}
   `;
 
+  const withHandlersOptions = {
+    [`create${typeName}`]: ({ mutate, ownProps }) => args => {
+      const { data } = args;
+      return mutate({
+        variables: { data }
+      });
+    },
+    // OpenCRUD backwards compatibility
+    newMutation: ({ mutate, ownProps }) => args => {
+      const { document } = args;
+      return mutate({
+        variables: { data: document }
+      });
+    }
+  }    
+
   // wrap component with graphql HoC
-  return graphql(query, {
-    alias: `withCreate${typeName}`,
-    props: ({ ownProps, mutate }) => ({
-      [`create${typeName}`]: args => {
-        const { data } = args;
-        return mutate({
-          variables: { data }
-        });
-      },
-      // OpenCRUD backwards compatibility
-      newMutation: args => {
-        const { document } = args;
-        return mutate({
-          variables: { data: document }
-        });
-      }
-    })
-  });
+  return compose(
+    graphql(query, {alias: `withCreate${typeName}`}),
+    withHandlers(withHandlersOptions)
+  )
 };
 
 export default withCreate;

--- a/packages/vulcan-core/lib/modules/containers/withUpdate.js
+++ b/packages/vulcan-core/lib/modules/containers/withUpdate.js
@@ -29,6 +29,7 @@ Child Props:
 
 import React, { Component } from 'react';
 import { graphql } from 'react-apollo';
+import { compose, withHandlers } from 'recompose';
 import gql from 'graphql-tag';
 import { updateClientTemplate, extractCollectionInfo, extractFragmentInfo } from 'meteor/vulcan:lib';
 import clone from 'lodash/clone';
@@ -43,32 +44,34 @@ const withUpdate = options => {
     ${fragment}
   `;
 
-  return graphql(query, {
-    alias: `withUpdate${typeName}`,
-    props: ({ ownProps, mutate }) => ({
-      [`update${typeName}`]: args => {
-        const { selector, data } = args;
-        return mutate({
-          variables: { selector, data }
-          // note: updateQueries is not needed for editing documents
+  const withHandlersOptions = {
+    [`update${typeName}`]: ({ mutate, ownProps }) => args => {
+      const { selector, data } = args;
+      return mutate({
+        variables: { selector, data }
+        // note: updateQueries is not needed for editing documents
+      });
+    },
+    // OpenCRUD backwards compatibility
+    editMutation: ({ mutate, ownProps }) => args => {
+      const { documentId, set, unset } = args;
+      const selector = { documentId };
+      const data = clone(set);
+      unset &&
+        Object.keys(unset).forEach(fieldName => {
+          data[fieldName] = null;
         });
-      },
-      // OpenCRUD backwards compatibility
-      editMutation: args => {
-        const { documentId, set, unset } = args;
-        const selector = { documentId };
-        const data = clone(set);
-        unset &&
-          Object.keys(unset).forEach(fieldName => {
-            data[fieldName] = null;
-          });
-        return mutate({
-          variables: { selector, data }
-          // note: updateQueries is not needed for editing documents
-        });
-      }
-    })
-  });
+      return mutate({
+        variables: { selector, data }
+        // note: updateQueries is not needed for editing documents
+      });
+    }
+  }
+  
+  return compose(
+    graphql(query, {alias: `withUpdate${typeName}`}),
+    withHandlers(withHandlersOptions)
+  )
 };
 
 export default withUpdate;

--- a/packages/vulcan-core/lib/modules/containers/withUpsert.js
+++ b/packages/vulcan-core/lib/modules/containers/withUpsert.js
@@ -32,7 +32,7 @@ import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
 import { upsertClientTemplate } from 'meteor/vulcan:core';
 import clone from 'lodash/clone';
-
+import { compose, withHandlers } from 'recompose';
 import { extractCollectionInfo, extractFragmentInfo } from 'meteor/vulcan:lib';
 
 const withUpsert = options => {
@@ -45,32 +45,34 @@ const withUpsert = options => {
     ${fragment}
   `;
 
-  return graphql(query, {
-    alias: `withUpsert${typeName}`,
-    props: ({ ownProps, mutate }) => ({
-      [`upsert${typeName}`]: args => {
-        const { selector, data } = args;
-        return mutate({
-          variables: { selector, data }
-          // note: updateQueries is not needed for editing documents
+  const withHandlersOptions = {
+    [`upsert${typeName}`]: ({ mutate, ownProps }) => args => {
+      const { selector, data } = args;
+      return mutate({
+        variables: { selector, data }
+        // note: updateQueries is not needed for editing documents
+      });
+    },
+    // OpenCRUD backwards compatibility
+    upsertMutation: ({ mutate, ownProps }) => args => {
+      const { selector, set, unset } = args;
+      const data = clone(set);
+      unset &&
+        Object.keys(unset).forEach(fieldName => {
+          data[fieldName] = null;
         });
-      },
+      return mutate({
+        variables: { selector, data }
+        // note: updateQueries is not needed for editing documents
+      });
+    }
+  }    
 
-      // OpenCRUD backwards compatibility
-      upsertMutation: args => {
-        const { selector, set, unset } = args;
-        const data = clone(set);
-        unset &&
-          Object.keys(unset).forEach(fieldName => {
-            data[fieldName] = null;
-          });
-        return mutate({
-          variables: { selector, data }
-          // note: updateQueries is not needed for editing documents
-        });
-      }
-    })
-  });
+  return compose(
+    graphql(query, {alias: `withUpsert${typeName}`}),
+    withHandlers(withHandlersOptions)
+  )
+  
 };
 
 export default withUpsert;


### PR DESCRIPTION
As part of upgrading to Vulcan 1.13/Apollo2, I'm going throw places where LW has diverged and upstreaming changes.

React decides which parts of the tree need to be rerendered by comparing component props, assuming that if a component's old and new props don't compare as equal (===), the component needs to be rerendered. If a prop is a callback or an object, and hasn't truly changed but has been reconstructed, it will compare as not-equal and cause a rerender. Vulcan's mutator HoCs add some callbacks to props, which you can call to perform mutations, but they get reconstructed - and, therefore, compare as not-equal - on every render. This caused some performance problems on LW.

This shuffles the construction of objects and callbacks around a bit, to prevent spurious rerenders caused by some Vulcan mutation HoCs. It does not cover every HoC. More importantly, this has (so far) only been  tested on Vulcan 1.12/Apollo1, and it's possible that some subtleties of the `graphql` function have changed, so it should be retested (both for not-breaking-anything and for not-rerendering) on Vulcan 1.13.