### PR TITLE
Fix a crash when using addFields together with a recursive schema

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -477,7 +477,8 @@ class SmartForm extends Component {
       // get nested schema
       // for each nested field, get field object by calling createField recursively
       field.nestedFields = this.getFieldNames({
-        schema: field.nestedSchema
+        schema: field.nestedSchema,
+        addExtraFields: false
       }).map(subFieldName => {
         return this.createField(
           subFieldName,


### PR DESCRIPTION
Forms have an `addField` prop, which can be used to override the defaults of which fields are visible in a form. We use this in combination with a custom submit button to make comment boxes show for logged out users (who don't have write/create access to the relevant fields). But it turns out that if you have a nested schema, it tries to add the extra fields into the subschema, not just the root schema, resulting in a crash.