### PR TITLE
Fix a falsy-vs-undefined bug in getSetting

### DIFF
--- a/packages/vulcan-lib/lib/modules/settings.js
+++ b/packages/vulcan-lib/lib/modules/settings.js
@@ -69,7 +69,8 @@ export const getSetting = (settingName, settingDefault) => {
   let setting;
 
   // if a default value has been registered using registerSetting, use it
-  const defaultValue = settingDefault || Settings[settingName] && Settings[settingName].defaultValue;
+  if (typeof settingDefault === 'undefined' && Settings[settingName])
+    settingDefault = Settings[settingName].defaultValue;
 
   if (Meteor.isServer) {
     // look in public, private, and root
@@ -80,7 +81,7 @@ export const getSetting = (settingName, settingDefault) => {
     // if setting is an object, "collect" properties from all three places
     if (typeof rootSetting === 'object' || typeof privateSetting === 'object' || typeof publicSetting === 'object') {
       setting = {
-        ...defaultValue,
+        ...settingDefault,
         ...rootSetting,
         ...privateSetting,
         ...publicSetting,
@@ -93,14 +94,14 @@ export const getSetting = (settingName, settingDefault) => {
       } else if (typeof publicSetting !== 'undefined') {
         setting = publicSetting;
       } else {
-        setting = defaultValue;
+        setting = settingDefault;
       }
     }
 
   } else {
     // look only in public
     const publicSetting = Meteor.settings.public && getNestedProperty(Meteor.settings.public, settingName);
-    setting = typeof publicSetting !== 'undefined' ? publicSetting : defaultValue;
+    setting = typeof publicSetting !== 'undefined' ? publicSetting : settingDefault;
   }
 
   // Settings[settingName] = {...Settings[settingName], settingValue: setting};


### PR DESCRIPTION
`getSetting` was checking its `settingDefault` parameter for truthiness, rather than for presence. This meant that if you pass a settingDefault of false, and the setting isn't defined and doesn't have a registered default, then instead of getting false you'll get undefined. This caused some subtle breakage in LessWrong when the result of getSetting was then used in a mongodb selector, where undefined and false have very different meanings.