### PR TITLE
add consideration to default values on accounts extra fields

### DIFF
--- a/packages/vulcan-accounts/imports/ui/components/LoginFormInner.jsx
+++ b/packages/vulcan-accounts/imports/ui/components/LoginFormInner.jsx
@@ -105,6 +105,13 @@ export class AccountsLoginFormInner extends TrackerComponent {
       ...this.getDefaultFieldValues(),
     }));
 
+    // if extra fields have been specified, add their default values
+    if (this.props.extraFields) {
+      this.props.extraFields.forEach(field => {
+        this.setState({ [field.id]: field.defaultValue});
+      });
+    }
+
     // Listen for the user to login/logout.
     this.autorun(() => {
 
@@ -278,7 +285,7 @@ export class AccountsLoginFormInner extends TrackerComponent {
         };
       });
     }
-      
+
     if (!hasPasswordService() && getLoginServices().length == 0) {
       loginFields.push({
         label: 'No login service added, i.e. accounts-password',
@@ -783,7 +790,7 @@ export class AccountsLoginFormInner extends TrackerComponent {
         options[id] = this.state[id];
       });
     }
-    
+
     const self = this;
 
     let error = false;


### PR DESCRIPTION
This will respect defaultValue on extraFields in AccountsLoginForm, even with no onChange event triggered, and will allow hidden fields when needed

Should also fix #2258