### PR TITLE
[WIP] fix MUI inputProperties handling

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -4,11 +4,11 @@
 import { addDecorator, configure } from '@storybook/react';
 
 // init UI using a Decorator
-//import BootstrapDecorator from './decorators/BootstrapDecorator'
-//addDecorator(BootstrapDecorator)
+import BootstrapDecorator from './decorators/BootstrapDecorator'
+addDecorator(BootstrapDecorator)
 // Uncomment to activate material UI instead
-import MaterialUIDecorator from './decorators/MaterialUIDecorator'
-addDecorator(MaterialUIDecorator)
+// import MaterialUIDecorator from './decorators/MaterialUIDecorator'
+// addDecorator(MaterialUIDecorator)
 
 /*
 

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -4,11 +4,11 @@
 import { addDecorator, configure } from '@storybook/react';
 
 // init UI using a Decorator
-import BootstrapDecorator from './decorators/BootstrapDecorator'
-addDecorator(BootstrapDecorator)
+//import BootstrapDecorator from './decorators/BootstrapDecorator'
+//addDecorator(BootstrapDecorator)
 // Uncomment to activate material UI instead
-//import MaterialUIDecorator from './decorators/MaterialUIDecorator'
-//addDecorator(MaterialUIDecorator)
+import MaterialUIDecorator from './decorators/MaterialUIDecorator'
+addDecorator(MaterialUIDecorator)
 
 /*
 

--- a/packages/vulcan-lib/lib/modules/ui_utils.js
+++ b/packages/vulcan-lib/lib/modules/ui_utils.js
@@ -4,7 +4,7 @@
  * @returns Initial props + props specific to the HTML input in an inputProperties object
  */
 export const getHtmlInputProps = props => {
-  const { name, path, options, label, onChange, value, disabled } = props;
+  const { name, path, options, label, onChange, onBlur, value, disabled } = props;
 
   // these properties are whitelisted so that they can be safely passed to the actual form input
   // and avoid https://facebook.github.io/react/warnings/unknown-prop.html warnings
@@ -14,6 +14,7 @@ export const getHtmlInputProps = props => {
     options,
     label,
     onChange,
+    onBlur,
     value,
     disabled,
     ...props.inputProperties,

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiCheckboxGroup.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiCheckboxGroup.jsx
@@ -77,8 +77,9 @@ const MuiCheckboxGroup = createReactClass({
   
   changeCheckbox: function () {
     const value = [];
-    this.props.options.forEach(function (option, key) {
-      if (this[this.props.name + '-' + option.value].checked) {
+    const { options, name } = this.props.inputProperties;
+    options.forEach(function (option, key) {
+      if (this[name + '-' + option.value].checked) {
         value.push(option.value);
       }
     }.bind(this));
@@ -94,10 +95,11 @@ const MuiCheckboxGroup = createReactClass({
   },
   
   renderElement: function () {
-    const controls = this.props.options.map((checkbox, key) => {
+    const { name, options, disabled: _disabled } = this.props.inputProperties;
+    const controls = options.map((checkbox, key) => {
       let value = checkbox.value;
-      let checked = (this.props.value.indexOf(value) !== -1);
-      let disabled = checkbox.disabled || this.props.disabled;
+      let checked = (value.indexOf(value) !== -1);
+      let disabled = checkbox.disabled || _disabled;
       const Component = this.props.variant === 'switch' ? Switch : Checkbox;
       
       return (
@@ -105,7 +107,7 @@ const MuiCheckboxGroup = createReactClass({
           key={key}
           control={
             <Component
-              inputRef={(c) => this[this.props.name + '-' + value] = c}
+              inputRef={(c) => this[name + '-' + value] = c}
               checked={checked}
               onChange={this.changeCheckbox}
               value={value}
@@ -117,7 +119,7 @@ const MuiCheckboxGroup = createReactClass({
       );
     });
     
-    const maxLength = this.props.options.reduce((max, option) =>
+    const maxLength = options.reduce((max, option) =>
       option.label.length > max ? option.label.length : max, 0);
   
     const columnClass = maxLength < 20 ? 'threeColumn' : maxLength < 30 ? 'twoColumn' : '';

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiRadioGroup.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiRadioGroup.jsx
@@ -66,11 +66,13 @@ const styles = theme => ({
 const MuiRadioGroup = createReactClass({
   
   mixins: [ComponentMixin],
-  
+
   propTypes: {
-    name: PropTypes.string.isRequired,
     type: PropTypes.oneOf(['inline', 'stacked']),
-    options: PropTypes.array.isRequired
+    inputProperties: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      options: PropTypes.array.isRequired
+    })
   },
   
 
@@ -98,9 +100,10 @@ const MuiRadioGroup = createReactClass({
   },
   
   renderElement: function () {
-    const controls = this.props.options.map((radio, key) => {
-      let checked = (this.props.value === radio.value);
-      let disabled = radio.disabled || this.props.disabled;
+    const { options, value, name, disabled: _disabled } = this.props.inputProperties;
+    const controls = options.map((radio, key) => {
+      let checked = (value === radio.value);
+      let disabled = radio.disabled || _disabled;
       
       return (
         <FormControlLabel
@@ -118,7 +121,7 @@ const MuiRadioGroup = createReactClass({
       );
     });
     
-    const maxLength = this.props.options.reduce((max, option) =>
+    const maxLength = options.reduce((max, option) =>
       option.label.length > max ? option.label.length : max, 0);
     
     let columnClass = maxLength < 18 ? 'threeColumn' : maxLength < 30 ? 'twoColumn' : '';
@@ -126,10 +129,10 @@ const MuiRadioGroup = createReactClass({
     
     return (
       <RadioGroup
-        aria-label={this.props.name}
-        name={this.props.name}
+        aria-label={name}
+        name={name}
         className={classNames(this.props.classes.group, this.props.classes[columnClass])}
-        value={this.props.value}
+        value={value}
         onChange={this.changeRadio}
       >
         {controls}

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiSuggest.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiSuggest.jsx
@@ -309,6 +309,7 @@ const MuiSuggest = createReactClass({
           name: this.props.name,
           'aria-haspopup': 'true',
           ...this.props.inputProps,
+          ...this.props.inputProperties,
           startAdornment,
           endAdornment,
         }}

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiSwitch.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiSwitch.jsx
@@ -47,6 +47,7 @@ const MuiSwitch = createReactClass({
   },
   
   renderElement: function () {
+    const { disabled, value, label } = this.props.inputProperties;
     return (
       <FormControlLabel
         control={
@@ -54,12 +55,12 @@ const MuiSwitch = createReactClass({
             ref={(c) => this.element = c}
             {...this.cleanSwitchProps(this.cleanProps(this.props))}
             id={this.getId()}
-            checked={this.props.value === true}
+            checked={value === true}
             onChange={this.changeValue}
-            disabled={this.props.disabled}
+            disabled={disabled}
           />
         }
-        label={this.props.label}
+        label={label}
       />
     );
   },

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Checkbox.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Checkbox.jsx
@@ -3,8 +3,8 @@ import MuiSwitch from '../base-controls/MuiSwitch';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
-const CheckboxComponent = ({ refFunction, inputProperties }) =>
-  <MuiSwitch {...inputProperties} ref={refFunction}/>;
+const CheckboxComponent = ({ refFunction, ...properties }) =>
+  <MuiSwitch {...properties} ref={refFunction}/>;
 
 
 registerComponent('FormComponentCheckbox', CheckboxComponent);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/CheckboxGroup.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/CheckboxGroup.jsx
@@ -3,8 +3,8 @@ import MuiCheckboxGroup from '../base-controls/MuiCheckboxGroup';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
-const CheckboxGroupComponent = ({ refFunction, inputProperties }) =>
-  <MuiCheckboxGroup {...inputProperties} ref={refFunction}/>;
+const CheckboxGroupComponent = ({ refFunction, ...properties }) =>
+  <MuiCheckboxGroup {...properties} ref={refFunction}/>;
 
 
 registerComponent('FormComponentCheckboxGroup', CheckboxGroupComponent);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Date.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Date.jsx
@@ -29,7 +29,7 @@ export const styles = theme => ({
   
 });
 
-const DateComponent = ({ refFunction, classes, inputProperties }) =>
-  <MuiPicker {...inputProperties} {...classes} ref={refFunction}/>;
+const DateComponent = ({ refFunction, classes, ...properties }) =>
+  <MuiPicker {...properties} {...classes} ref={refFunction}/>;
 
 registerComponent('FormComponentDate', DateComponent, [withStyles, styles]);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/DateTime.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/DateTime.jsx
@@ -30,8 +30,8 @@ export const styles = theme => ({
 });
 
 
-const DateTimeComponent = ({ refFunction, classes, inputProperties }) =>
-  <MuiInput {...inputProperties} ref={refFunction} type="datetime-local"/>;
+const DateTimeComponent = ({ refFunction, classes, ...properties }) =>
+  <MuiInput {...properties} ref={refFunction} type="datetime-local"/>;
 
 
 registerComponent('FormComponentDateTime', DateTimeComponent, [withStyles, styles]);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Default.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Default.jsx
@@ -3,8 +3,8 @@ import MuiInput from '../base-controls/MuiInput';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
-const Default = ({ refFunction, inputProperties }) =>
-  <MuiInput {...inputProperties} ref={refFunction}/>;
+const Default = ({ refFunction, ...properties }) =>
+  <MuiInput {...properties} ref={refFunction}/>;
 
 
 registerComponent('FormComponentDefault', Default);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Email.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Email.jsx
@@ -3,8 +3,8 @@ import MuiInput from '../base-controls/MuiInput';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
-const EmailComponent = ({ refFunction, inputProperties }) =>
-  <MuiInput {...inputProperties} ref={refFunction} type="email" />;
+const EmailComponent = ({ refFunction, ...properties }) =>
+  <MuiInput {...properties} ref={refFunction} type="email" />;
 
 
 registerComponent('FormComponentEmail', EmailComponent);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Number.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Number.jsx
@@ -3,8 +3,8 @@ import MuiInput from '../base-controls/MuiInput';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
-const NumberComponent = ({ refFunction, inputProperties }) =>
-  <MuiInput {...inputProperties} ref={refFunction} type="number" />;
+const NumberComponent = ({ refFunction, ...properties }) =>
+  <MuiInput {...properties} ref={refFunction} type="number" />;
 
 
 registerComponent('FormComponentNumber', NumberComponent);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/PostalCode.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/PostalCode.jsx
@@ -4,11 +4,11 @@ import { registerComponent } from 'meteor/vulcan:core';
 import { getCountryInfo } from './RegionSelect';
 
 
-const PostalCode = ({ classes, refFunction, inputProperties, ...properties }) => {
+const PostalCode = ({ classes, refFunction,  ...properties }) => {
   const currentCountryInfo = getCountryInfo(properties);
   const postalLabel = currentCountryInfo ? currentCountryInfo.postalLabel : 'Postal code';
   
-  return <MuiInput {...inputProperties} ref={refFunction} label={postalLabel}/>;
+  return <MuiInput {...properties} ref={refFunction} label={postalLabel}/>;
 };
 
 

--- a/packages/vulcan-ui-material/lib/components/forms/controls/RadioGroup.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/RadioGroup.jsx
@@ -3,8 +3,8 @@ import MuiRadioGroup from '../base-controls/MuiRadioGroup';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
-const RadioGroupComponent = ({ refFunction, inputProperties }) => {
-  return <MuiRadioGroup {...inputProperties} ref={refFunction}/>;
+const RadioGroupComponent = ({ refFunction, ...properties }) => {
+  return <MuiRadioGroup {...properties} ref={refFunction}/>;
 };
 
 

--- a/packages/vulcan-ui-material/lib/components/forms/controls/RegionSelect.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/RegionSelect.jsx
@@ -21,9 +21,9 @@ const RegionSelect = ({ classes, refFunction, inputProperties, ...properties }) 
   const regionLabel = currentCountryInfo ? currentCountryInfo.regionLabel : 'Region';
   
   if (options) {
-    return <MuiSuggest {...inputProperties} ref={refFunction} options={options} label={regionLabel}/>;
+    return <MuiSuggest inputProperties={inputProperties} {...properties} ref={refFunction} options={options} label={regionLabel}/>;
   } else {
-    return <MuiInput {...inputProperties} ref={refFunction} label={regionLabel}/>;
+    return <MuiInput inputProperties={inputProperties} {...properties} ref={refFunction} label={regionLabel}/>;
   }
 };
 

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Select.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Select.jsx
@@ -3,11 +3,11 @@ import MuiSelect from '../base-controls/MuiSelect';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
-const SelectComponent = ({ refFunction, inputProperties }) => {
+const SelectComponent = ({ refFunction, inputProperties, ...properties }) => {
   const noneOption = { label: '', value: '' };
   const options = [noneOption, ...inputProperties.options];
   
-  return <MuiSelect {...inputProperties} options={options} ref={refFunction}/>;
+  return <MuiSelect inputProperties={inputProperties} {...properties} options={options} ref={refFunction}/>;
 };
 
 

--- a/packages/vulcan-ui-material/lib/components/forms/controls/SelectMultiple.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/SelectMultiple.jsx
@@ -3,8 +3,8 @@ import MuiSelect from '../base-controls/MuiSelect';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
-const SelectMultiple = ({ refFunction, inputProperties }) => {
-  return <MuiSelect {...inputProperties} multiple={true} ref={refFunction}/>;
+const SelectMultiple = ({ refFunction, ...properties }) => {
+  return <MuiSelect {...properties} multiple={true} ref={refFunction}/>;
 };
 
 

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Textarea.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Textarea.jsx
@@ -3,10 +3,11 @@ import MuiInput from '../base-controls/MuiInput';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
-const TextareaComponent = ({ refFunction, inputProperties }) =>
-  <MuiInput {...inputProperties}
+const TextareaComponent = ({ refFunction, inputProperties, ...properties }) =>
+  <MuiInput {...properties}
             ref={refFunction}
             multiline={true}
+            inputProperties={inputProperties}
             rows={inputProperties.rows ? inputProperties.rows : 2}
             rowsMax={10}
   />;

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Time.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Time.jsx
@@ -30,8 +30,8 @@ export const styles = theme => ({
 });
 
 
-const TimeComponent = ({ refFunction, classes, inputProperties }) =>
-  <MuiInput {...inputProperties} ref={refFunction} type="time"/>;
+const TimeComponent = ({ refFunction, classes, ...properties }) =>
+  <MuiInput {...properties} ref={refFunction} type="time"/>;
 
 
 registerComponent('FormComponentTime', TimeComponent, [withStyles, styles]);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Url.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Url.jsx
@@ -3,8 +3,8 @@ import MuiInput from '../base-controls/MuiInput';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
-const UrlComponent = ({ refFunction, inputProperties }) =>
-  <MuiInput {...inputProperties} ref={refFunction} type="url" />;
+const UrlComponent = ({ refFunction, ...properties }) =>
+  <MuiInput {...properties} ref={refFunction} type="url" />;
 
 
 registerComponent('FormComponentUrl', UrlComponent);


### PR DESCRIPTION
Hi,
As suggested by @justinr1234 we may have regression in Material UI forms in the current implementation. `inputProperties` are taken into account, but they overshadow props specific to Material UI inputs.

I tried to provide a solution here, @justinr1234 what's your opinon on this?

I've had some troubles with `inputProps` prop of Material UI, because it seems to create unexpected behaviour. Eg if `inputProps` is defined, then the top level `onChange` seems to be ignored.