### PR TITLE
inputProperties function parameters bug

### DIFF
--- a/packages/vulcan-lib/lib/modules/ui_utils.js
+++ b/packages/vulcan-lib/lib/modules/ui_utils.js
@@ -9,6 +9,7 @@ export const getHtmlInputProps = props => {
   // these properties are whitelisted so that they can be safely passed to the actual form input
   // and avoid https://facebook.github.io/react/warnings/unknown-prop.html warnings
   const inputProperties = {
+    ...props.inputProperties,
     name,
     path,
     options,
@@ -17,7 +18,6 @@ export const getHtmlInputProps = props => {
     onBlur,
     value,
     disabled,
-    ...props.inputProperties,
   };
 
   return {


### PR DESCRIPTION
When the schema defines inputProperties.disabled as a function, it's already evaluated to a boolean by this point. However props.inputProperties still has it as a function. Having ...props.inputProperties at the end of the spread overwrites the boolean with the function, resulting in an error.