### PR TITLE
Fixed MuiCheckBoxGroup

### DIFF
--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiCheckboxGroup.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiCheckboxGroup.jsx
@@ -77,8 +77,9 @@ const MuiCheckboxGroup = createReactClass({
   
   changeCheckbox: function () {
     const value = [];
-    this.props.options.forEach(function (option, key) {
-      if (this[this.props.name + '-' + option.value].checked) {
+    const { options, name } = this.props.inputProperties;
+    options.forEach(function (option, key) {
+      if (this[name + '-' + option.value].checked) {
         value.push(option.value);
       }
     }.bind(this));
@@ -94,10 +95,11 @@ const MuiCheckboxGroup = createReactClass({
   },
   
   renderElement: function () {
-    const controls = this.props.options.map((checkbox, key) => {
-      let value = checkbox.value;
-      let checked = (this.props.value.indexOf(value) !== -1);
-      let disabled = checkbox.disabled || this.props.disabled;
+    const { name, options, disabled: _disabled, value:_values } = this.props.inputProperties;
+    const controls = options.map((checkbox, key) => {
+      let checkboxValue = checkbox.value;
+      let checked = (_values.indexOf(checkboxValue) !== -1);
+      let disabled = checkbox.disabled || _disabled;
       const Component = this.props.variant === 'switch' ? Switch : Checkbox;
       
       return (
@@ -105,10 +107,10 @@ const MuiCheckboxGroup = createReactClass({
           key={key}
           control={
             <Component
-              inputRef={(c) => this[this.props.name + '-' + value] = c}
+              inputRef={(c) => this[name + '-' + checkboxValue] = c}
               checked={checked}
               onChange={this.changeCheckbox}
-              value={value}
+              value={checkboxValue}
               disabled={disabled}
             />
           }
@@ -117,7 +119,7 @@ const MuiCheckboxGroup = createReactClass({
       );
     });
     
-    const maxLength = this.props.options.reduce((max, option) =>
+    const maxLength = options.reduce((max, option) =>
       option.label.length > max ? option.label.length : max, 0);
   
     const columnClass = maxLength < 20 ? 'threeColumn' : maxLength < 30 ? 'twoColumn' : '';
@@ -130,7 +132,6 @@ const MuiCheckboxGroup = createReactClass({
   },
   
   render: function () {
-    
     if (this.props.layout === 'elementOnly') {
       return (
         <div>{this.renderElement()}</div>


### PR DESCRIPTION
With the commit before, all check box were selected from the beginning and couldn't be unselected. This is fixed.