### PR TITLE
fix radiogroup for numbers

### DIFF
--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiRadioGroup.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiRadioGroup.jsx
@@ -10,7 +10,6 @@ import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import classNames from 'classnames';
 
-
 const styles = theme => ({
   group: {
     marginTop: '8px',
@@ -62,22 +61,18 @@ const styles = theme => ({
   },
 });
 
-
 const MuiRadioGroup = createReactClass({
-  
   mixins: [ComponentMixin],
 
   propTypes: {
     type: PropTypes.oneOf(['inline', 'stacked']),
     inputProperties: PropTypes.shape({
       name: PropTypes.string.isRequired,
-      options: PropTypes.array.isRequired
-    })
+      options: PropTypes.array.isRequired,
+    }),
   },
-  
 
-  
-  getDefaultProps: function () {
+  getDefaultProps: function() {
     return {
       type: 'stacked',
       label: '',
@@ -85,77 +80,77 @@ const MuiRadioGroup = createReactClass({
       classes: PropTypes.object.isRequired,
     };
   },
-  
-  changeRadio: function (event) {
+
+  changeRadio: function(event) {
     const value = event.target.value;
     //this.setValue(value);
     this.props.onChange(value);
   },
-  
-  validate: function () {
+
+  validate: function() {
     if (this.props.onBlur) {
       this.props.onBlur();
     }
     return true;
   },
-  
-  renderElement: function () {
+
+  renderElement: function() {
     const { options, value, name, disabled: _disabled } = this.props.inputProperties;
+    const valueString = String(value);
     const controls = options.map((radio, key) => {
-      let checked = (value === radio.value);
+      let checked = valueString === radio.value;
       let disabled = radio.disabled || _disabled;
-      
+
       return (
         <FormControlLabel
           key={key}
           value={radio.value}
-          control={<Radio
-            className={this.props.classes.radio}
-            inputRef={(c) => this['element-' + key] = c}
-            checked={checked}
-            disabled={disabled}
-          />}
+          control={
+            <Radio
+              className={this.props.classes.radio}
+              inputRef={c => (this['element-' + key] = c)}
+              checked={checked}
+              disabled={disabled}
+            />
+          }
           className={this.props.classes.line}
           label={radio.label}
         />
       );
     });
-    
-    const maxLength = options.reduce((max, option) =>
-      option.label.length > max ? option.label.length : max, 0);
-    
+
+    const maxLength = options.reduce(
+      (max, option) => (option.label.length > max ? option.label.length : max),
+      0
+    );
+
     let columnClass = maxLength < 18 ? 'threeColumn' : maxLength < 30 ? 'twoColumn' : '';
     if (this.props.type === 'inline') columnClass = 'inline';
-    
+
     return (
       <RadioGroup
         aria-label={name}
         name={name}
         className={classNames(this.props.classes.group, this.props.classes[columnClass])}
-        value={value}
-        onChange={this.changeRadio}
-      >
+        value={valueString}
+        onChange={this.changeRadio}>
         {controls}
       </RadioGroup>
     );
   },
-  
-  render: function () {
-    
+
+  render: function() {
     if (this.props.layout === 'elementOnly') {
-      return (
-        <div>{this.renderElement()}</div>
-      );
+      return <div>{this.renderElement()}</div>;
     }
-    
+
     return (
-      <MuiFormControl{...this.getFormControlProperties()} fakeLabel={true}>
+      <MuiFormControl {...this.getFormControlProperties()} fakeLabel={true}>
         {this.renderElement()}
-        <MuiFormHelper {...this.getFormHelperProperties()}/>
+        <MuiFormHelper {...this.getFormHelperProperties()} />
       </MuiFormControl>
     );
-  }
+  },
 });
-
 
 export default withStyles(styles)(MuiRadioGroup);


### PR DESCRIPTION
Hi guys, 

I saw that radiogroup doesn't work for fields with a *Number* type.
When I selected things, it was selected but I didn't see the radio button checked.

2 reasons for that:

  1) we got a `let checked = value === radio.value;`
In this case, *value* is a *Number* but *radio.value* is a *String*
  2) We call the component *Radiogroup*, wich comes from the material-ui package.
*Radiogroup* does not accept a *Number* for his *value*, only a *String*

So, I cast the *value* to be a *String*, now I can use *Number* in radiogroup.
It does not affect the value in the database, it is just a UI modification.

My Prettier formated the document, I think is a good thing, but if you prefer I can keep the old format.

Have a nice day, and thank you for your work!