### PR TITLE
FormWrapper is correctly reinitialized on documentId change

### DIFF
--- a/packages/vulcan-forms/lib/components/FormWrapper.jsx
+++ b/packages/vulcan-forms/lib/components/FormWrapper.jsx
@@ -57,7 +57,7 @@ class FormWrapper extends PureComponent {
   constructor(props) {
     super(props);
   }
-  componentWillMount(){
+  UNSAFE_componentWillMount(){
     // instantiate the wrapped component outside of render
     // see https://reactjs.org/docs/higher-order-components.html#dont-use-hocs-inside-the-render-method
     this.FormComponent = this.getComponent(this.props);

--- a/packages/vulcan-forms/lib/components/FormWrapper.jsx
+++ b/packages/vulcan-forms/lib/components/FormWrapper.jsx
@@ -53,8 +53,6 @@ import { callbackProps } from './propTypes';
 
 const intlSuffix = '_intl';
 
-const RESET_PROPS = ["documentId"]
-
 class FormWrapper extends PureComponent {
   constructor(props) {
     super(props);
@@ -65,7 +63,8 @@ class FormWrapper extends PureComponent {
     this.FormComponent = this.getComponent(this.props);
   }
   UNSAFE_componentWillReceiveProps(nextProps){
-    const shouldReset = !!RESET_PROPS.find(resetProp => nextProps[resetProp] !== this.props[resetProp])
+    // reset if a documentId has been added or removed
+    const shouldReset = nextProps.documentId && !this.props.documentId || !nextProps.documentId && this.props.documentId
     // reinit the component on certain props change
     if (shouldReset){
       this.FormComponent = this.getComponent(nextProps);


### PR DESCRIPTION
Hi,

Currently there might be issues when changing a SmartForm from a "new" mode to an "edit" mode, and vice-versa. Even using 2 different SmartForm won't work. This is because in the `FormWrapper` component we rely on the constructor to define the component, which may sometimes be incorrectly shared across instances that are different.

Example of faulty code:
```
if (!document) return (
        <Components.SmartForm
          collection={projectChoicesCollection}
        />
    )
    return (
      <Components.SmartForm
            collection={projectChoicesCollection}
            documentId={document._id}
          />
```

React won't recreate a SmartForm instance in this case even if "document" is updated, probably for perf reasons, because it detects that you use the same component with different props. Thus, the `FormComponent` is not updated in the `FormWrapper` because the constructor does not run a second time.

I provide a quickfix (see the top of the files, other changes are only here to be able to use `nextProps` instead of `this.props`), however I'd like a review because this is not very clean. 
When adding a `documentId`, the Form will "blink" because the component is destroyed, and also show a warning `Warning: Can't perform a React state update on an unmounted component.`.

I think we can do better, but I don't know yet how. Maybe by using state instead of directly setting the component as a class variable React would handle the switch in a smoother way.