### PR TITLE
Fix SSR issues with react-apollo and style wrappers

### DIFF
--- a/packages/vulcan-lib/lib/server/apollo-ssr/renderPage.js
+++ b/packages/vulcan-lib/lib/server/apollo-ssr/renderPage.js
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 import ReactDOM from 'react-dom/server';
-import { renderToStringWithData } from 'react-apollo';
+import { getDataFromTree } from 'react-apollo';
 
 import { runCallbacks } from '../../modules/callbacks';
 import { createClient } from './apolloClient';
@@ -33,6 +33,11 @@ const makePageRenderer = ({ computeContext }) => {
 
     const App = <AppGenerator req={req} apolloClient={client} context={context} />;
 
+    // fill apollo store
+    // NOTE: we CAN'T use renderToStringWithData on the wrapped app (so with Material UI, styled components etc.), 
+    //because react-apollo may trigger style generation while walking the React tree to find query
+    await getDataFromTree(App);
+
     // run user registered callbacks that wraps the React app
     const WrappedApp = runCallbacks({
       name: 'router.server.wrapper',
@@ -43,7 +48,7 @@ const makePageRenderer = ({ computeContext }) => {
     // equivalent to calling getDataFromTree and then renderToStringWithData
     let htmlContent = '';
     try {
-    htmlContent = await renderToStringWithData(WrappedApp);
+      htmlContent = await ReactDOM.renderToString(WrappedApp);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error(`Error while server-rendering. date: ${new Date().toString()} url: ${req.url}`); // eslint-disable-line no-console

--- a/packages/vulcan-lib/lib/server/apollo-ssr/renderPage.js
+++ b/packages/vulcan-lib/lib/server/apollo-ssr/renderPage.js
@@ -34,26 +34,37 @@ const makePageRenderer = ({ computeContext }) => {
     const App = <AppGenerator req={req} apolloClient={client} context={context} />;
 
     // run user registered callbacks that wraps the React app
+    // The wrappers must NOT have any side effect during React tree traversal
+    // otherwise SSR may fail
     const WrappedApp = runCallbacks({
       name: 'router.server.wrapper',
       iterator: App,
       properties: { req, context, apolloClient: client },
     });
 
+
+    // run wrappers that must only me applied during the data collection step
+    // eg Material UI theming WITHOUT style generation
+    // The wrappers must NOT have any side effect during React tree traversal
+    // otherwise SSR may fail
+    const DataWrappedApp = runCallbacks({
+      name: 'router.server.dataWrapper',
+      iterator: WrappedApp,
+      properties: { req, context, apolloClient: client },
+    });
     // fill apollo store
     // NOTE: we CAN'T use renderToStringWithData on the wrapped app (so with Material UI, styled components etc.), 
     //because react-apollo may trigger style generation while walking the React tree to find query
-    await getDataFromTree(WrappedApp);
+    await getDataFromTree(DataWrappedApp);
 
-    // run callback related to style (need to be done AFTER we get the data with Apollo
-    // otherwise SSR is messed up)
+    // run callback related to rendering
+    // eg Material UI theming WITH style generation
+    // those wrapper can tolerate side effects during React tree traversal (eg className/styles generation)
     const StyledWrappedApp = runCallbacks({
-      name: 'router.server.styleWrapper',
-      iterator: App,
+      name: 'router.server.renderWrapper',
+      iterator: WrappedApp,
       properties: { req, context, apolloClient: client },
     });
-
-
     // equivalent to calling getDataFromTree and then renderToStringWithData
     let htmlContent = '';
     try {

--- a/packages/vulcan-styled-components/lib/server/setupStyledComponents.js
+++ b/packages/vulcan-styled-components/lib/server/setupStyledComponents.js
@@ -3,7 +3,7 @@ import { ServerStyleSheet } from 'styled-components';
 import { addCallback } from 'meteor/vulcan:core';
 
 const setupStyledComponents = () => {
-  addCallback('router.server.styleWrapper', function collectStyles(app, { context }) {
+  addCallback('router.server.renderWrapper', function collectStyles(app, { context }) {
     const stylesheet = new ServerStyleSheet();
     // @see https://www.styled-components.com/docs/advanced/#example
     const wrappedApp = stylesheet.collectStyles(app);

--- a/packages/vulcan-styled-components/lib/server/setupStyledComponents.js
+++ b/packages/vulcan-styled-components/lib/server/setupStyledComponents.js
@@ -3,7 +3,7 @@ import { ServerStyleSheet } from 'styled-components';
 import { addCallback } from 'meteor/vulcan:core';
 
 const setupStyledComponents = () => {
-  addCallback('router.server.wrapper', function collectStyles(app, { context }) {
+  addCallback('router.server.styleWrapper', function collectStyles(app, { context }) {
     const stylesheet = new ServerStyleSheet();
     // @see https://www.styled-components.com/docs/advanced/#example
     const wrappedApp = stylesheet.collectStyles(app);

--- a/packages/vulcan-ui-material/lib/server/wrapWithMuiTheme.jsx
+++ b/packages/vulcan-ui-material/lib/server/wrapWithMuiTheme.jsx
@@ -8,26 +8,36 @@ import { SheetsRegistry } from 'react-jss/lib/jss';
 import JssCleanup from '../components/theme/JssCleanup';
 
 function wrapWithMuiTheme(app, { context }) {
+  const sheetsRegistry = new SheetsRegistry();
+  context.sheetsRegistry = sheetsRegistry;
+
   const sheetsManager = new Map();
 
   const theme = getCurrentTheme();
-
   return (
-    <MuiThemeProvider theme={theme} sheetsManager={sheetsManager}>
-      {app}
-    </MuiThemeProvider>
+    <JssProvider registry={sheetsRegistry} disableStylesGeneration={true}>
+      <MuiThemeProvider theme={theme} sheetsManager={sheetsManager} disableStylesGeneration={true}>
+        <JssCleanup>{app}</JssCleanup>
+      </MuiThemeProvider>
+    </JssProvider>
   );
 }
 
-function wrapWithJSSProvider(app, { context }) {
+function wrapWithMuiStyleGenerator(app, { context }) {
   const sheetsRegistry = new SheetsRegistry();
   context.sheetsRegistry = sheetsRegistry;
+
+  const sheetsManager = new Map();
+
+  const theme = getCurrentTheme();
 
   const generateClassName = createGenerateClassName({ seed: '' });
 
   return (
     <JssProvider registry={sheetsRegistry} generateClassName={generateClassName}>
-      <JssCleanup>{app}</JssCleanup>
+      <MuiThemeProvider theme={theme} sheetsManager={sheetsManager}>
+        <JssCleanup>{app}</JssCleanup>
+      </MuiThemeProvider>
     </JssProvider>
   );
 }
@@ -38,6 +48,10 @@ function injectJss(sink, { context }) {
   return sink;
 }
 
-addCallback('router.server.wrapper', wrapWithMuiTheme);
-addCallback('router.server.styleWrapper', wrapWithJSSProvider);
+// only run during Apollo's data collection, will provide the theme but won't generate the styles
+addCallback('router.server.dataWrapper', wrapWithMuiTheme);
+// only run during actual rendering, will both provide the theme and generate the styles
+addCallback('router.server.renderWrapper', wrapWithMuiStyleGenerator);
+
+// inject the <style> tag after rendering
 addCallback('router.server.postRender', injectJss);

--- a/packages/vulcan-ui-material/lib/server/wrapWithMuiTheme.jsx
+++ b/packages/vulcan-ui-material/lib/server/wrapWithMuiTheme.jsx
@@ -39,5 +39,5 @@ function injectJss(sink, { context }) {
 }
 
 
-addCallback('router.server.wrapper', wrapWithMuiTheme);
+addCallback('router.server.styleWrapper', wrapWithMuiTheme);
 addCallback('router.server.postRender', injectJss);

--- a/packages/vulcan-ui-material/lib/server/wrapWithMuiTheme.jsx
+++ b/packages/vulcan-ui-material/lib/server/wrapWithMuiTheme.jsx
@@ -7,37 +7,37 @@ import { getCurrentTheme } from '../modules/themes';
 import { SheetsRegistry } from 'react-jss/lib/jss';
 import JssCleanup from '../components/theme/JssCleanup';
 
-
-function wrapWithMuiTheme (app, { context }) {
-  const sheetsRegistry = new SheetsRegistry();
-  context.sheetsRegistry = sheetsRegistry;
-  
+function wrapWithMuiTheme(app, { context }) {
   const sheetsManager = new Map();
 
   const theme = getCurrentTheme();
-  
+
+  return (
+    <MuiThemeProvider theme={theme} sheetsManager={sheetsManager}>
+      {app}
+    </MuiThemeProvider>
+  );
+}
+
+function wrapWithJSSProvider(app, { context }) {
+  const sheetsRegistry = new SheetsRegistry();
+  context.sheetsRegistry = sheetsRegistry;
+
   const generateClassName = createGenerateClassName({ seed: '' });
-  
+
   return (
     <JssProvider registry={sheetsRegistry} generateClassName={generateClassName}>
-      <MuiThemeProvider theme={theme} sheetsManager={sheetsManager}>
-        <JssCleanup>
-          {app}
-        </JssCleanup>
-      </MuiThemeProvider>
+      <JssCleanup>{app}</JssCleanup>
     </JssProvider>
   );
 }
 
-
 function injectJss(sink, { context }) {
   const sheets = context.sheetsRegistry.toString();
-  sink.appendToHead(
-    `<style id="jss-server-side">${sheets}</style>`
-  );
+  sink.appendToHead(`<style id="jss-server-side">${sheets}</style>`);
   return sink;
 }
 
-
-addCallback('router.server.styleWrapper', wrapWithMuiTheme);
+addCallback('router.server.wrapper', wrapWithMuiTheme);
+addCallback('router.server.styleWrapper', wrapWithJSSProvider);
 addCallback('router.server.postRender', injectJss);


### PR DESCRIPTION
Fixes https://github.com/VulcanJS/Vulcan/issues/2338
Fix based on:https://github.com/mui-org/material-ui/issues/10522

It seems that React tree traversal triggers side effects. For example, when using Material UI, it will generate className.

During SSR, 2 steps needs a traversal of the tree:
- graphQL data generation with `react-apollo`
- and the actual render with ReactDOM/server.

In the current implementation, they were done in one call to `renderToStringWithData` from `react-apollo` **which I advise to never use** (won a line of code, lost hours of debugging... one function = one side effect and one goal, not 2).

I split those steps. 
Data fetching is now done on the unwrapped `App` component, before `router.server.wrapper` is run. It will find `Query` components and fill Apollo's store accordingly.
 
Rendering is done on the whole app, including wrappers registered with `router.server.wrapper`, so the Material UI theme wrapper, Styled Component wrapper, Redux store provider and so one.

Only edge case I can imagine is having queries that depends on a wrapper component. Maybe with Redux? If this happens the solution will be to create a new callback, differentiating wrapper that needs top be included while fetching data and style wrappers.

