### PR TITLE
EJSONStackOverflow

### DIFF
--- a/packages/vulcan-lib/lib/server/inject_data.js
+++ b/packages/vulcan-lib/lib/server/inject_data.js
@@ -12,8 +12,12 @@ export const InjectData = {
 
   // encode object to string
   _encode(ejson) {
-    const ejsonString = EJSON.stringify(ejson);
-    return encodeURIComponent(ejsonString);
+    try {
+      const ejsonString = EJSON.stringify(ejson);
+      return encodeURIComponent(ejsonString);
+    } catch (error) {
+      return null;
+    }
   },
 
   // decode string to object
@@ -55,8 +59,12 @@ export const InjectData = {
     if (res._injectPayload) {
       // same as _.clone(res._injectPayload[key]);
       const data = res._injectPayload[key];
-      const clonedData = EJSON.parse(EJSON.stringify(data));
-      return clonedData;
+      try {
+        const clonedData = EJSON.parse(EJSON.stringify(data));
+        return clonedData;
+      } catch (error) {
+        return null;
+      }
     }
     return null;
   },


### PR DESCRIPTION
Fixed bug: EJSON.stringify() will throw a stack overflow error when attempting to stringify an object with circular references