### PR TITLE
Feature/apollo register link

### DIFF
--- a/packages/vulcan-lib/lib/client/apollo-client/apolloClient.js
+++ b/packages/vulcan-lib/lib/client/apollo-client/apolloClient.js
@@ -16,6 +16,7 @@ export const createApolloClient = () => {
   // links registered by packages
   const registeredLinks = getLinks();
   const terminatingLinks = getTerminatingLinks();
+  if (terminatingLinks.length > 1) console.warn('Warning: You registered more than one terminating Apollo link.');
 
   const stateLink = createStateLink({ cache });
   const newClient = new ApolloClient({
@@ -24,8 +25,8 @@ export const createApolloClient = () => {
       ...registeredLinks,
       ...staticLinks,
       // terminating
-      ...terminatingLinks,
-      httpLink]),
+      ...(terminatingLinks.length ? terminatingLinks : [httpLink]),
+    ]),
     cache,
   });
   // register the client

--- a/packages/vulcan-lib/lib/client/apollo-client/apolloClient.js
+++ b/packages/vulcan-lib/lib/client/apollo-client/apolloClient.js
@@ -6,15 +6,26 @@ import meteorAccountsLink from './links/meteor';
 import errorLink from './links/error';
 import { createStateLink } from '../../modules/apollo-common';
 import cache from './cache';
+import { getTerminatingLinks, getLinks } from './links/registerLinks';
 
 // these links do not change once created
-const staticLinks = [watchedMutationLink, errorLink, meteorAccountsLink, httpLink];
+const staticLinks = [watchedMutationLink, errorLink, meteorAccountsLink];
 
 let apolloClient;
 export const createApolloClient = () => {
+  // links registered by packages
+  const registeredLinks = getLinks();
+  const terminatingLinks = getTerminatingLinks();
+
   const stateLink = createStateLink({ cache });
   const newClient = new ApolloClient({
-    link: ApolloLink.from([stateLink, ...staticLinks]),
+    link: ApolloLink.from([
+      stateLink,
+      ...registeredLinks,
+      ...staticLinks,
+      // terminating
+      ...terminatingLinks,
+      httpLink]),
     cache,
   });
   // register the client

--- a/packages/vulcan-lib/lib/client/apollo-client/index.js
+++ b/packages/vulcan-lib/lib/client/apollo-client/index.js
@@ -1,2 +1,3 @@
 export * from './updates';
 export * from './apolloClient';
+export * from './links/registerLinks';

--- a/packages/vulcan-lib/lib/client/apollo-client/links/registerLinks.js
+++ b/packages/vulcan-lib/lib/client/apollo-client/links/registerLinks.js
@@ -1,0 +1,18 @@
+const terminatingLinksRegistry = [];
+const linksRegistry = [];
+
+// register one or more links
+export const registerLink = (link) => {
+    const links = Array.isArray(link) ? link : [link];
+    linksRegistry.unshift(...links);
+};
+
+export const registerTerminatingLink = (link) => {
+    const links = Array.isArray(link) ? link : [link];
+    terminatingLinksRegistry.push(...links);
+};
+
+
+
+export const getLinks = () => linksRegistry;
+export const getTerminatingLinks = () => terminatingLinksRegistry;

--- a/packages/vulcan-lib/lib/server/apollo-server/apollo_server.js
+++ b/packages/vulcan-lib/lib/server/apollo-server/apollo_server.js
@@ -35,6 +35,7 @@ import { getApolloApplyMiddlewareOptions, getApolloServerOptions } from './setti
 
 import { getSetting } from '../../modules/settings.js';
 import { formatError } from 'apollo-errors';
+import { runCallbacks } from '../../modules/callbacks';
 
 export const setupGraphQLMiddlewares = (apolloServer, config, apolloApplyMiddlewareOptions) => {
   // IMPORTANT: order matters !
@@ -55,6 +56,14 @@ export const setupGraphQLMiddlewares = (apolloServer, config, apolloApplyMiddlew
     bodyParser.json({ limit: getSetting('apolloServer.jsonParserOptions.limit') })
   );
   WebApp.connectHandlers.use(config.path, bodyParser.text({ type: 'application/graphql' }));
+
+
+  // enhance webapp
+  runCallbacks({
+    name: 'graphql.middlewares.setup',
+    iterator: WebApp,
+    properties: {}
+  });
 
   // Provide the Meteor WebApp Connect server instance to Apollo
   // Apollo will use it instead of its own HTTP server when handling requests
@@ -113,7 +122,7 @@ export const onStart = () => {
   const config = {
     path: '/graphql',
     maxAccountsCacheSizeInMB: 1,
-    configServer: apolloServer => {},
+    configServer: apolloServer => { },
     voyagerPath: '/graphql-voyager',
     graphiqlPath: '/graphiql',
     // customConfigFromReq


### PR DESCRIPTION
Add link registering functions, for normal links and terminating links.

This allowed me to install `apollo-file-upload` from an additional package.

Also added a callback to add middlewares on `/graphql` but I did not used it in the end. Might still be useful for advanced usages.