### PR TITLE
Bugfix/button props

### DIFF
--- a/packages/vulcan-forms/lib/components/FormNestedArrayLayout.jsx
+++ b/packages/vulcan-forms/lib/components/FormNestedArrayLayout.jsx
@@ -28,7 +28,7 @@ const FormNestedArrayLayout = (props) => {
         {
           addItem &&
 
-          <FormComponents.Button className="form-nested-button" size="small" variant="success" onClick={addItem}>
+          <FormComponents.Button className="form-nested-button" size="sm" variant="success" onClick={addItem}>
             <FormComponents.IconAdd height={12} width={12} />
           </FormComponents.Button>
         }

--- a/packages/vulcan-forms/lib/components/FormNestedArrayLayout.jsx
+++ b/packages/vulcan-forms/lib/components/FormNestedArrayLayout.jsx
@@ -15,34 +15,34 @@ const FormNestedArrayLayout = (props) => {
     children,
   } = props;
   const FormComponents = formComponents;
-  
+
   return (
     <div className={`form-group row form-nested ${hasErrors ? 'input-error' : ''}`}>
-      
+
       {instantiateComponent(beforeComponent, props)}
-      
+
       <label className="control-label col-sm-3">{label}</label>
-      
+
       <div className="col-sm-9">
         {children}
         {
           addItem &&
-          
+
           <FormComponents.Button className="form-nested-button" size="small" variant="success" onClick={addItem}>
-            <FormComponents.IconAdd height={12} width={12}/>
+            <FormComponents.IconAdd height={12} width={12} />
           </FormComponents.Button>
         }
         {
           props.hasErrors
             ?
-            <FormComponents.FieldErrors key="form-nested-errors" errors={nestedArrayErrors}/>
+            <FormComponents.FieldErrors key="form-nested-errors" errors={nestedArrayErrors} />
             :
             null
         }
       </div>
-      
+
       {instantiateComponent(afterComponent, props)}
-    
+
     </div>
   );
 };

--- a/packages/vulcan-forms/lib/components/FormNestedItem.jsx
+++ b/packages/vulcan-forms/lib/components/FormNestedItem.jsx
@@ -50,7 +50,7 @@ const FormNestedItem = (
             <Components.Button
               className="form-nested-button"
               variant="danger"
-              size="small"
+              size="sm"
               iconButton
               tabIndex="-1"
               onClick={() => {

--- a/packages/vulcan-ui-material/lib/components/ui/Button.jsx
+++ b/packages/vulcan-ui-material/lib/components/ui/Button.jsx
@@ -111,13 +111,13 @@ const Button = ({ children, variant, size, iconButton, classes, theme, ...rest }
 
   switch (size) {
     case 'sm':
-      size = 'small';
+      size = 'sm';
       break;
     case 'md':
-      size = 'medium';
+      size = 'md';
       break;
     case 'lg':
-      size = 'large';
+      size = 'lg';
       break;
     default:
       size = undefined;

--- a/packages/vulcan-ui-material/lib/components/ui/Button.jsx
+++ b/packages/vulcan-ui-material/lib/components/ui/Button.jsx
@@ -111,13 +111,13 @@ const Button = ({ children, variant, size, iconButton, classes, theme, ...rest }
 
   switch (size) {
     case 'sm':
-      size = 'sm';
+      size = 'small';
       break;
     case 'md':
-      size = 'md';
+      size = 'medium';
       break;
     case 'lg':
-      size = 'lg';
+      size = 'large';
       break;
     default:
       size = undefined;

--- a/packages/vulcan-ui-material/lib/components/ui/Button.jsx
+++ b/packages/vulcan-ui-material/lib/components/ui/Button.jsx
@@ -8,77 +8,77 @@ import withTheme from '@material-ui/core/styles/withTheme';
 
 
 const styles = theme => ({
-  
+
   success: {
     '&:hover': {
       backgroundColor: theme.palette.success.main,
       color: theme.palette.success.contrastText,
     }
   },
-  
+
   outline_success: {
     '&:hover': {
       borderColor: theme.palette.success.main,
       color: theme.palette.success.main,
     }
   },
-  
+
   warning: {
     '&:hover': {
       backgroundColor: theme.palette.warning.main,
       color: theme.palette.warning.contrastText,
     }
   },
-  
+
   outline_warning: {
     '&:hover': {
       borderColor: theme.palette.warning.main,
       color: theme.palette.warning.main,
     }
   },
-  
+
   danger: {
     '&:hover': {
       backgroundColor: theme.palette.error.main,
       color: theme.palette.error.contrastText,
     }
   },
-  
+
   outline_danger: {
     '&:hover': {
       borderColor: theme.palette.error.main,
       color: theme.palette.error.main,
     }
   },
-  
+
   info: {
     '&:hover': {
       backgroundColor: theme.palette.info.main,
       color: theme.palette.info.contrastText,
     }
   },
-  
+
   outline_info: {
     '&:hover': {
       borderColor: theme.palette.info.main,
       color: theme.palette.info.main,
     }
   },
-  
+
   light: {},
-  
+
   outline_light: {},
-  
+
   dark: {
     backgroundColor: theme.palette.common.black,
     color: theme.palette.common.white,
   },
-  
+
   outline_dark: {
     borderColor: theme.palette.common.black,
     color: theme.palette.common.black,
   },
-  
+
 });
 
 
@@ -87,7 +87,7 @@ const Button = ({ children, variant, size, iconButton, classes, theme, ...rest }
   const outline = varParts && varParts.length > 1 ? varParts[0] : null;
   variant = varParts && varParts.length > 1 ? varParts[1] : varParts && varParts.length > 0 ? varParts[0] : null;
   let color;
-  
+
   switch (variant) {
     case 'primary':
       color = 'primary';
@@ -102,13 +102,13 @@ const Button = ({ children, variant, size, iconButton, classes, theme, ...rest }
       color = 'default';
       break;
   }
-  
-  const root = ['success', 'warning', 'danger', 'info', 'light', 'dark'].includes(variant) ? 
-    classes[outline ? outline + '_' + variant : variant] : 
+
+  const root = ['success', 'warning', 'danger', 'info', 'light', 'dark'].includes(variant) ?
+    classes[outline ? outline + '_' + variant : variant] :
     null;
-  
+
   variant = outline === 'outline' ? 'outlined' : variant && variant !== 'link' ? 'contained' : 'text';
-  
+
   switch (size) {
     case 'sm':
       size = 'small';
@@ -119,11 +119,11 @@ const Button = ({ children, variant, size, iconButton, classes, theme, ...rest }
     case 'lg':
       size = 'large';
       break;
-    default: 
+    default:
       size = undefined;
       break;
   }
-  
+
   if (iconButton) {
     return (
       <MuiIconButton color={color} variant={variant} size={size} classes={{ root }} {...rest}>
@@ -131,7 +131,7 @@ const Button = ({ children, variant, size, iconButton, classes, theme, ...rest }
       </MuiIconButton>
     );
   }
-  
+
   return (
     <MuiButton color={color} variant={variant} size={size} classes={{ root }} {...rest}>
       {children}
@@ -145,7 +145,7 @@ Button.displayName = 'Button';
 
 Button.propTypes = {
   variant: PropTypes.oneOf(['primary', 'secondary', 'success', 'warning', 'danger', 'info', 'light', 'dark', 'link',
-    'outline-primary', 'outline-secondary', 'outline-success', 'outline-warning', 'outline-danger', 'outline-info', 
+    'outline-primary', 'outline-secondary', 'outline-success', 'outline-warning', 'outline-danger', 'outline-info',
     'outline-light', 'outline-dark', 'inherit']),
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
   iconButton: PropTypes.bool,


### PR DESCRIPTION
Hi everyone, 

Since a time, I've React warnings to change size of buttons from "small" to "sm".

I searched them on Vulcan and changed them, but there are 2 fun facts:

1. On the material-ui button API doc , it's written that the props should be "small, medium & large", for the version 3 and 4.
https://v3.material-ui.com/api/button/
https://material-ui.com/api/button/
2.  When I change the size in the file AccountsButton.jsx, I've a warning to change it from "sm" to "small" x)

So, I changed them in the 3 other files but not this one, and I've no more warnings.
Maybe you've more explanations.

Have a good day!

Julien.
