### PR TITLE
Fix bug in Utils.getUnusedSlug()

### DIFF
--- a/packages/vulcan-lib/lib/modules/utils.js
+++ b/packages/vulcan-lib/lib/modules/utils.js
@@ -168,7 +168,7 @@ Utils.getOutgoingUrl = function (url) {
 };
 
 Utils.slugify = function (s) {
-  var slug = getSlug(s, {
+  let slug = getSlug(s, {
     truncate: 60
   });
 
@@ -179,17 +179,16 @@ Utils.slugify = function (s) {
 
   return slug;
 };
-Utils.getUnusedSlug = function (collection, slug) {
-  let suffix = '';
-  let index = 0;
 
+Utils.getUnusedSlug = function (collection, slug, documentId) {
   // test if slug is already in use
-  while (!!collection.findOne({slug: slug+suffix})) {
-    index++;
-    suffix = '-'+index;
+  for (let index = 0; index <= Number.MAX_SAFE_INTEGER; index++) {
+    const suffix = index ? '-' + index : '';
+    const documentWithSlug = collection.findOne({ slug: slug + suffix });
+    if (!documentWithSlug || (documentId && documentWithSlug._id === documentId)) {
+      return slug + suffix;
+    }
   }
-
-  return slug+suffix;
 };
 
 // Different version, less calls to the db but it cannot be used until we figure out how to use async for onCreate functions
@@ -209,8 +208,8 @@ Utils.getUnusedSlug = function (collection, slug) {
 //   return slug + suffix;
 // };
 
-Utils.getUnusedSlugByCollectionName = function (collectionName, slug) {
-  return Utils.getUnusedSlug(getCollection(collectionName), slug);
+Utils.getUnusedSlugByCollectionName = function (collectionName, slug, documentId) {
+  return Utils.getUnusedSlug(getCollection(collectionName), slug, documentId);
 };
 
 Utils.getShortUrl = function(post) {

--- a/packages/vulcan-lib/test/index.js
+++ b/packages/vulcan-lib/test/index.js
@@ -1,2 +1,3 @@
-import './handleOptions.test.js';
 import './components.test.js';
+import './handleOptions.test.js';
+import './utils.test.js';

--- a/packages/vulcan-lib/test/utils.test.js
+++ b/packages/vulcan-lib/test/utils.test.js
@@ -1,0 +1,80 @@
+import { Utils } from '../lib/modules/utils';
+import expect from 'expect';
+
+
+describe('vulcan:lib/utils', function () {
+  
+  const collection = {
+    findOne: function ({ slug }) {
+      switch(slug) {
+        case 'duplicate-name':
+          return {
+            _id: 'duplicate-name',
+            name: 'Duplicate name',
+            slug: 'duplicate-name',
+          };
+        case 'triplicate-name':
+          return {
+            _id: 'triplicate-name',
+            name: 'Triplicate name',
+            slug: 'triplicate-name',
+          };
+        case 'triplicate-name-1':
+          return {
+            _id: 'triplicate-name-1',
+            name: 'Triplicate name',
+            slug: 'triplicate-name-1',
+          };
+        case 'renamed-name':
+          return {
+            _id: 'renamed-name',
+            name: 'RENAMED NAME',
+            slug: 'renamed-name',
+          };
+        default:
+          return null;
+      }
+    }
+  };
+  
+  it('returns the same slug when there are no conflicts', function () {
+    const slug = 'unique-name';
+    const unusedSlug = Utils.getUnusedSlug(collection, slug);
+
+    expect(unusedSlug).toEqual(slug);
+  });
+  
+  it('appends integer to slug when there is a conflict', function () {
+    const slug = 'duplicate-name';
+    const unusedSlug = Utils.getUnusedSlug(collection, slug);
+
+    expect(unusedSlug).toEqual(slug + '-1');
+  });
+  
+  it('appends incremented integer to slug when there is a conflict', function () {
+    const slug = 'triplicate-name';
+    const unusedSlug = Utils.getUnusedSlug(collection, slug);
+
+    expect(unusedSlug).toEqual(slug + '-2');
+  });
+  
+  it('returns the same slug when the conflict has the same _id', function () {
+    // This tests the case where a document is renamed, but its slug remains the same
+    // For example 'RENAMED NAME' is changed to 'Renamed name'; the slug should not increment
+    const slug = 'renamed-name';
+    const documentId = 'renamed-name';
+    const unusedSlug = Utils.getUnusedSlug(collection, slug, documentId);
+    
+    expect(unusedSlug).toEqual(slug);
+  });
+  
+  it('appends integer to slug when the conflict has the same _id, but it’s not passed to getUnusedSlug', function () {
+    // This tests the case where a document is renamed, but its slug remains the same
+    // For example 'RENAMED NAME' is changed to 'Renamed name'; the slug should not increment
+    const slug = 'renamed-name';
+    const unusedSlug = Utils.getUnusedSlug(collection, slug);
+    
+    expect(unusedSlug).toEqual(slug + '-1');
+  });
+  
+});


### PR DESCRIPTION
`Utils.getUnusedSlug()` creates a problem when a document is renamed, but its slug remains the same. For example, if 'RENAMED NAME' is changed to 'Renamed name'; the slug would change from `renamed-name` to `renamed-name-1`. To resolve this, pass the document's _id as the 3rd parameter to `getUnusedSlug`. Unit tests included.