### PR TITLE
Handle Nested types the graphql way

### DIFF
--- a/packages/vulcan-lib/lib/modules/config.js
+++ b/packages/vulcan-lib/lib/modules/config.js
@@ -41,6 +41,7 @@ SimpleSchema.extendOptions([
   'canUpdate', // who can edit the field
   'editableBy', // who can edit the field (OpenCRUD backwards compatibility)
 
+  'typeName', // the type to resolve the field with
   'resolveAs', // field-level resolver
   'searchable', // whether a field is searchable
   'description', // description/help

--- a/packages/vulcan-lib/lib/modules/graphql/collection.js
+++ b/packages/vulcan-lib/lib/modules/graphql/collection.js
@@ -275,14 +275,11 @@ const collectionToGraphQL = (collection) => {
         }
 
         const { queriesToAdd, resolversToAdd } = createResolvers({ resolvers, typeName });
-        const { mutationsToAdd,
-
-            mutationsResolversToAdd
-        } = createMutations({
+        const { mutationsToAdd, mutationsResolversToAdd } = createMutations({
             mutations,
             typeName,
             collectionName,
-            fields
+            fields,
         });
 
         graphQLSchema = schemaFragments.join('\n\n') + '\n\n\n';

--- a/packages/vulcan-lib/lib/modules/graphql/collection.js
+++ b/packages/vulcan-lib/lib/modules/graphql/collection.js
@@ -2,33 +2,31 @@
  * Generates the GraphQL schema and
  * the resolvers and mutations for a Vulcan collectio
  */
+import { getSchemaFields } from './schemaFields';
 import {
-    getSchemaFields
-} from './schemaFields';
-import {
-    selectorInputTemplate,
-    mainTypeTemplate,
-    createInputTemplate,
-    createDataInputTemplate,
-    updateInputTemplate,
-    updateDataInputTemplate,
-    orderByInputTemplate,
-    selectorUniqueInputTemplate,
-    deleteInputTemplate,
-    upsertInputTemplate,
-    singleInputTemplate,
-    multiInputTemplate,
-    multiOutputTemplate,
-    singleOutputTemplate,
-    mutationOutputTemplate,
-    singleQueryTemplate,
-    multiQueryTemplate,
-    createMutationTemplate,
-    updateMutationTemplate,
-    upsertMutationTemplate,
-    deleteMutationTemplate,
-    enumTypeTemplate,
-    nestedInputTemplate
+  selectorInputTemplate,
+  mainTypeTemplate,
+  createInputTemplate,
+  createDataInputTemplate,
+  updateInputTemplate,
+  updateDataInputTemplate,
+  orderByInputTemplate,
+  selectorUniqueInputTemplate,
+  deleteInputTemplate,
+  upsertInputTemplate,
+  singleInputTemplate,
+  multiInputTemplate,
+  multiOutputTemplate,
+  singleOutputTemplate,
+  mutationOutputTemplate,
+  singleQueryTemplate,
+  multiQueryTemplate,
+  createMutationTemplate,
+  updateMutationTemplate,
+  upsertMutationTemplate,
+  deleteMutationTemplate,
+  enumTypeTemplate,
+  nestedInputTemplate,
 } from '../graphql_templates.js';
 
 import { Utils } from '../utils.js';
@@ -38,268 +36,256 @@ import _initial from 'lodash/initial';
 
 /**
  * Extract relevant collection information and set default values
- * @param {*} collection 
+ * @param {*} collection
  */
-const getCollectionInfos = (collection) => {
-    const collectionName = collection.options.collectionName;
-    const typeName = collection.typeName
-        ? collection.typeName
-        : Utils.camelToSpaces(_initial(collectionName).join('')); // default to posts -> Post
-    const schema = collection.simpleSchema()._schema;
-    const description = collection.options.description
-        ? collection.options.description
-        : `Type for ${collectionName}`;
-    return {
-        ...collection.options,
-        collectionName,
-        typeName,
-        schema,
-        description,
-    };
+const getCollectionInfos = collection => {
+  const collectionName = collection.options.collectionName;
+  const typeName = collection.typeName
+    ? collection.typeName
+    : Utils.camelToSpaces(_initial(collectionName).join('')); // default to posts -> Post
+  const schema = collection.simpleSchema()._schema;
+  const description = collection.options.description
+    ? collection.options.description
+    : `Type for ${collectionName}`;
+  return {
+    ...collection.options,
+    collectionName,
+    typeName,
+    schema,
+    description,
+  };
 };
 
 const createResolvers = ({ resolvers, typeName }) => {
-    const queryResolvers = {};
-    const queriesToAdd = [];
-    const resolversToAdd = [];
-    if (_isEmpty(resolvers)) return { queriesToAdd, resolversToAdd };
-    // single
-    if (resolvers.single) {
-        queriesToAdd.push(
-            [singleQueryTemplate({ typeName }), resolvers.single.description],
-        );
-        //addGraphQLQuery(singleQueryTemplate({ typeName }), resolvers.single.description);
-        queryResolvers[Utils.camelCaseify(typeName)] = resolvers.single.resolver.bind(
-            resolvers.single
-        );
-    }
-    // multi
-    if (resolvers.multi) {
-        queriesToAdd.push(
-            [multiQueryTemplate({ typeName }), resolvers.multi.description]
-        );
-        //addGraphQLQuery(multiQueryTemplate({ typeName }), resolvers.multi.description);
-        queryResolvers[
-            Utils.camelCaseify(Utils.pluralize(typeName))
-        ] = resolvers.multi.resolver.bind(resolvers.multi);
-    }
-    //addGraphQLResolvers({ Query: { ...queryResolvers } });
-    resolversToAdd.push(
-        { Query: { ...queryResolvers } }
+  const queryResolvers = {};
+  const queriesToAdd = [];
+  const resolversToAdd = [];
+  if (_isEmpty(resolvers)) return { queriesToAdd, resolversToAdd };
+  // single
+  if (resolvers.single) {
+    queriesToAdd.push([singleQueryTemplate({ typeName }), resolvers.single.description]);
+    //addGraphQLQuery(singleQueryTemplate({ typeName }), resolvers.single.description);
+    queryResolvers[Utils.camelCaseify(typeName)] = resolvers.single.resolver.bind(resolvers.single);
+  }
+  // multi
+  if (resolvers.multi) {
+    queriesToAdd.push([multiQueryTemplate({ typeName }), resolvers.multi.description]);
+    //addGraphQLQuery(multiQueryTemplate({ typeName }), resolvers.multi.description);
+    queryResolvers[Utils.camelCaseify(Utils.pluralize(typeName))] = resolvers.multi.resolver.bind(
+      resolvers.multi
     );
-    return {
-        queriesToAdd,
-        resolversToAdd
-    };
+  }
+  //addGraphQLResolvers({ Query: { ...queryResolvers } });
+  resolversToAdd.push({ Query: { ...queryResolvers } });
+  return {
+    queriesToAdd,
+    resolversToAdd,
+  };
 };
 const createMutations = ({ mutations, typeName, collectionName, fields }) => {
-    const mutationResolvers = {};
-    const mutationsToAdd = [];
-    const mutationsResolversToAdd = [];
-    if (_isEmpty(mutations)) return { mutationsToAdd, mutationsResolversToAdd };
+  const mutationResolvers = {};
+  const mutationsToAdd = [];
+  const mutationsResolversToAdd = [];
+  if (_isEmpty(mutations)) return { mutationsToAdd, mutationsResolversToAdd };
 
-    const { create, update } = fields;
+  const { create, update } = fields;
 
-    // create
-    if (mutations.create) {
-        // e.g. "createMovie(input: CreateMovieInput) : Movie"
-        if (create.length === 0) {
-            // eslint-disable-next-line no-console
-            console.log(
-                `// Warning: you defined a "create" mutation for collection ${collectionName}, but it doesn't have any mutable fields, so no corresponding mutation types can be generated. Remove the "create" mutation or define a "canCreate" property on a field to disable this warning`
-            );
-        } else {
-            //addGraphQLMutation(createMutationTemplate({ typeName }), mutations.create.description);
-            mutationsToAdd.push(
-                [createMutationTemplate({ typeName }), mutations.create.description]
-            );
-            mutationResolvers[`create${typeName}`] = mutations.create.mutation.bind(
-                mutations.create
-            );
-        }
+  // create
+  if (mutations.create) {
+    // e.g. "createMovie(input: CreateMovieInput) : Movie"
+    if (create.length === 0) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `// Warning: you defined a "create" mutation for collection ${collectionName}, but it doesn't have any mutable fields, so no corresponding mutation types can be generated. Remove the "create" mutation or define a "canCreate" property on a field to disable this warning`
+      );
+    } else {
+      //addGraphQLMutation(createMutationTemplate({ typeName }), mutations.create.description);
+      mutationsToAdd.push([createMutationTemplate({ typeName }), mutations.create.description]);
+      mutationResolvers[`create${typeName}`] = mutations.create.mutation.bind(mutations.create);
     }
-    // update
-    if (mutations.update) {
-        // e.g. "updateMovie(input: UpdateMovieInput) : Movie"
-        if (update.length === 0) {
-            // eslint-disable-next-line no-console
-            console.log(
-                `// Warning: you defined an "update" mutation for collection ${collectionName}, but it doesn't have any mutable fields, so no corresponding mutation types can be generated. Remove the "update" mutation or define a "canUpdate" property on a field to disable this warning`
-            );
-        } else {
-            mutationsToAdd.push(
-                [updateMutationTemplate({ typeName }), mutations.update.description]
-            );
-            //addGraphQLMutation(updateMutationTemplate({ typeName }), mutations.update.description);
-            mutationResolvers[`update${typeName}`] = mutations.update.mutation.bind(
-                mutations.update
-            );
-        }
+  }
+  // update
+  if (mutations.update) {
+    // e.g. "updateMovie(input: UpdateMovieInput) : Movie"
+    if (update.length === 0) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `// Warning: you defined an "update" mutation for collection ${collectionName}, but it doesn't have any mutable fields, so no corresponding mutation types can be generated. Remove the "update" mutation or define a "canUpdate" property on a field to disable this warning`
+      );
+    } else {
+      mutationsToAdd.push([updateMutationTemplate({ typeName }), mutations.update.description]);
+      //addGraphQLMutation(updateMutationTemplate({ typeName }), mutations.update.description);
+      mutationResolvers[`update${typeName}`] = mutations.update.mutation.bind(mutations.update);
     }
-    // upsert
-    if (mutations.upsert) {
-        // e.g. "upsertMovie(input: UpsertMovieInput) : Movie"
-        if (update.length === 0) {
-            // eslint-disable-next-line no-console
-            console.log(
-                `// Warning: you defined an "upsert" mutation for collection ${collectionName}, but it doesn't have any mutable fields, so no corresponding mutation types can be generated. Remove the "upsert" mutation or define a "canUpdate" property on a field to disable this warning`
-            );
-        } else {
-            mutationsToAdd.push(
-                [upsertMutationTemplate({ typeName }), mutations.upsert.description]
-            );
-            //addGraphQLMutation(upsertMutationTemplate({ typeName }), mutations.upsert.description);
-            mutationResolvers[`upsert${typeName}`] = mutations.upsert.mutation.bind(
-                mutations.upsert
-            );
-        }
+  }
+  // upsert
+  if (mutations.upsert) {
+    // e.g. "upsertMovie(input: UpsertMovieInput) : Movie"
+    if (update.length === 0) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `// Warning: you defined an "upsert" mutation for collection ${collectionName}, but it doesn't have any mutable fields, so no corresponding mutation types can be generated. Remove the "upsert" mutation or define a "canUpdate" property on a field to disable this warning`
+      );
+    } else {
+      mutationsToAdd.push([upsertMutationTemplate({ typeName }), mutations.upsert.description]);
+      //addGraphQLMutation(upsertMutationTemplate({ typeName }), mutations.upsert.description);
+      mutationResolvers[`upsert${typeName}`] = mutations.upsert.mutation.bind(mutations.upsert);
     }
-    // delete
-    if (mutations.delete) {
-        // e.g. "deleteMovie(input: DeleteMovieInput) : Movie"
-        //addGraphQLMutation(deleteMutationTemplate({ typeName }), mutations.delete.description);
-        mutationsToAdd.push(
-            [deleteMutationTemplate({ typeName }), mutations.delete.description]
-        );
-        mutationResolvers[`delete${typeName}`] = mutations.delete.mutation.bind(mutations.delete);
-    }
-    //addGraphQLResolvers({ Mutation: { ...mutationResolvers } });
-    mutationsResolversToAdd.push(
-        { Mutation: { ...mutationResolvers } }
-    );
-    return { mutationsResolversToAdd, mutationsToAdd };
+  }
+  // delete
+  if (mutations.delete) {
+    // e.g. "deleteMovie(input: DeleteMovieInput) : Movie"
+    //addGraphQLMutation(deleteMutationTemplate({ typeName }), mutations.delete.description);
+    mutationsToAdd.push([deleteMutationTemplate({ typeName }), mutations.delete.description]);
+    mutationResolvers[`delete${typeName}`] = mutations.delete.mutation.bind(mutations.delete);
+  }
+  //addGraphQLResolvers({ Mutation: { ...mutationResolvers } });
+  mutationsResolversToAdd.push({ Mutation: { ...mutationResolvers } });
+  return { mutationsResolversToAdd, mutationsToAdd };
 };
 
-
 // generate types, input and enums
-const generateSchemaFragments = ({ typeName, description, interfaces = [], fields, isNested = false }) => {
-    const schemaFragments = [];
-    const { mainType, create, update, selector, selectorUnique, orderBy, enums } = fields;
-    schemaFragments.push(
-        mainTypeTemplate({ typeName, description, interfaces, fields: mainType })
-    );
+const generateSchemaFragments = ({
+  typeName,
+  description,
+  interfaces = [],
+  fields,
+  isNested = false,
+}) => {
+  const schemaFragments = [];
+  const { mainType, create, update, selector, selectorUnique, orderBy, enums } = fields;
+  schemaFragments.push(mainTypeTemplate({ typeName, description, interfaces, fields: mainType }));
 
-    if (enums) {
-        for (const { allowedValues, typeName: enumTypeName } of enums) {
-            schemaFragments.push(enumTypeTemplate({ typeName: enumTypeName, allowedValues }));
-        }
+  if (enums) {
+    for (const { allowedValues, typeName: enumTypeName } of enums) {
+      schemaFragments.push(enumTypeTemplate({ typeName: enumTypeName, allowedValues }));
     }
-    if (isNested) {
-        schemaFragments.push(nestedInputTemplate({ typeName, fields: mainType }));
-        //schemaFragments.push(deleteInputTemplate({ typeName }));
-        //schemaFragments.push(singleInputTemplate({ typeName }));
-        //schemaFragments.push(multiInputTemplate({ typeName }));
-        //schemaFragments.push(singleOutputTemplate({ typeName }));
-        //schemaFragments.push(multiOutputTemplate({ typeName }));
-        //schemaFragments.push(mutationOutputTemplate({ typeName }));
-
-        if (create.length) {
-            //   schemaFragments.push(createInputTemplate({ typeName }));
-            schemaFragments.push(createDataInputTemplate({ typeName, fields: create }));
-        }
-
-        if (update.length) {
-            //        schemaFragments.push(updateInputTemplate({ typeName }));
-            //      schemaFragments.push(upsertInputTemplate({ typeName }));
-            schemaFragments.push(updateDataInputTemplate({ typeName, fields: update }));
-        }
-
-        //   schemaFragments.push(selectorInputTemplate({ typeName, fields: selector }));
-
-        //    schemaFragments.push(selectorUniqueInputTemplate({ typeName, fields: selectorUnique }));
-
-        //    schemaFragments.push(orderByInputTemplate({ typeName, fields: orderBy }));
-        return schemaFragments; // return now
-    }
-    schemaFragments.push(deleteInputTemplate({ typeName }));
-    schemaFragments.push(singleInputTemplate({ typeName }));
-    schemaFragments.push(multiInputTemplate({ typeName }));
-    schemaFragments.push(singleOutputTemplate({ typeName }));
-    schemaFragments.push(multiOutputTemplate({ typeName }));
-    schemaFragments.push(mutationOutputTemplate({ typeName }));
+  }
+  if (isNested) {
+    schemaFragments.push(nestedInputTemplate({ typeName, fields: mainType }));
+    //schemaFragments.push(deleteInputTemplate({ typeName }));
+    //schemaFragments.push(singleInputTemplate({ typeName }));
+    //schemaFragments.push(multiInputTemplate({ typeName }));
+    //schemaFragments.push(singleOutputTemplate({ typeName }));
+    //schemaFragments.push(multiOutputTemplate({ typeName }));
+    //schemaFragments.push(mutationOutputTemplate({ typeName }));
 
     if (create.length) {
-        schemaFragments.push(createInputTemplate({ typeName }));
-        schemaFragments.push(createDataInputTemplate({ typeName, fields: create }));
+      //   schemaFragments.push(createInputTemplate({ typeName }));
+      schemaFragments.push(createDataInputTemplate({ typeName, fields: create }));
     }
 
     if (update.length) {
-        schemaFragments.push(updateInputTemplate({ typeName }));
-        schemaFragments.push(upsertInputTemplate({ typeName }));
-        schemaFragments.push(updateDataInputTemplate({ typeName, fields: update }));
+      //        schemaFragments.push(updateInputTemplate({ typeName }));
+      //      schemaFragments.push(upsertInputTemplate({ typeName }));
+      schemaFragments.push(updateDataInputTemplate({ typeName, fields: update }));
     }
 
-    schemaFragments.push(selectorInputTemplate({ typeName, fields: selector }));
+    //   schemaFragments.push(selectorInputTemplate({ typeName, fields: selector }));
 
-    schemaFragments.push(selectorUniqueInputTemplate({ typeName, fields: selectorUnique }));
+    //    schemaFragments.push(selectorUniqueInputTemplate({ typeName, fields: selectorUnique }));
 
-    schemaFragments.push(orderByInputTemplate({ typeName, fields: orderBy }));
+    //    schemaFragments.push(orderByInputTemplate({ typeName, fields: orderBy }));
+    return schemaFragments; // return now
+  }
+  schemaFragments.push(deleteInputTemplate({ typeName }));
+  schemaFragments.push(singleInputTemplate({ typeName }));
+  schemaFragments.push(multiInputTemplate({ typeName }));
+  schemaFragments.push(singleOutputTemplate({ typeName }));
+  schemaFragments.push(multiOutputTemplate({ typeName }));
+  schemaFragments.push(mutationOutputTemplate({ typeName }));
 
+  if (create.length) {
+    schemaFragments.push(createInputTemplate({ typeName }));
+    schemaFragments.push(createDataInputTemplate({ typeName, fields: create }));
+  }
 
+  if (update.length) {
+    schemaFragments.push(updateInputTemplate({ typeName }));
+    schemaFragments.push(upsertInputTemplate({ typeName }));
+    schemaFragments.push(updateDataInputTemplate({ typeName, fields: update }));
+  }
 
-    return schemaFragments;
+  schemaFragments.push(selectorInputTemplate({ typeName, fields: selector }));
 
+  schemaFragments.push(selectorUniqueInputTemplate({ typeName, fields: selectorUnique }));
+
+  schemaFragments.push(orderByInputTemplate({ typeName, fields: orderBy }));
+
+  return schemaFragments;
 };
-const collectionToGraphQL = (collection) => {
-    let graphQLSchema = '';
-    const schemaFragments = [];
+const collectionToGraphQL = collection => {
+  let graphQLSchema = '';
+  const schemaFragments = [];
 
-    const {
-        collectionName, typeName, schema, description,
-        interfaces = [], resolvers, mutations
-    } = getCollectionInfos(collection);
+  const {
+    collectionName,
+    typeName,
+    schema,
+    description,
+    interfaces = [],
+    resolvers,
+    mutations,
+  } = getCollectionInfos(collection);
 
-    const { nestedFieldsList, fields, resolvers: schemaResolvers } = getSchemaFields(schema, typeName);
+  const { nestedFieldsList, fields, resolvers: schemaResolvers } = getSchemaFields(
+    schema,
+    typeName
+  );
 
-    const { mainType } = fields;
+  const { mainType } = fields;
 
-    if (mainType.length) {
-        schemaFragments.push(...generateSchemaFragments({
-            typeName,
-            description,
-            interfaces,
-            fields,
-            isNested: false,
-        }));
-        /* NESTED */
-        // TODO: factorize to use the same function as for non nested fields
-        // the schema may produce a list of additional graphQL types for nested arrays/objects
-        if (nestedFieldsList) {
-            for (const nestedFields of nestedFieldsList) {
-                schemaFragments.push(...generateSchemaFragments({
-                    typeName: nestedFields.typeName,
-                    fields: nestedFields.fields,
-                    isNested: true
-                }));
-            }
-        }
-
-        const { queriesToAdd, resolversToAdd } = createResolvers({ resolvers, typeName });
-        const { mutationsToAdd, mutationsResolversToAdd } = createMutations({
-            mutations,
-            typeName,
-            collectionName,
-            fields,
-        });
-
-        graphQLSchema = schemaFragments.join('\n\n') + '\n\n\n';
-
-        return {
-            graphQLSchema,
-            queriesToAdd,
-            schemaResolvers,
-            resolversToAdd,
-            mutationsToAdd,
-            mutationsResolversToAdd,
-        };
-    } else {
-        // eslint-disable-next-line no-console
-        console.log(
-            `// Warning: collection ${collectionName} doesn't have any GraphQL-enabled fields, so no corresponding type can be generated. Pass generateGraphQLSchema = false to createCollection() to disable this warning`
+  if (mainType.length) {
+    schemaFragments.push(
+      ...generateSchemaFragments({
+        typeName,
+        description,
+        interfaces,
+        fields,
+        isNested: false,
+      })
+    );
+    /* NESTED */
+    // TODO: factorize to use the same function as for non nested fields
+    // the schema may produce a list of additional graphQL types for nested arrays/objects
+    if (nestedFieldsList) {
+      for (const nestedFields of nestedFieldsList) {
+        schemaFragments.push(
+          ...generateSchemaFragments({
+            typeName: nestedFields.typeName,
+            fields: nestedFields.fields,
+            isNested: true,
+          })
         );
+      }
     }
 
-    return { graphQLSchema };
+    const { queriesToAdd, resolversToAdd } = createResolvers({ resolvers, typeName });
+    const { mutationsToAdd, mutationsResolversToAdd } = createMutations({
+      mutations,
+      typeName,
+      collectionName,
+      fields,
+    });
+
+    graphQLSchema = schemaFragments.join('\n\n') + '\n\n\n';
+
+    return {
+      graphQLSchema,
+      queriesToAdd,
+      schemaResolvers,
+      resolversToAdd,
+      mutationsToAdd,
+      mutationsResolversToAdd,
+    };
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(
+      `// Warning: collection ${collectionName} doesn't have any GraphQL-enabled fields, so no corresponding type can be generated. Pass generateGraphQLSchema = false to createCollection() to disable this warning`
+    );
+  }
+
+  return { graphQLSchema };
 };
 
 export default collectionToGraphQL;

--- a/packages/vulcan-lib/lib/modules/graphql/graphql.js
+++ b/packages/vulcan-lib/lib/modules/graphql/graphql.js
@@ -14,7 +14,7 @@ import { disableFragmentWarnings } from 'graphql-tag';
 
 import collectionToGraphQL from './collection';
 import { generateResolversFromSchema } from './resolvers';
-import { mainTypeTemplate } from '../graphql_templates';
+import { mainTypeTemplate, createDataInputTemplate, updateDataInputTemplate } from '../graphql_templates';
 import getSchemaFields from './schemaFields'
 
 disableFragmentWarnings();
@@ -127,11 +127,13 @@ export const GraphQLSchema = {
       throw Error('Error: trying to add type without typeName')
     }
 
-    const { fields, nestedFieldsList, schemaResolvers = [] } = getSchemaFields(schema._schema, typeName);
+    const { fields, nestedFieldsList, schemaResolvers = [],  } = getSchemaFields(schema._schema, typeName);
     mainType = fields.mainType;
     // generate a graphql type def from the simpleSchema 
     console.log('--------------------')
     console.log(typeName)
+    console.log(fields.create)
+    console.log(fields.update)
     // console.log(mainType)
     // console.log(fields)
     // console.log(nestedFieldsList)
@@ -140,10 +142,18 @@ export const GraphQLSchema = {
 
     // console.log(JSON.stringify(fields, null, 2))
     const mainGraphQLSchema = mainTypeTemplate({typeName, fields: mainType, description, interfaces });
-
     // console.log(mainGraphQLSchema)
     // add the type and its resolver
     this.addSchema(mainGraphQLSchema);
+    
+    // createTypeDataInput
+    if ((fields.create || []).length) {
+      this.addSchema(createDataInputTemplate({typeName, fields: fields.create}));
+    }
+    // updateTypeDataInput
+    if ((fields.update || []).length) {
+      this.addSchema(updateDataInputTemplate({typeName, fields: fields.update}));
+    }
     const resolvers = generateResolversFromSchema(schema)
     if(resolvers){
       this.addResolvers({[typeName]: resolvers});
@@ -181,9 +191,9 @@ export const GraphQLSchema = {
     } = getCollectionInfos(collection);
 
 
-    const { nestedFieldsList, fields, resolvers: schemaResolvers = [] } = getSchemaFields(schema._schema, typeName);
+    // const { nestedFieldsList, fields, resolvers: schemaResolvers = [] } = getSchemaFields(schema._schema, typeName);
 
-    addTypeAndResolvers({ typeName, schema, description, });
+    addTypeAndResolvers({ typeName, schema, description, interfaces });
 
     const {
       graphQLSchema,

--- a/packages/vulcan-lib/lib/modules/graphql/graphql.js
+++ b/packages/vulcan-lib/lib/modules/graphql/graphql.js
@@ -29,9 +29,7 @@ disableFragmentWarnings();
  */
 const getCollectionInfos = collection => {
   const collectionName = collection.options.collectionName;
-  const typeName = collection.typeName
-    ? collection.typeName
-    : Utils.camelToSpaces(_initial(collectionName).join('')); // default to posts -> Post
+  const typeName = collection.typeName;
   const schema = collection.simpleSchema();
   const description = collection.options.description
     ? collection.options.description

--- a/packages/vulcan-lib/lib/modules/graphql/graphql.js
+++ b/packages/vulcan-lib/lib/modules/graphql/graphql.js
@@ -13,6 +13,8 @@ import Vulcan from '../config.js'; // used for global export
 import { disableFragmentWarnings } from 'graphql-tag';
 
 import collectionToGraphQL from './collection';
+import {mainTypeTemplate} from '../graphql_templates';
+import getSchemaFields from './schemaFields'
 
 disableFragmentWarnings();
 
@@ -98,6 +100,21 @@ export const GraphQLSchema = {
     this.directives = deepmerge(this.directives, directive);
   },
 
+  addType({ typeName, resolver, schema, description = '', interfaces = [] }) {
+    if(!typeName) {
+      throw Error('Error: trying to add type without typeName')
+    }
+    // generate a graphql type def from the simpleSchema 
+    const { fields } = getSchemaFields(schema, typeName);
+    // console.log(JSON.stringify(fields, null, 2))
+    const graphQLSchema = mainTypeTemplate({typeName, fields: fields.mainType, description, interfaces })
+    console.log(graphQLSchema)
+    // add the type and its resolver
+  },
+
+  // TODO
+  getType(){},
+
 
   // generate a GraphQL schema corresponding to a given collection
   generateSchema(collection) {
@@ -159,4 +176,4 @@ export const removeGraphQLResolver = GraphQLSchema.removeResolver.bind(GraphQLSc
 export const addToGraphQLContext = GraphQLSchema.addToContext.bind(GraphQLSchema);
 export const addGraphQLDirective = GraphQLSchema.addDirective.bind(GraphQLSchema);
 export const addStitchedSchema = GraphQLSchema.addStitchedSchema.bind(GraphQLSchema);
-
+export const addType = GraphQLSchema.addType.bind(GraphQLSchema);

--- a/packages/vulcan-lib/lib/modules/graphql/graphql.js
+++ b/packages/vulcan-lib/lib/modules/graphql/graphql.js
@@ -142,6 +142,9 @@ export const GraphQLSchema = {
 
     // add the type and its resolver
     this.addSchema(mainGraphQLSchema);
+    if( typeName === 'Schema') {
+      // console.log( fields.create )
+    }
 
     // createTypeDataInput
     if ((fields.create || []).length) {

--- a/packages/vulcan-lib/lib/modules/graphql/resolvers.js
+++ b/packages/vulcan-lib/lib/modules/graphql/resolvers.js
@@ -1,6 +1,5 @@
 import SimpleSchema from 'simpl-schema';
 
-
 export /**
  * Generate resolvers for the type defined in the SimpleSchema.
  *
@@ -8,22 +7,14 @@ export /**
  * @returns an object mapping the field names to a GraphQL resolver function
  */
 const generateResolversFromSchema = schema => {
-  // console.log(schema);
   if (!(schema instanceof SimpleSchema)) {
     throw Error('must pass a SimpleSchema to generate Resolvers');
   }
-  const { _schema, _schemaKeys, _firstLevelSchemaKeys, _objectKeys, _blackboxKeys } = schema;
+  const { _schema, _firstLevelSchemaKeys } = schema;
   const resolvers = {};
-  console.log('schemakeys: ', _schemaKeys)
-  console.log('firstLevelSchemaKeys: ', _firstLevelSchemaKeys)
-  console.log('objectKeys: ', _objectKeys)
-  console.log('blackboxKeys: ', _blackboxKeys)
 
   _firstLevelSchemaKeys.forEach(key => {
-    // console.log(_schema[key]);
     const resolver = (root, args, context) => {
-      // console.log('in resolver!!!')
-      // console.log(root)
       const result = root[key];
       if (!result) return null;
       const { currentUser, Users } = context;

--- a/packages/vulcan-lib/lib/modules/graphql/resolvers.js
+++ b/packages/vulcan-lib/lib/modules/graphql/resolvers.js
@@ -1,0 +1,39 @@
+import SimpleSchema from 'simpl-schema';
+
+
+export /**
+ * Generate resolvers for the type defined in the SimpleSchema.
+ *
+ * @param {SimpleSchema} schema
+ * @returns an object mapping the field names to a GraphQL resolver function
+ */
+const generateResolversFromSchema = schema => {
+  // console.log(schema);
+  if (!(schema instanceof SimpleSchema)) {
+    throw Error('must pass a SimpleSchema to generate Resolvers');
+  }
+  const { _schema, _schemaKeys, _firstLevelSchemaKeys, _objectKeys, _blackboxKeys } = schema;
+  const resolvers = {};
+  console.log('schemakeys: ', _schemaKeys)
+  console.log('firstLevelSchemaKeys: ', _firstLevelSchemaKeys)
+  console.log('objectKeys: ', _objectKeys)
+  console.log('blackboxKeys: ', _blackboxKeys)
+
+  _firstLevelSchemaKeys.forEach(key => {
+    // console.log(_schema[key]);
+    const resolver = (root, args, context) => {
+      // console.log('in resolver!!!')
+      // console.log(root)
+      const result = root[key];
+      if (!result) return null;
+      const { currentUser, Users } = context;
+      if (Users.canReadField(currentUser, _schema[key], root)) {
+        return result;
+      } else {
+        return null;
+      }
+    };
+    resolvers[key] = resolver;
+  });
+  return resolvers;
+};

--- a/packages/vulcan-lib/lib/modules/graphql/schemaFields.js
+++ b/packages/vulcan-lib/lib/modules/graphql/schemaFields.js
@@ -28,7 +28,7 @@ const isValidEnum = (values) => !values.find((val => !isValidName(val)));
 // get GraphQL type for a nested object (<MainTypeName><FieldName> e.g PostAuthor, EventAdress, etc.)
 export const getNestedGraphQLType = (typeName, fieldName, isInput) => `${typeName}${capitalize(unarrayfyFieldName(fieldName))}${isInput ? 'Input' : ''}`;
 
-export const getEnumType = (typeName, fieldName) => `${typeName}${capitalize(unarrayfyFieldName(fieldName))}Enum`;
+// export const getEnumType = (typeName, fieldName) => `${typeName}${capitalize(unarrayfyFieldName(fieldName))}Enum`;
 
 
 // get GraphQL type for a given schema and field name
@@ -50,9 +50,9 @@ export const getGraphQLType = ({
 
   switch (fieldTypeName) {
     case 'String':
-      if (hasAllowedValues(field) && isValidEnum(getAllowedValues(field))) {
-        return getEnumType(typeName, fieldName);
-      }
+      // if (hasAllowedValues(field) && isValidEnum(getAllowedValues(field))) {
+      //   return getEnumType(typeName, fieldName);
+      // }
       return 'String';
 
     case 'Boolean':
@@ -99,7 +99,7 @@ export const getGraphQLType = ({
   }
 };
 
-const isNestedObjectField = (field) => !!getNestedSchema(field);
+const isNestedObjectField = (field) => !!field.typeName; 
 const getNestedSchema = field => field.type.singleType._schema;
 
 const isArrayChildField = (fieldName) => fieldName.indexOf('$') !== -1;
@@ -268,6 +268,7 @@ export const getPermissionFields = ({
 // for a given schema, return main type fields, selector fields,
 // unique selector fields, orderBy fields, creatable fields, and updatable fields
 export const getSchemaFields = (schema, typeName) => {
+  if(!schema) console.log('/////////////////////',typeName, '/////////////////////')
   const fields = {
     mainType: [],
     create: [],
@@ -321,22 +322,22 @@ export const getSchemaFields = (schema, typeName) => {
 
 
       // if field has allowedValues, add enum type
-      if (hasAllowedValues(field)) {
-        const allowedValues = getAllowedValues(field);
-        // TODO: we can't force value creation
-        //if (!isValidEnum(allowedValues)) throw new Error(`Allowed values of field ${ fieldName } can not be used as enum.
-        //One or more values are not respecting the Name regex: /[_A-Za-z][_0-9A-Za-z]*/.`)//;
+      // if (hasAllowedValues(field)) {
+      //   const allowedValues = getAllowedValues(field);
+      //   // TODO: we can't force value creation
+      //   //if (!isValidEnum(allowedValues)) throw new Error(`Allowed values of field ${ fieldName } can not be used as enum.
+      //   //One or more values are not respecting the Name regex: /[_A-Za-z][_0-9A-Za-z]*/.`)//;
 
-        // ignore arrays containing invalid values
-        if (isValidEnum(allowedValues)) {
-          fields.enums.push({//
-            allowedValues,
-            typeName: getEnumType(typeName, fieldName)
-          });
-        } else {
-          console.warn(`Warning: Allowed values of field ${fieldName} can not be used as GraphQL Enum. One or more values are not respecting the Name regex: /[_A-Za-z][_0-9A-Za-z]*/. Consider normalizing allowedValues and using separate labels for displaying.`);
-        }
-      }
+      //   // ignore arrays containing invalid values
+      //   if (isValidEnum(allowedValues)) {
+      //     fields.enums.push({//
+      //       allowedValues,
+      //       typeName: getEnumType(typeName, fieldName)
+      //     });
+      //   } else {
+      //     console.warn(`Warning: Allowed values of field ${fieldName} can not be used as GraphQL Enum. One or more values are not respecting the Name regex: /[_A-Za-z][_0-9A-Za-z]*/. Consider normalizing allowedValues and using separate labels for displaying.`);
+      //   }
+      // }
 
       const permissionsFields = getPermissionFields({ field, fieldName, fieldType, inputFieldType, hasNesting });
       fields.create.push(...permissionsFields.create);
@@ -346,27 +347,27 @@ export const getSchemaFields = (schema, typeName) => {
       fields.orderBy.push(...permissionsFields.orderBy);
 
       // check for nested fields
-      if (isNestedObject) {
-        //console.log('detected a nested field', fieldName);
-        const nestedSchema = getNestedSchema(field);
-        const nestedTypeName = getNestedGraphQLType(typeName, fieldName);
-        //const nestedInputTypeName = `${nestedTypeName}Input`;
-        const nestedFields = getSchemaFields(nestedSchema, nestedTypeName);
-        // add the generated typeName to the info
-        nestedFields.typeName = nestedTypeName;
-        //nestedFields.inputTypeName = nestedInputTypeName;
-        nestedFieldsList.push(nestedFields);
-      }
-      // check if field is an array of objects
-      if (isNestedArray) {
-        //console.log('detected a field with an array child', fieldName);
-        const arrayNestedSchema = getArrayChildSchema(fieldName, schema);
-        const arrayNestedTypeName = getNestedGraphQLType(typeName, fieldName);
-        const arrayNestedFields = getSchemaFields(arrayNestedSchema, arrayNestedTypeName);
-        // add the generated typeName to the info
-        arrayNestedFields.typeName = arrayNestedTypeName;
-        nestedFieldsList.push(arrayNestedFields);
-      }
+      // if (isNestedObject) {
+      //   //console.log('detected a nested field', fieldName);
+      //   const nestedSchema = getNestedSchema(field);
+      //   const nestedTypeName = getNestedGraphQLType(typeName, fieldName);
+      //   //const nestedInputTypeName = `${nestedTypeName}Input`;
+      //   const nestedFields = getSchemaFields(nestedSchema, nestedTypeName);
+      //   // add the generated typeName to the info
+      //   nestedFields.typeName = nestedTypeName;
+      //   //nestedFields.inputTypeName = nestedInputTypeName;
+      //   nestedFieldsList.push(nestedFields);
+      // }
+      // // check if field is an array of objects
+      // if (isNestedArray) {
+      //   //console.log('detected a field with an array child', fieldName);
+      //   const arrayNestedSchema = getArrayChildSchema(fieldName, schema);
+      //   const arrayNestedTypeName = getNestedGraphQLType(typeName, fieldName);
+      //   const arrayNestedFields = getSchemaFields(arrayNestedSchema, arrayNestedTypeName);
+      //   // add the generated typeName to the info
+      //   arrayNestedFields.typeName = arrayNestedTypeName;
+      //   nestedFieldsList.push(arrayNestedFields);
+      // }
 
     }
   });

--- a/packages/vulcan-lib/lib/modules/graphql/schemaFields.js
+++ b/packages/vulcan-lib/lib/modules/graphql/schemaFields.js
@@ -3,13 +3,9 @@
  */
 /* eslint-disable no-console */
 import { isIntlField } from '../intl.js';
-import {
-  hasAllowedValues,
-  getAllowedValues,
-  unarrayfyFieldName
-} from '../simpleSchema_utils';
+import { hasAllowedValues, getAllowedValues, unarrayfyFieldName } from '../simpleSchema_utils';
 
-const capitalize = (word) => {
+const capitalize = word => {
   if (!word) return word;
   const [first, ...rest] = word;
   return [first.toUpperCase(), ...rest].join('');
@@ -17,32 +13,33 @@ const capitalize = (word) => {
 
 // @see https://graphql.github.io/graphql-spec/June2018/#sec-Enums
 // @see https://graphql.github.io/graphql-spec/June2018/#sec-Names
-const isValidName = (name) => {
+const isValidName = name => {
   if (typeof name !== 'string') {
-    throw new Error(`Allowed value of field of type String is not a string (value: ${name}, type:${typeof name})`);
+    throw new Error(
+      `Allowed value of field of type String is not a string (value: ${name}, type:${typeof name})`
+    );
   }
   return name.match(/^[_A-Za-z][_0-9A-Za-z]*$/);
 };
-const isValidEnum = (values) => !values.find((val => !isValidName(val)));
+const isValidEnum = values => !values.find(val => !isValidName(val));
 
 // get GraphQL type for a nested object (<MainTypeName><FieldName> e.g PostAuthor, EventAdress, etc.)
-export const getNestedGraphQLType = (typeName, fieldName, isInput) => `${typeName}${capitalize(unarrayfyFieldName(fieldName))}${isInput ? 'Input' : ''}`;
+export const getNestedGraphQLType = (typeName, fieldName, isInput) =>
+  `${typeName}${capitalize(unarrayfyFieldName(fieldName))}${isInput ? 'Input' : ''}`;
 
 // export const getEnumType = (typeName, fieldName) => `${typeName}${capitalize(unarrayfyFieldName(fieldName))}Enum`;
 
-
 // get GraphQL type for a given schema and field name
-export const getGraphQLType = ({
-  schema,
-  fieldName,
-  typeName,
-  isInput = false
-}) => {
+export const getGraphQLType = ({ schema, fieldName, typeName, isInput = false }) => {
   const field = schema[fieldName];
 
   const fieldType = field.type.singleType;
   const fieldTypeName =
-    typeof fieldType === 'object' ? 'Object' : typeof fieldType === 'function' ? fieldType.name : fieldType;
+    typeof fieldType === 'object'
+      ? 'Object'
+      : typeof fieldType === 'function'
+      ? fieldType.name
+      : fieldType;
 
   if (field.isIntlData) {
     return isInput ? '[IntlValueInput]' : '[IntlValue]';
@@ -74,7 +71,7 @@ export const getGraphQLType = ({
           schema,
           fieldName: arrayItemFieldName,
           typeName,
-          isInput
+          isInput,
         });
         return arrayItemType ? `[${arrayItemType}]` : null;
       }
@@ -99,24 +96,26 @@ export const getGraphQLType = ({
   }
 };
 
-const isNestedObjectField = (field) => !!field.typeName; 
+const isNestedObjectField = field => !!field.typeName;
 const getNestedSchema = field => field.type.singleType._schema;
 
-const isArrayChildField = (fieldName) => fieldName.indexOf('$') !== -1;
+const isArrayChildField = fieldName => fieldName.indexOf('$') !== -1;
 const getArrayChild = (fieldName, schema) => schema[`${fieldName}.$`];
 const hasArrayChild = (fieldName, schema) => !!getArrayChild(fieldName, schema);
 
 const getArrayChildSchema = (fieldName, schema) => {
   return getNestedSchema(getArrayChild(fieldName, schema));
 };
-const hasArrayNestedChild = (fieldName, schema) => hasArrayChild(fieldName, schema) && !!getArrayChildSchema(fieldName, schema);
+const hasArrayNestedChild = (fieldName, schema) =>
+  hasArrayChild(fieldName, schema) && !!getArrayChildSchema(fieldName, schema);
 
-const hasPermissions = field => (
-  field.canRead || field.canCreate || field.canUpdate
-);
+const hasPermissions = field => field.canRead || field.canCreate || field.canUpdate;
 const hasLegacyPermissions = field => {
   const hasLegacyPermissions = field.viewableBy || field.insertableBy || field.editableBy;
-  if (hasLegacyPermissions) console.warn('Some field is using legacy permission fields viewableBy, insertableBy and editableBy. Please replace those fields with canRead, canCreate and canUpdate.');
+  if (hasLegacyPermissions)
+    console.warn(
+      'Some field is using legacy permission fields viewableBy, insertableBy and editableBy. Please replace those fields with canRead, canCreate and canUpdate.'
+    );
   return hasLegacyPermissions;
 };
 
@@ -159,9 +158,7 @@ export const getResolveAsFields = ({
         const { Users, currentUser } = context;
         // check that current user has permission to access the original non-resolved field
         const canReadField = Users.canReadField(currentUser, field, document);
-        return canReadField
-          ? field.resolveAs.resolver(document, args, context, info)
-          : null;
+        return canReadField ? field.resolveAs.resolver(document, args, context, info) : null;
       },
     },
   };
@@ -179,7 +176,6 @@ export const getResolveAsFields = ({
   }
   return { fields, resolvers };
 };
-
 
 // [Foo] => [CreateFoo]
 const prefixType = (prefix, type) => {
@@ -199,7 +195,7 @@ export const getPermissionFields = ({
   fieldName,
   fieldType,
   inputFieldType,
-  hasNesting = false
+  hasNesting = false,
 }) => {
   const fields = {
     create: [],
@@ -208,8 +204,12 @@ export const getPermissionFields = ({
     selectorUnique: [],
     orderBy: [],
   };
-  const createInputFieldType = hasNesting ? suffixType(prefixType('Create', fieldType), 'DataInput') : inputFieldType;
-  const updateInputFieldType = hasNesting ? suffixType(prefixType('Update', fieldType), 'DataInput') : inputFieldType;
+  const createInputFieldType = hasNesting
+    ? suffixType(prefixType('Create', fieldType), 'DataInput')
+    : inputFieldType;
+  const updateInputFieldType = hasNesting
+    ? suffixType(prefixType('Update', fieldType), 'DataInput')
+    : inputFieldType;
 
   // OpenCRUD backwards compatibility
   if (field.canCreate || field.insertableBy) {
@@ -268,7 +268,7 @@ export const getPermissionFields = ({
 // for a given schema, return main type fields, selector fields,
 // unique selector fields, orderBy fields, creatable fields, and updatable fields
 export const getSchemaFields = (schema, typeName) => {
-  if(!schema) console.log('/////////////////////',typeName, '/////////////////////')
+  if (!schema) console.log('/////////////////////', typeName, '/////////////////////');
   const fields = {
     mainType: [],
     create: [],
@@ -276,7 +276,7 @@ export const getSchemaFields = (schema, typeName) => {
     selector: [],
     selectorUnique: [],
     orderBy: [],
-    enums: []
+    enums: [],
   };
   const nestedFieldsList = [];
   const resolvers = [];
@@ -293,9 +293,7 @@ export const getSchemaFields = (schema, typeName) => {
     // only include fields that are viewable/insertable/editable and don't contain "$" in their name
     // note: insertable/editable fields must be included in main schema in case they're returned by a mutation
     // OpenCRUD backwards compatibility
-    if (
-      (hasPermissions(field) || hasLegacyPermissions(field)) && !isArrayChildField(fieldName)
-    ) {
+    if ((hasPermissions(field) || hasLegacyPermissions(field)) && !isArrayChildField(fieldName)) {
       const fieldDescription = field.description;
       const fieldDirective = isIntlField(field) ? '@intl' : '';
       const fieldArguments = isIntlField(field) ? [{ name: 'locale', type: 'String' }] : [];
@@ -303,7 +301,13 @@ export const getSchemaFields = (schema, typeName) => {
       // if field has a resolveAs, push it to schema
       if (field.resolveAs) {
         const { fields: resolveAsFields, resolvers: resolveAsResolvers } = getResolveAsFields({
-          typeName, field, fieldName, fieldType, fieldDescription, fieldDirective, fieldArguments
+          typeName,
+          field,
+          fieldName,
+          fieldType,
+          fieldDescription,
+          fieldDirective,
+          fieldArguments,
         });
         resolvers.push(...resolveAsResolvers);
         fields.mainType.push(...resolveAsFields.mainType);
@@ -319,7 +323,6 @@ export const getSchemaFields = (schema, typeName) => {
           });
         }
       }
-
 
       // if field has allowedValues, add enum type
       // if (hasAllowedValues(field)) {
@@ -339,7 +342,13 @@ export const getSchemaFields = (schema, typeName) => {
       //   }
       // }
 
-      const permissionsFields = getPermissionFields({ field, fieldName, fieldType, inputFieldType, hasNesting });
+      const permissionsFields = getPermissionFields({
+        field,
+        fieldName,
+        fieldType,
+        inputFieldType,
+        hasNesting,
+      });
       fields.create.push(...permissionsFields.create);
       fields.update.push(...permissionsFields.update);
       fields.selector.push(...permissionsFields.selector);
@@ -368,13 +377,12 @@ export const getSchemaFields = (schema, typeName) => {
       //   arrayNestedFields.typeName = arrayNestedTypeName;
       //   nestedFieldsList.push(arrayNestedFields);
       // }
-
     }
   });
   return {
     fields,
     nestedFieldsList,
-    resolvers
+    resolvers,
   };
 };
 

--- a/packages/vulcan-lib/lib/modules/graphql/schemaFields.js
+++ b/packages/vulcan-lib/lib/modules/graphql/schemaFields.js
@@ -85,6 +85,10 @@ export const getGraphQLType = ({
       if (!field.blackbox && fieldType._schema) {
         return getNestedGraphQLType(typeName, fieldName, isInput);
       }
+      // getType(typeName)
+      if (field.type.definitions[0].blackbox && field.typeName) {
+        return field.typeName;
+      }
       // blackbox JSON object
       return 'JSON';
     case 'Date':

--- a/packages/vulcan-lib/lib/modules/graphql_templates.js
+++ b/packages/vulcan-lib/lib/modules/graphql_templates.js
@@ -114,11 +114,13 @@ enum MovieOrderByInput {
   createdAt
 }
 
+NB: the foobar is not a mistake, we need it because the type should always
+be defined, even if there are no fields.
+
 */
 export const orderByInputTemplate = ({ typeName, fields }) =>
   `enum ${typeName}OrderByInput {
-  foobar
-  ${fields.join('\n  ')}
+  ${Array.isArray(fields) && fields.length ? fields.join('\n  ') : 'foobar'}
 }`;
 
 /* ------------------------------------- Query Types ------------------------------------- */

--- a/packages/vulcan-lib/lib/modules/graphql_templates.js
+++ b/packages/vulcan-lib/lib/modules/graphql_templates.js
@@ -47,7 +47,7 @@ type Movie{
 
 */
 export const mainTypeTemplate = ({ typeName, description = '', interfaces = '', fields }) =>
-  `# ${description}
+  `${description ? '# ' + description : ''}
 type ${typeName} ${interfaces.length ? `implements ${interfaces.join(', ')} ` : ''}{
 ${convertToGraphQL(fields, '  ')}
 }

--- a/packages/vulcan-lib/lib/server/apollo-server/initGraphQL.js
+++ b/packages/vulcan-lib/lib/server/apollo-server/initGraphQL.js
@@ -11,6 +11,7 @@ import { runCallbacks } from '../../modules/callbacks.js';
 const initGraphQL = () => {
   runCallbacks('graphql.init.before');
   const typeDefs = generateTypeDefs(GraphQLSchema);
+  // console.log(GraphQLSchema.resolvers)
   const executableSchema = makeExecutableSchema({
     typeDefs,
     resolvers: GraphQLSchema.resolvers,

--- a/packages/vulcan-lib/lib/server/apollo-server/initGraphQL.js
+++ b/packages/vulcan-lib/lib/server/apollo-server/initGraphQL.js
@@ -11,7 +11,7 @@ import { runCallbacks } from '../../modules/callbacks.js';
 const initGraphQL = () => {
   runCallbacks('graphql.init.before');
   const typeDefs = generateTypeDefs(GraphQLSchema);
-  // console.log(GraphQLSchema.resolvers)
+
   const executableSchema = makeExecutableSchema({
     typeDefs,
     resolvers: GraphQLSchema.resolvers,

--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -178,7 +178,9 @@ export const isAdmin = Users.isAdmin;
 /**
  * @summary Check if a user can view a field
  * @param {Object} user - The user performing the action
- * @param {Object} field - The field being edited or inserted
+ * @param {Object} field - The schema of the requested field
+ * @param {Object} field - The full document of the collection
+ * @returns {Boolean} - true if the user can read the field, false if not
  */
  Users.canReadField = function (user, field, document) {
    const canRead = field.canRead || field.viewableBy; //OpenCRUD backwards compatibility

--- a/packages/vulcan-users/lib/modules/schema.js
+++ b/packages/vulcan-users/lib/modules/schema.js
@@ -39,6 +39,18 @@ const ownsOrIsAdmin = (user, document) => {
   return getCollection('Users').owns(user, document) || getCollection('Users').isAdmin(user);
 };
 
+const UserEmail = {
+  address: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Email,
+    optional: true,
+  },
+  verified: {
+    type: Boolean,
+    optional: true,
+  },
+};
+
 /**
  * @summary Users schema
  * @type {Object}
@@ -67,23 +79,14 @@ const schema = {
     },
     searchable: true,
   },
-  emails: {
-    type: Array,
-    optional: true,
-  },
-  'emails.$': {
-    type: Object,
-    optional: true,
-  },
-  'emails.$.address': {
-    type: String,
-    regEx: SimpleSchema.RegEx.Email,
-    optional: true,
-  },
-  'emails.$.verified': {
-    type: Boolean,
-    optional: true,
-  },
+  // emails: {
+  //   type: Array,
+  //   optional: true,
+  // },
+  // 'emails.$': {
+  //   type: Object,
+  //   optional: true,
+  // },
   createdAt: {
     type: Date,
     optional: true,

--- a/packages/vulcan-users/lib/modules/schema.js
+++ b/packages/vulcan-users/lib/modules/schema.js
@@ -1,5 +1,5 @@
 import SimpleSchema from 'simpl-schema';
-import { Utils, getCollection, Connectors, Locales } from 'meteor/vulcan:lib'; // import from vulcan:lib because vulcan:core isn't loaded yet
+import { Utils, getCollection, Connectors, Locales, getType, addTypeAndResolvers } from 'meteor/vulcan:lib'; // import from vulcan:lib because vulcan:core isn't loaded yet
 
 ///////////////////////////////////////
 // Order for the Schema is as follows. Change as you see fit:
@@ -44,12 +44,15 @@ const UserEmail = {
     type: String,
     regEx: SimpleSchema.RegEx.Email,
     optional: true,
+    canRead: ['admin']
   },
   verified: {
     type: Boolean,
     optional: true,
+    canRead: ['admin']
   },
 };
+addTypeAndResolvers({ typeName: 'UserEmail', schema: new SimpleSchema(UserEmail), description: 'The known emails of the user' });
 
 /**
  * @summary Users schema
@@ -79,14 +82,15 @@ const schema = {
     },
     searchable: true,
   },
-  // emails: {
-  //   type: Array,
-  //   optional: true,
-  // },
-  // 'emails.$': {
-  //   type: Object,
-  //   optional: true,
-  // },
+  emails: {
+    type: Array,
+    optional: true,
+    canRead: ['admin']
+  },
+  'emails.$': {
+    ...getType('UserEmail'),
+    optional: true,
+  },
   createdAt: {
     type: Date,
     optional: true,


### PR DESCRIPTION
Hi all,
This is a draft of the way we should handle nested types IMO. 
Here is a recap of how it works, as said in #2323 : 

Every time we create a collection with a schema, it registers the graphql schema through a function called `addTypeAndResolver` (name to change maybe). This function creates the type definition, input types and resolvers for the **flat** type. Nested types have to be registered directly through this function, and can be referenced thanks to another function `getType` (name to change because too generic). Also, each field resolver checks the `canRead` to make sure the field can be read by the user. One thing to get though, is that the `canRead` is tied to the type, so if you reuse the type at two places, then it will have the same schema.
You can see an example in `vulcan:users/modules/schema`, on the emails field.

This way, we can really handle nested types and deeply nested fields inside one document.
I have reworked the `Users` collection which had some kind of nesting in it (field emails, but not viewable).

This is just a draft. What remains to be done is : 

- [ ] find better names for the new functions
- [ ] rework / clean / optimize the code in vulcan:lib/lib/modules/graphql
- [ ] rework default fragment generation
- [ ] rework validation on mutation resolvers (will probably need to memo the schema for each type)
- [ ] Forms
- [ ] Datatable
- [ ] fix unit tests
- [ ] test it a lot

I will begin developing my side project on this branch, so I can test it.

Any feedback is welcome!

PS : This will be a breaking change, but it is necesary. I suggest we take advantage of this and remove all the backwards compatibility related to previous releases, for instance all related to the openCRUD change. So we might want to add warnings on every soon-to-be-deprecated feature to the next minor release.