### PR TITLE
Re-enable RouterHook component so that pageview events are sent to analytics

### DIFF
--- a/packages/vulcan-core/lib/modules/components/RouterHook.jsx
+++ b/packages/vulcan-core/lib/modules/components/RouterHook.jsx
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { registerComponent, runCallbacks, runCallbacksAsync } from 'meteor/vulcan:lib';
 import { withApollo } from 'react-apollo';
 
@@ -18,11 +19,19 @@ class RouterHook extends PureComponent {
     // note: this item is not used in this specific callback: router.onUpdate
     runCallbacks('router.onUpdate', {}, currentRoute, client.store, client);
 
-    runCallbacksAsync('router.onUpdate.async', props, nextProps);
+    runCallbacksAsync('router.onupdate.async', props, nextProps);
   };
 
   render() {
     return null;
   }
 }
+
+RouterHook.propTypes = {
+  currentRoute: PropTypes.object,
+  client: PropTypes.object,
+};
+
+RouterHook.displayName = 'RouterHook';
+
 registerComponent('RouterHook', RouterHook, withApollo);

--- a/packages/vulcan-events-segment/lib/client/segment-client.js
+++ b/packages/vulcan-events-segment/lib/client/segment-client.js
@@ -11,7 +11,7 @@ import {
 Track Page
 
 */
-function segmentTrackPage(route) {
+function segmentTrackPage (route) {
   const { name, path } = route;
   const properties = {
     url: Utils.getSiteUrl().slice(0, -1) + path,
@@ -27,7 +27,7 @@ addPageFunction(segmentTrackPage);
 Identify User
 
 */
-function segmentIdentify(currentUser) {
+function segmentIdentify (currentUser) {
   window.analytics.identify(currentUser._id, {
     email: currentUser.email,
     pageUrl: currentUser.pageUrl,
@@ -40,7 +40,7 @@ addIdentifyFunction(segmentIdentify);
 Track Event
 
 */
-function segmentTrack(eventName, eventProperties) {
+function segmentTrack (eventName, eventProperties) {
   window.analytics.track(eventName, eventProperties);
 }
 addTrackFunction(segmentTrack);
@@ -50,39 +50,20 @@ addTrackFunction(segmentTrack);
 Init Snippet
 
 */
-function segmentInit() {
-  !(function() {
-    var analytics = (window.analytics = window.analytics || []);
+function segmentInit () {
+  !function () {
+    var analytics = window.analytics = window.analytics || [];
     if (!analytics.initialize)
       if (analytics.invoked)
-        // eslint-disable-next-line no-console
-        window.console &&
-          // eslint-disable-next-line no-console
-          console.error &&
-          // eslint-disable-next-line no-console
-          console.error('Segment snippet included twice.');
+      // eslint-disable-next-line no-console
+        window.console && console.error && console.error('Segment snippet included twice.');
       else {
         analytics.invoked = !0;
-        analytics.methods = [
-          'trackSubmit',
-          'trackClick',
-          'trackLink',
-          'trackForm',
-          'pageview',
-          'identify',
-          'reset',
-          'group',
-          'track',
-          'ready',
-          'alias',
-          'debug',
-          'page',
-          'once',
-          'off',
-          'on',
-        ];
-        analytics.factory = function(t) {
-          return function() {
+        analytics.methods =
+          ['trackSubmit', 'trackClick', 'trackLink', 'trackForm', 'pageview', 'identify',
+            'reset', 'group', 'track', 'ready', 'alias', 'debug', 'page', 'once', 'off', 'on'];
+        analytics.factory = function (t) {
+          return function () {
             var e = Array.prototype.slice.call(arguments);
             e.unshift(t);
             analytics.push(e);
@@ -93,21 +74,18 @@ function segmentInit() {
           var e = analytics.methods[t];
           analytics[e] = analytics.factory(e);
         }
-        analytics.load = function(t) {
-          var e = document.createElement('script');
-          e.type = 'text/javascript';
-          e.async = !0;
-          e.src =
-            ('https:' === document.location.protocol ? 'https://' : 'http://') +
-            'cdn.segment.com/analytics.js/v1/' +
-            t +
-            '/analytics.min.js';
-          var n = document.getElementsByTagName('script')[0];
-          n.parentNode.insertBefore(e, n);
+        analytics.load = function (t, e) {
+          var n = document.createElement('script');
+          n.type = 'text/javascript';
+          n.async = !0;
+          n.src = 'https://cdn.segment.com/analytics.js/v1/' + t + '/analytics.min.js';
+          var a = document.getElementsByTagName('script')[0];
+          a.parentNode.insertBefore(n, a);
+          analytics._loadOptions = e;
         };
-        analytics.SNIPPET_VERSION = '4.0.0';
+        analytics.SNIPPET_VERSION = '4.1.0';
         analytics.load(getSetting('segment.clientKey'));
       }
-  })();
+  }();
 }
 addInitFunction(segmentInit);

--- a/packages/vulcan-events/lib/modules/events.js
+++ b/packages/vulcan-events/lib/modules/events.js
@@ -45,5 +45,5 @@ export const addPageFunction = f => {
   descriptor.value = f.name;
   Object.defineProperty(f2, 'name', descriptor);
 
-  addCallback('router.onUpdate.async', f2);
+  addCallback('router.onupdate.async', f2);
 };

--- a/packages/vulcan-lib/lib/modules/utils.js
+++ b/packages/vulcan-lib/lib/modules/utils.js
@@ -180,6 +180,15 @@ Utils.slugify = function (s) {
   return slug;
 };
 
+/**
+ * @summary Given a collection and a slug, returns the same or modified slug that's unique within the collection;
+ * It's modified by appending a dash and an integer; eg: my-slug  =>  my-slug-1
+ * @param {Object} collection
+ * @param {string} slug
+ * @param {string} [documentId] If you are generating a slug for an existing document, pass it's _id to
+ * avoid the slug changing
+ * @returns {string} The slug passed in the 2nd param, but may be
+ */
 Utils.getUnusedSlug = function (collection, slug, documentId) {
   // test if slug is already in use
   for (let index = 0; index <= Number.MAX_SAFE_INTEGER; index++) {
@@ -208,6 +217,13 @@ Utils.getUnusedSlug = function (collection, slug, documentId) {
 //   return slug + suffix;
 // };
 
+/**
+ * @summary This is the same as Utils.getUnusedSlug(), but takes the name of the collection instead
+ * @param {string} collectionName
+ * @param {string} slug
+ * @param {string} [documentId]
+ * @returns {string}
+ */
 Utils.getUnusedSlugByCollectionName = function (collectionName, slug, documentId) {
   return Utils.getUnusedSlug(getCollection(collectionName), slug, documentId);
 };


### PR DESCRIPTION
Re-enable RouterHook component in App.jsx so that page view events are sent to analytics.

 * Moved `RouterHook` component from `App` (where it was commented out anyway) to `RouteWithLayout`
 * Fixed bug: changed `router.onUpdate.async` to `router.onupdate.async`
 * In `vulcan:events-segment` upgraded the Segment analytics snippet to version '4.1.0'
 * Fixed bug: `segmentIdentifyServer()` would identify the same user repeatedly (several times a minute)
 * Unrelated: Added JSDoc to `Utils.getUnusedSlug()` and `Utils.getUnusedSlugByCollectionName`