### PR TITLE
MaterialUiStartAdornment

### DIFF
--- a/packages/vulcan-ui-material/history.md
+++ b/packages/vulcan-ui-material/history.md
@@ -1,3 +1,11 @@
+1.13.2 / 2019-09-13
+===================
+
+ * Forms: Added indicator for required fields
+ * Forms: Added support for styling of disabled input
+ * LoadMore: Fixed bug that would sometimes display "NaN items"
+ * StartAdornment: url and email inputs are now adorned with an icon button link - unless you pass `hideLink: true` in inputProperties
+ 
 1.13.0_1 / 2019-07-23
 =====================
 

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/StartAdornment.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/StartAdornment.jsx
@@ -5,15 +5,21 @@ import withStyles from '@material-ui/core/styles/withStyles';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import IconButton from '@material-ui/core/IconButton';
 import OpenInNewIcon from 'mdi-material-ui/OpenInNew';
+import WebIcon from 'mdi-material-ui/Web';
+import EmailIcon from 'mdi-material-ui/EmailOutline';
 import { styles } from './EndAdornment';
 
 
 export const hideStartAdornment = (props) => {
-  return !props.addonBefore && !props.isUrl;
+  const { type, hideLink } = props;
+  return !props.addonBefore && (!['url', 'email'].includes(type) || hideLink);
 };
 
 
-export const fixUrl = (url) => {
+export const fixUrl = (url, type) => {
+  if (type === 'email') {
+    return `mailto:${url}`;
+  }
   return url.indexOf('http://') === -1 && url.indexOf('https://') ? 'http://' + url : url;
 };
 
@@ -23,14 +29,20 @@ const StartAdornment = (props) => {
   
   if (hideStartAdornment(props)) return null;
   
-  const urlButton = type === 'url' &&
+  const urlButton = ['url', 'email'].includes(type) &&
     <IconButton
       className={classes.urlButton}
-      href={fixUrl(value)}
+      href={fixUrl(value, type)}
       target="_blank"
       disabled={!value}
     >
-      <OpenInNewIcon/>
+      {
+        type === 'url'
+          ?
+          <WebIcon/>
+          :
+          <EmailIcon/>
+      }
     </IconButton>;
   
   

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/mixins/component.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/mixins/component.jsx
@@ -82,6 +82,7 @@ export default {
       'afterComponent',
       'addonAfter',
       'addonBefore',
+      'hideLink',
       'help',
       'label',
       'hideLabel',

--- a/packages/vulcan-ui-material/package.js
+++ b/packages/vulcan-ui-material/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'vulcan:ui-material',
-  version: '1.13.0_1',
+  version: '1.13.2',
   summary: 'Replacement for Vulcan (http://vulcanjs.org/) components using material-ui',
   documentation: 'README.md'
 });

--- a/packages/vulcan-ui-material/readme.md
+++ b/packages/vulcan-ui-material/readme.md
@@ -1,4 +1,4 @@
-# vulcan:ui-material 1.13.0_1
+# vulcan:ui-material 1.13.2
 
 Package initially created by [Erik Dakoda](https://github.com/ErikDakoda) ([`erikdakoda:vulcan-material-ui`](https://github.com/ErikDakoda/vulcan-material-ui))
 
@@ -109,6 +109,8 @@ You can pass a couple of extra options to inputs from the `form` property of you
       inputClassName: 'halfWidthLeft', // use 'halfWidthLeft' or 'halfWidthRight'
                                        //   to display two controls side by side
       hideLabel: true,                 // hide the label
+      hideLink: true,                  // url and email inputs are are adorned with
+                                       // an icon button link - unless you hide them
       rows: 10,                        // for textareas you can specify the rows
       variant: 'switch',               // for checkboxgroups you can use either 
                                        //   'checkbox' (default) or 'switch'


### PR DESCRIPTION
 * Url and email inputs are now adorned with an icon button link - unless you pass `hideLink: true` in inputProperties
 * Brought version up to 1.13.2 including history and readme