### PR TITLE
Ensure  props that can be applied to the SmartForm component  are propagated when said props are specified on the Card component.

### DIFF
--- a/packages/vulcan-core/lib/modules/components/Card.jsx
+++ b/packages/vulcan-core/lib/modules/components/Card.jsx
@@ -191,7 +191,7 @@ const CardEdit = (props, context) => (
 
 CardEdit.contextTypes = { intl: intlShape };
 
-const CardEditForm = ({ collection, document, closeModal, ...editFormOptions }) => (
+const CardEditForm = ({ collection, document, closeModal, ...editFormProps }) => (
   <Components.SmartForm
     collection={collection}
     documentId={document._id}
@@ -199,12 +199,12 @@ const CardEditForm = ({ collection, document, closeModal, ...editFormOptions }) 
     successCallback={document => {
       closeModal();
     }}
-    {...editFormOptions}
+    {...editFormProps}
   />
 );
 
 const Card = (
-  { title, className, collection, document, currentUser, fields, showEdit = true, ...editFormOptions },
+  { title, className, collection, document, currentUser, fields, showEdit = true, ...editFormProps },
   { intl }
 ) => {
   const fieldNames = fields ? fields : without(Object.keys(document), '__typename');
@@ -221,7 +221,7 @@ const Card = (
       <table className="table table-bordered" style={{ maxWidth: '100%' }}>
         <tbody>
           {canEdit ? (
-            <CardEdit collection={collection} document={document} {...editFormOptions} />
+            <CardEdit collection={collection} document={document} {...editFormProps} />
           ) : null}
           {fieldNames.map((fieldName, index) => (
             <CardItem
@@ -246,7 +246,7 @@ Card.propTypes = {
   currentUser: PropTypes.object,
   fields: PropTypes.array,
   showEdit: PropTypes.bool,
-  editFormOptions: PropTypes.object,
+  editFormProps: PropTypes.object,
 };
 
 Card.contextTypes = {

--- a/packages/vulcan-core/lib/modules/components/Card.jsx
+++ b/packages/vulcan-core/lib/modules/components/Card.jsx
@@ -191,7 +191,7 @@ const CardEdit = (props, context) => (
 
 CardEdit.contextTypes = { intl: intlShape };
 
-const CardEditForm = ({ collection, document, closeModal }) => (
+const CardEditForm = ({ collection, document, closeModal, ...editFormOptions }) => (
   <Components.SmartForm
     collection={collection}
     documentId={document._id}
@@ -199,11 +199,12 @@ const CardEditForm = ({ collection, document, closeModal }) => (
     successCallback={document => {
       closeModal();
     }}
+    {...editFormOptions}
   />
 );
 
 const Card = (
-  { title, className, collection, document, currentUser, fields, showEdit = true },
+  { title, className, collection, document, currentUser, fields, showEdit = true, ...editFormOptions },
   { intl }
 ) => {
   const fieldNames = fields ? fields : without(Object.keys(document), '__typename');
@@ -219,7 +220,9 @@ const Card = (
       {title && <div className="datacard-title">{title}</div>}
       <table className="table table-bordered" style={{ maxWidth: '100%' }}>
         <tbody>
-          {canEdit ? <CardEdit collection={collection} document={document} /> : null}
+          {canEdit ? (
+            <CardEdit collection={collection} document={document} {...editFormOptions} />
+          ) : null}
           {fieldNames.map((fieldName, index) => (
             <CardItem
               key={index}
@@ -243,6 +246,7 @@ Card.propTypes = {
   currentUser: PropTypes.object,
   fields: PropTypes.array,
   showEdit: PropTypes.bool,
+  editFormOptions: PropTypes.object,
 };
 
 Card.contextTypes = {


### PR DESCRIPTION
### Purpose:
    • Enable the Components.Card component to additionally support the props supported by the Components.SmartForm component
### Result:
    • Is is now possible to hide schema fields displayed on an editable Card component on the form displayed when the Edit button is clicked
### Process:
    • It is possible to elect to not show schema fields that ordinarily would be shown by default on a SmartForm using the hideFields prop. This same feature was not available on the Card component and more specifically to be able to hide schema fields on the Card edit form. The edit form uses the SmartForm so the solution was minimal and required simply passing the applicable SmartForm props specified on the Card component down the child component hierarchy to the SmartForm called to enable Card editing.