### PR TITLE
Material-UI - README Installation - Set Version of react-jss

### DIFF
--- a/packages/vulcan-ui-material/readme.md
+++ b/packages/vulcan-ui-material/readme.md
@@ -17,7 +17,7 @@ To add vulcan-material-ui to an existing Vulcan project, run the following in th
 meteor add vulcan:ui-material
 
 meteor npm install --save @material-ui/core@3.9.3
-meteor npm install --save react-jss
+meteor npm install --save react-jss@8.1.0
 meteor npm install --save mdi-material-ui
 meteor npm install --save react-autosuggest
 meteor npm install --save autosuggest-highlight


### PR DESCRIPTION
When you add react-jss without a version it will install the newly released version 10 (released 5 days ago)
You will get an error "Module not found: Can't resolve 'react-jss/lib/JssProvider"
There is already in issue in material-ui 
https://github.com/mui-org/material-ui/issues/13146

It solved the issue for me with this comment
https://github.com/mui-org/material-ui/issues/13146#issuecomment-534532789

I also tried to install it with @9.0.0 but npm didnt find any matching version. With the last version of 8.1.0 it works great