### PR TITLE
FormGroupHiddenProp

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -386,8 +386,9 @@ class SmartForm extends Component {
     // }
 
     // if options are a function, call it
+    const document = this.getDocument();
     if (typeof field.options === 'function') {
-      field.options = field.options.call(fieldSchema, this.props);
+      field.options = field.options.call(fieldSchema, { ...this.props, document });
     }
 
     // if this an intl'd field, use a special intlInput
@@ -401,7 +402,9 @@ class SmartForm extends Component {
     for (const prop in inputProperties) {
       const property = inputProperties[prop];
       field[prop] =
-        typeof property === 'function' ? property.call(fieldSchema, this.props) : property;
+        typeof property === 'function'
+          ? property.call(fieldSchema, { ...this.props, document })
+          : property;
     }
 
     // add description as help prop
@@ -1015,6 +1018,7 @@ class SmartForm extends Component {
     group: omit(group, ['fields']),
     errors: this.state.errors,
     throwError: this.throwError,
+    document: this.getDocument(),
     currentValues: this.state.currentValues,
     updateCurrentValues: this.updateCurrentValues,
     deletedValues: this.state.deletedValues,

--- a/packages/vulcan-forms/lib/components/FormGroup.jsx
+++ b/packages/vulcan-forms/lib/components/FormGroup.jsx
@@ -1,53 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Components, instantiateComponent, Utils } from 'meteor/vulcan:core';
-import classNames from 'classnames';
+import { instantiateComponent } from 'meteor/vulcan:core';
 import { registerComponent, mergeWithComponents } from 'meteor/vulcan:core';
 import Users from 'meteor/vulcan:users';
 
-const FormGroupHeader = ({ toggle, collapsed, label }) => (
-  <div className="form-section-heading" onClick={toggle}>
-    <h3 className="form-section-heading-title">{label}</h3>
-    <span className="form-section-heading-toggle">
-      {collapsed ? (
-        <Components.IconRight height={16} width={16}/>
-      ) : (
-        <Components.IconDown height={16} width={16}/>
-      )}
-    </span>
-  </div>
-);
-FormGroupHeader.propTypes = {
-  toggle: PropTypes.func.isRequired,
-  label: PropTypes.string.isRequired,
-  collapsed: PropTypes.bool,
-  group: PropTypes.object,
-};
-registerComponent({ name: 'FormGroupHeader', component: FormGroupHeader });
-
-const FormGroupLayout = ({ children, label, anchorName, heading, collapsed, group, hasErrors }) => (
-  <div className={`form-section form-section-${anchorName} form-section-${Utils.slugify(label)}`}>
-    <a name={anchorName}/>
-    {heading}
-    <div
-      className={classNames({
-        'form-section-collapsed': collapsed && !hasErrors
-      })}
-    >
-      {children}
-    </div>
-  </div>
-);
-FormGroupLayout.propTypes = {
-  label: PropTypes.string,
-  anchorName: PropTypes.string,
-  heading: PropTypes.node,
-  collapsed: PropTypes.bool,
-  group: PropTypes.object,
-  hasErrors: PropTypes.bool,
-  children: PropTypes.node
-};
-registerComponent({ name: 'FormGroupLayout', component: FormGroupLayout });
 
 class FormGroup extends PureComponent {
   constructor (props) {
@@ -71,6 +27,7 @@ class FormGroup extends PureComponent {
         toggle={this.toggle}
         label={this.props.label}
         collapsed={this.state.collapsed}
+        hidden={this.isHidden()}
         group={this.props.group}
       />
     );
@@ -83,6 +40,14 @@ class FormGroup extends PureComponent {
         .length;
     });
   
+  isHidden = () => {
+    const { hidden, document } = this.props;
+    const isHidden = typeof hidden === 'function'
+      ? hidden({ ...this.props, document })
+      : hidden || false;
+    return isHidden;
+  };
+  
   render () {
     if (this.props.group.adminsOnly && !Users.isAdmin(this.props.currentUser)) {
       return null;
@@ -90,7 +55,7 @@ class FormGroup extends PureComponent {
   
     const { name, fields, formComponents, label, group } = this.props;
     const { collapsed } = this.state;
-    
+  
     const FormComponents = mergeWithComponents(formComponents);
     const anchorName = name.split('.').length > 1 ? name.split('.')[1] : name;
     
@@ -100,6 +65,7 @@ class FormGroup extends PureComponent {
           anchorName={anchorName}
           toggle={this.toggle}
           collapsed={collapsed}
+          hidden={this.isHidden()}
           group={group}
           heading={name === 'default' ? null : this.renderHeading(FormComponents)}
           hasErrors={this.hasErrors()}
@@ -137,6 +103,7 @@ FormGroup.propTypes = {
   name: PropTypes.string,
   label: PropTypes.string,
   order: PropTypes.number,
+  hidden: PropTypes.func,
   fields: PropTypes.array.isRequired,
   group: PropTypes.object.isRequired,
   errors: PropTypes.array.isRequired,
@@ -154,47 +121,3 @@ FormGroup.propTypes = {
 export default FormGroup;
 
 registerComponent('FormGroup', FormGroup);
-
-const IconRight = ({ width = 24, height = 24 }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width={width}
-    height={height}
-    viewBox="0 0 24 24"
-  >
-    <polyline
-      fill="none"
-      stroke="#000"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeMiterlimit="10"
-      points="5.5,23.5 18.5,12 5.5,0.5"
-      id="Outline_Icons"
-    />
-    <rect fill="none" width="24" height="24" id="Frames-24px"/>
-  </svg>
-);
-
-registerComponent('IconRight', IconRight);
-
-const IconDown = ({ width = 24, height = 24 }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width={width}
-    height={height}
-    viewBox="0 0 24 24"
-  >
-    <polyline
-      fill="none"
-      stroke="#000"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeMiterlimit="10"
-      points="0.501,5.5 12.001,18.5 23.501,5.5"
-      id="Outline_Icons"
-    />
-    <rect fill="none" width="24" height="24" id="Frames-24px"/>
-  </svg>
-);
-
-registerComponent('IconDown', IconDown);

--- a/packages/vulcan-ui-bootstrap/lib/components/forms/FormGroupDefault.jsx
+++ b/packages/vulcan-ui-bootstrap/lib/components/forms/FormGroupDefault.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Components, Utils } from 'meteor/vulcan:core';
+import classNames from 'classnames';
+import { registerComponent } from 'meteor/vulcan:core';
+
+const FormGroupHeader = ({ toggle, collapsed, label }) => (
+  <div className="form-section-heading" onClick={toggle}>
+    <h3 className="form-section-heading-title">{label}</h3>
+    <span className="form-section-heading-toggle">
+      {collapsed ? (
+        <Components.IconRight height={16} width={16}/>
+      ) : (
+        <Components.IconDown height={16} width={16}/>
+      )}
+    </span>
+  </div>
+);
+FormGroupHeader.propTypes = {
+  toggle: PropTypes.func.isRequired,
+  label: PropTypes.string.isRequired,
+  collapsed: PropTypes.bool,
+  group: PropTypes.object,
+};
+registerComponent({ name: 'FormGroupHeader', component: FormGroupHeader });
+
+const FormGroupLayout = ({ children, label, anchorName, heading, collapsed, hidden, group, hasErrors }) => (
+  <div className={classNames('form-section', `form-section-${anchorName}`, 
+    `form-section-${Utils.slugify(label)}`, hidden && 'form-section-hidden')}>
+    <a name={anchorName}/>
+    {heading}
+    <div
+      className={classNames({
+        'form-section-collapsed': collapsed && !hasErrors
+      })}
+    >
+      {children}
+    </div>
+  </div>
+);
+FormGroupLayout.propTypes = {
+  label: PropTypes.string,
+  anchorName: PropTypes.string,
+  heading: PropTypes.node,
+  collapsed: PropTypes.bool,
+  hidden: PropTypes.bool,
+  group: PropTypes.object,
+  hasErrors: PropTypes.bool,
+  children: PropTypes.node
+};
+registerComponent({ name: 'FormGroupLayout', component: FormGroupLayout });
+
+const IconRight = ({ width = 24, height = 24 }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+  >
+    <polyline
+      fill="none"
+      stroke="#000"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeMiterlimit="10"
+      points="5.5,23.5 18.5,12 5.5,0.5"
+      id="Outline_Icons"
+    />
+    <rect fill="none" width="24" height="24" id="Frames-24px"/>
+  </svg>
+);
+
+registerComponent('IconRight', IconRight);
+
+const IconDown = ({ width = 24, height = 24 }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+  >
+    <polyline
+      fill="none"
+      stroke="#000"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeMiterlimit="10"
+      points="0.501,5.5 12.001,18.5 23.501,5.5"
+      id="Outline_Icons"
+    />
+    <rect fill="none" width="24" height="24" id="Frames-24px"/>
+  </svg>
+);
+
+registerComponent('IconDown', IconDown);

--- a/packages/vulcan-ui-bootstrap/lib/modules/components.js
+++ b/packages/vulcan-ui-bootstrap/lib/modules/components.js
@@ -1,4 +1,3 @@
-import '../components/forms/FormElement.jsx';
 import '../components/forms/Checkbox.jsx';
 import '../components/forms/Checkboxgroup.jsx';
 import '../components/forms/Date.jsx';
@@ -6,17 +5,19 @@ import '../components/forms/Date2.jsx';
 import '../components/forms/Datetime.jsx';
 import '../components/forms/Default.jsx';
 import '../components/forms/Email.jsx';
+import '../components/forms/FormComponentInner.jsx';
+import '../components/forms/FormControl.jsx'; // note: only used by old accounts package, remove soon?
+import '../components/forms/FormElement.jsx';
+import '../components/forms/FormGroupDefault';
+import '../components/forms/FormItem.jsx';
 import '../components/forms/Number.jsx';
 import '../components/forms/Radiogroup.jsx';
 import '../components/forms/Select.jsx';
 import '../components/forms/SelectMultiple.jsx';
+import '../components/forms/StaticText.jsx';
 import '../components/forms/Textarea.jsx';
 import '../components/forms/Time.jsx';
 import '../components/forms/Url.jsx';
-import '../components/forms/StaticText.jsx';
-import '../components/forms/FormComponentInner.jsx';
-import '../components/forms/FormControl.jsx'; // note: only used by old accounts package, remove soon?
-import '../components/forms/FormItem.jsx';
 
 import '../components/ui/Button.jsx';
 import '../components/ui/Alert.jsx';

--- a/packages/vulcan-ui-bootstrap/lib/stylesheets/style.scss
+++ b/packages/vulcan-ui-bootstrap/lib/stylesheets/style.scss
@@ -156,6 +156,10 @@ div.ReactTags__suggestions mark{
   display: none;
 }
 
+.form-section-hidden {
+  display: none;
+}
+
 .form-errors{
   .alert{
     ul{

--- a/packages/vulcan-ui-material/lib/components/forms/FormGroupDefault.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/FormGroupDefault.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { replaceComponent } from 'meteor/vulcan:core';
+import { registerComponent } from 'meteor/vulcan:core';
 import withStyles from '@material-ui/core/styles/withStyles';
 import Collapse from '@material-ui/core/Collapse';
 import Paper from '@material-ui/core/Paper';
@@ -56,14 +56,19 @@ const styles = theme => ({
     overflow: 'visible',
   },
   
+  hidden: {
+    display: 'none',
+  },
+  
 });
 
 
-const FormGroupHeader = ({ toggle, collapsed, label, group, classes }) => {
+const FormGroupHeader = ({ toggle, collapsed, hidden, label, group, classes }) => {
   const collapsible = group && group.collapsible || group && group.name === 'admin';
   
   return (
-    <div className={classNames(classes.headerRoot, collapsible && classes.collapsible, 'form-group-header')}
+    <div className={classNames(classes.headerRoot, collapsible && classes.collapsible, 
+      hidden && classes.hidden, 'form-group-header')}
          onClick={collapsible ? toggle : null}
     >
       
@@ -101,16 +106,18 @@ const FormGroupHeader = ({ toggle, collapsed, label, group, classes }) => {
 FormGroupHeader.propTypes = {
   toggle: PropTypes.func,
   collapsed: PropTypes.bool,
+  hidden: PropTypes.bool,
   label: PropTypes.string.isRequired,
   group: PropTypes.object,
   classes: PropTypes.object.isRequired,
 };
 
 
-replaceComponent('FormGroupHeader', FormGroupHeader, [withStyles, styles]);
+registerComponent('FormGroupHeader', FormGroupHeader, [withStyles, styles]);
 
 
-const FormGroupLayout = ({ label, anchorName, collapsed, hasErrors, heading, group, children, classes }) => {
+const FormGroupLayout = ({ label, anchorName, collapsed, hidden, hasErrors, heading, group, children, classes }) => {
+  const collapsedIn = (!collapsed && !hidden) || hasErrors;
   
   return (
     <div className={classNames(classes.layoutRoot, 'form-section', `form-section-${anchorName}`)}>
@@ -119,7 +126,7 @@ const FormGroupLayout = ({ label, anchorName, collapsed, hasErrors, heading, gro
       
       {heading}
       
-      <Collapse classes={{ container: classes.container, entered: classes.entered }} in={!collapsed || hasErrors}>
+      <Collapse classes={{ container: classes.container, entered: classes.entered }} in={collapsedIn}>
         <Paper className={classes.paper}>
           
           {children}
@@ -135,6 +142,7 @@ FormGroupLayout.propTypes = {
   label: PropTypes.string.isRequired,
   anchorName: PropTypes.string.isRequired,
   collapsed: PropTypes.bool.isRequired,
+  hidden: PropTypes.bool.isRequired,
   hasErrors: PropTypes.bool.isRequired,
   heading: PropTypes.node,
   group: PropTypes.object.isRequired,
@@ -143,5 +151,5 @@ FormGroupLayout.propTypes = {
 };
 
 
-replaceComponent('FormGroupLayout', FormGroupLayout, [withStyles, styles]);
+registerComponent('FormGroupLayout', FormGroupLayout, [withStyles, styles]);
 

--- a/packages/vulcan-ui-material/lib/components/forms/FormGroupLine.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/FormGroupLine.jsx
@@ -108,7 +108,9 @@ FormGroupHeaderLine.displayName = 'FormGroupHeaderLine';
 registerComponent('FormGroupHeaderLine', FormGroupHeaderLine, [withStyles, styles]);
 
 
-const FormGroupLayoutLine = ({ label, anchorName, collapsed, hasErrors, heading, group, children, classes }) => {
+const FormGroupLayoutLine = ({ label, anchorName, collapsed, hidden, hasErrors, heading, group, children, classes }) => {
+  const collapsedIn = (!collapsed && !hidden) || hasErrors;
+  
   return (
     <div className={classNames(classes.layoutRoot, 'form-section', `form-section-${anchorName}`)}>
       
@@ -116,7 +118,7 @@ const FormGroupLayoutLine = ({ label, anchorName, collapsed, hasErrors, heading,
       
       {heading}
       
-      <Collapse classes={{ entered: classes.entered }} in={!collapsed || hasErrors}>
+      <Collapse classes={{ entered: classes.entered }} in={collapsedIn}>
         
         {children}
       
@@ -131,6 +133,7 @@ FormGroupLayoutLine.propTypes = {
   label: PropTypes.string.isRequired,
   anchorName: PropTypes.string.isRequired,
   collapsed: PropTypes.bool.isRequired,
+  hidden: PropTypes.bool.isRequired,
   hasErrors: PropTypes.bool.isRequired,
   heading: PropTypes.node,
   group: PropTypes.object.isRequired,

--- a/packages/vulcan-ui-material/lib/components/forms/FormGroupNone.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/FormGroupNone.jsx
@@ -10,6 +10,10 @@ const styles = theme => ({
   root: {
     minWidth: '320px'
   },
+  
+  hidden: {
+    display: 'none',
+  }
 
 });
 
@@ -22,9 +26,9 @@ const FormGroupHeaderNone = () => {
 registerComponent('FormGroupHeaderNone', FormGroupHeaderNone, [withStyles, styles]);
 
 
-const FormGroupLayoutNone = ({ label, anchorName, collapsed, hasErrors, heading, group, children, classes }) => {
+const FormGroupLayoutNone = ({ label, anchorName, collapsed, hidden, hasErrors, heading, group, children, classes }) => {
   return (
-    <div className={classNames(classes.root, 'form-section', `form-section-${anchorName}`)}>
+    <div className={classNames(classes.root, hidden && classes.hidden,'form-section', `form-section-${anchorName}`)}>
       
       <a name={anchorName}/>
   
@@ -39,6 +43,7 @@ FormGroupLayoutNone.propTypes = {
   label: PropTypes.string.isRequired,
   anchorName: PropTypes.string.isRequired,
   collapsed: PropTypes.bool.isRequired,
+  hidden: PropTypes.bool.isRequired,
   hasErrors: PropTypes.bool.isRequired,
   heading: PropTypes.node,
   group: PropTypes.object.isRequired,


### PR DESCRIPTION
 * Functions passed as values in `inputProperties` are now called with an additional parameter: `document`
 * `FormGroup` now accepts a `hidden` property, which can also be a function
 * Split bootstrap-specific code out to `FormGroupDefault`
 * Implemented `group.hidden` prop in `vulcan:ui-bootstrap` and `vulcan:ui-material`