### PR TITLE
populate.before callback

### DIFF
--- a/packages/vulcan-core/lib/client/start.jsx
+++ b/packages/vulcan-core/lib/client/start.jsx
@@ -9,12 +9,12 @@ import {
   populateComponentsApp,
   populateRoutesApp,
   initializeFragments,
-  runCallbacks
+  runCallbacks,
 } from 'meteor/vulcan:lib';
 
 Meteor.startup(() => {
   // run functions that must be called before populating components or routes
-  runCallbacks('startup.before');
+  runCallbacks('populate.before');
   // init the application components and routes, including components & routes from 3rd-party packages
   initializeFragments();
   populateComponentsApp();
@@ -34,9 +34,9 @@ Meteor.startup(() => {
     if (ssrUrl.hostname && ssrUrl.hostname !== window.location.hostname) {
       console.warn(
         `Mismatch between the browser hostname (${
-        window.location.hostname
+          window.location.hostname
         }) and the hostname used during SSR (${
-        ssrUrl.hostname
+          ssrUrl.hostname
         }). Will prevent full rehydration of the React DOM.`
       );
     } else {

--- a/packages/vulcan-core/lib/client/start.jsx
+++ b/packages/vulcan-core/lib/client/start.jsx
@@ -9,9 +9,12 @@ import {
   populateComponentsApp,
   populateRoutesApp,
   initializeFragments,
+  runCallbacks
 } from 'meteor/vulcan:lib';
 
 Meteor.startup(() => {
+  // run functions that must be called before populating components or routes
+  runCallbacks('startup.before');
   // init the application components and routes, including components & routes from 3rd-party packages
   initializeFragments();
   populateComponentsApp();
@@ -31,9 +34,9 @@ Meteor.startup(() => {
     if (ssrUrl.hostname && ssrUrl.hostname !== window.location.hostname) {
       console.warn(
         `Mismatch between the browser hostname (${
-          window.location.hostname
+        window.location.hostname
         }) and the hostname used during SSR (${
-          ssrUrl.hostname
+        ssrUrl.hostname
         }). Will prevent full rehydration of the React DOM.`
       );
     } else {

--- a/packages/vulcan-core/lib/modules/callbacks.js
+++ b/packages/vulcan-core/lib/modules/callbacks.js
@@ -1,7 +1,7 @@
 import { registerCallback } from 'meteor/vulcan:lib';
 
 registerCallback({
-    name: 'startup.before',
+    name: 'populate.before',
     description: 'Run before Vulcan objects are populated. Use if you need to add routes dynamically on startup for example.',
     arguments: [],
     runs: 'sync',

--- a/packages/vulcan-core/lib/modules/callbacks.js
+++ b/packages/vulcan-core/lib/modules/callbacks.js
@@ -1,0 +1,9 @@
+import { registerCallback } from 'meteor/vulcan:lib';
+
+registerCallback({
+    name: 'startup.before',
+    description: 'Run before Vulcan objects are populated. Use if you need to add routes dynamically on startup for example.',
+    arguments: [],
+    runs: 'sync',
+    returns: 'nothing',
+});

--- a/packages/vulcan-core/lib/modules/index.js
+++ b/packages/vulcan-core/lib/modules/index.js
@@ -1,5 +1,6 @@
 
 // import and re-export
+import './callbacks';
 export * from 'meteor/vulcan:lib';
 
 export * from './default_mutations.js';

--- a/packages/vulcan-lib/lib/modules/routes.js
+++ b/packages/vulcan-lib/lib/modules/routes.js
@@ -1,4 +1,4 @@
-import {Components, getComponent} from './components';
+import { Components, getComponent } from './components';
 
 export const Routes = {}; // will be populated on startup 
 export const RoutesTable = {}; // storage for infos about routes themselves
@@ -27,7 +27,7 @@ export const addRoute = (routeOrRouteArray, parentRouteName) => {
   } else {
 
     // modify the routes table with the new routes
-    addedRoutes.map(({name, path, ...properties}) => {
+    addedRoutes.map(({ name, path, ...properties }) => {
 
       // check if there is already a route registered to this path
       const routeWithSamePath = _.findWhere(RoutesTable, { path });
@@ -50,7 +50,7 @@ export const addRoute = (routeOrRouteArray, parentRouteName) => {
 
 export const extendRoute = (routeName, routeProps) => {
 
-  const route = _.findWhere(RoutesTable, {name: routeName});
+  const route = _.findWhere(RoutesTable, { name: routeName });
 
   if (route) {
     RoutesTable[route.name] = {
@@ -82,7 +82,7 @@ export const addAsChildRoute = (parentRouteName, addedRoutes) => {
   }
 
   // modify the routes table with the new routes
-  addedRoutes.map(({name, path, ...properties}) => {
+  addedRoutes.map(({ name, path, ...properties }) => {
 
     // get the current child routes for this Route
     const childRoutes = RoutesTable[parentRouteName]['childRoutes'] || [];
@@ -139,7 +139,7 @@ export const populateRoutesApp = () => {
   // loop over each component in the list
   Object.keys(RoutesTable).map(name => {
     // loop over child routes if available
-    if(typeof RoutesTable[name]['childRoutes'] !== typeof undefined){
+    if (typeof RoutesTable[name]['childRoutes'] !== typeof undefined) {
       RoutesTable[name]['childRoutes'].map((item, index) => {
         RoutesTable[name]['childRoutes'][index] = getChildRoute(name, index);
       });
@@ -153,3 +153,9 @@ export const populateRoutesApp = () => {
   });
 };
 
+// Should be used only in tests
+export const emptyRoutes = () => {
+  Object.keys(Routes).map((key) => {
+    delete Routes[key];
+  });
+};

--- a/packages/vulcan-lib/lib/server/apollo-ssr/enableSSR.js
+++ b/packages/vulcan-lib/lib/server/apollo-ssr/enableSSR.js
@@ -2,7 +2,7 @@
  * Actually enable SSR
  */
 
-import { populateComponentsApp, populateRoutesApp, initializeFragments } from 'meteor/vulcan:lib';
+import { runCallbacks, populateComponentsApp, populateRoutesApp, initializeFragments } from 'meteor/vulcan:lib';
 // onPageLoad is mostly equivalent to an Express middleware
 // excepts it is tailored to handle Meteor server side rendering
 import { onPageLoad } from 'meteor/server-render';
@@ -11,6 +11,7 @@ import makePageRenderer from './renderPage';
 
 const enableSSR = ({ computeContext }) => {
   Meteor.startup(() => {
+    runCallbacks('startup.before');
     // init the application components and routes, including components & routes from 3rd-party packages
     initializeFragments();
     populateComponentsApp();

--- a/packages/vulcan-lib/lib/server/apollo-ssr/enableSSR.js
+++ b/packages/vulcan-lib/lib/server/apollo-ssr/enableSSR.js
@@ -11,7 +11,7 @@ import makePageRenderer from './renderPage';
 
 const enableSSR = ({ computeContext }) => {
   Meteor.startup(() => {
-    runCallbacks('startup.before');
+    runCallbacks('populate.before');
     // init the application components and routes, including components & routes from 3rd-party packages
     initializeFragments();
     populateComponentsApp();

--- a/packages/vulcan-lib/test/index.js
+++ b/packages/vulcan-lib/test/index.js
@@ -1,3 +1,4 @@
 import './components.test.js';
 import './handleOptions.test.js';
 import './utils.test.js';
+import './routes.test';

--- a/packages/vulcan-lib/test/routes.test.js
+++ b/packages/vulcan-lib/test/routes.test.js
@@ -1,0 +1,51 @@
+import expect from 'expect'
+import { addRoute, populateRoutesApp, emptyRoutes, Routes } from '../lib/modules/routes'
+const Foo = () => 'foo'
+describe('vulcan:lib/routes', () => {
+    beforeEach(() => {
+        emptyRoutes()
+    })
+    it('add and retrieve a route', () => {
+        const route = {
+            name: 'foo',
+            path: '/coo',
+            component: Foo
+        }
+        addRoute(route)
+        populateRoutesApp()
+        expect(Routes['foo']).toEqual(route)
+    })
+    it('takes parent name into consideration', () => {
+        const parentRoute = {
+            name: 'parent',
+            path: '/parent',
+            component: Foo
+        }
+        const route = {
+            name: 'foo',
+            path: '/foo',
+            component: Foo
+        }
+        addRoute(parentRoute)
+        addRoute(route, 'parent')
+        populateRoutesApp()
+        expect(Routes['parent'].childRoutes).toEqual([route])
+    })
+    it('add array of routes', () => {
+        const route1 = {
+            name: 'foo1',
+            path: '/foo1',
+            component: Foo
+        }
+        const route2 = {
+            name: 'foo2',
+            path: '/foo2',
+            component: Foo
+        }
+        const routes = [route1, route2]
+        addRoute(routes)
+        populateRoutesApp()
+        expect(Routes['foo1']).toEqual(route1)
+        expect(Routes['foo2']).toEqual(route2)
+    })
+})


### PR DESCRIPTION
I've added a `startup.before` callback ran before routes and components are populated.
This allow to call functions during startup, but before Routes and Components are fully populated.

First use case is the Backoffice creation: https://github.com/VulcanJS/Vulcan/issues/2176
You need to wait for startup because otherwise Collections may not be correctly defined, but you also need to call it before Routes are fully populated in order to add a route for each collection.

Note that this call back won't be called before all `Meteor.startup`, but before the ones in `start.jsx` and SSR rendering.  Maybe we can find more appropriate names or even add additionnal callbacks like `render.before` or `populateRoutes.before` etc.

Closes https://github.com/VulcanJS/Vulcan/issues/2404