### PR TITLE
Incorrect link to telescopeapp.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Find more info in the [documentation](http://docs.vulcanjs.org/#Install).
 
 - [Vulcan Homepage](http://vulcanjs.org)
 - [Documentation](http://docs.vulcanjs.org)
-- [Old Telescope Homepage](http://telescopeapp.org)
+- [Old Telescope Homepage](http://www.telescopeapp.org)
 
 ### Other Versions
 


### PR DESCRIPTION
Looks like in A records for telescopeapp.org didn't set properly for redirect from http://telescopeapp.org to http://www.telescopeapp.org (which is the only URL for which server will send you page). So, basically, right now when you follow link telescope home page will not be opened, but 404 error will be received instead (at least, this is Chrome current behavior when you follow link) because there is http before link, another solution, instead of directly putting of "www" will be removal of protocol from link