### PR TITLE
Fixed links to changelog and migration documentation to

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Find more info in the [documentation](http://docs.vulcanjs.org/#Install).
 
 [See all releases](https://github.com/VulcanJS/Vulcan/releases).
 
-To update an existing Vulcan app, [see migration doc](https://github.com/VulcanJS/Vulcan/)) and [changelog](https://github.com/VulcanJS/Vulcan/).
+To update an existing Vulcan app, [see migration doc](MIGRATING.md)) and [changelog](CHANGELOG.md).
 
 You can find the older, non-Apollo version of Telescope Nova on the [nova-classic](https://github.com/TelescopeJS/Telescope/tree/nova-classic) branch. 
 


### PR DESCRIPTION
For some reason, links led just to repo, instead of files relevant for branch.