### PR TITLE
Bugfix/get viewable fields

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2,6 +2,10 @@ Doc to help updating downstream applications. Breaking changes and packages upda
 
 Please open an issue or a pull request if you feel this doc is incomplete.
 
+## From 1.13.3 to XXXX
+
+- Replace `Users.getViewableFields` by `Users.getReadableProjection` 
+
 ## From 1.13.2 to 1.13.3
 
 - Update React to a version over 16.8 (and under 17 which will bring breaking changes) to access hooks

--- a/packages/vulcan-lib/lib/modules/utils.js
+++ b/packages/vulcan-lib/lib/modules/utils.js
@@ -27,7 +27,7 @@ export const Utils = {};
  * @summary Convert a camelCase string to dash-separated string
  * @param {String} str
  */
-Utils.camelToDash = function(str) {
+Utils.camelToDash = function (str) {
   return str
     .replace(/\W+/g, '-')
     .replace(/([a-z\d])([A-Z])/g, '$1-$2')
@@ -39,8 +39,8 @@ Utils.camelToDash = function(str) {
  * See http://stackoverflow.com/questions/4149276/javascript-camelcase-to-regular-form
  * @param {String} str
  */
-Utils.camelToSpaces = function(str) {
-  return str.replace(/([A-Z])/g, ' $1').replace(/^./, function(str) {
+Utils.camelToSpaces = function (str) {
+  return str.replace(/([A-Z])/g, ' $1').replace(/^./, function (str) {
     return str.toUpperCase();
   });
 };
@@ -62,7 +62,7 @@ Utils.toTitleCase = str =>
  * @summary Convert an underscore-separated string to dash-separated string
  * @param {String} str
  */
-Utils.underscoreToDash = function(str) {
+Utils.underscoreToDash = function (str) {
   return str.replace('_', '-');
 };
 
@@ -70,8 +70,8 @@ Utils.underscoreToDash = function(str) {
  * @summary Convert a dash separated string to camelCase.
  * @param {String} str
  */
-Utils.dashToCamel = function(str) {
-  return str.replace(/(\-[a-z])/g, function($1) {
+Utils.dashToCamel = function (str) {
+  return str.replace(/(\-[a-z])/g, function ($1) {
     return $1.toUpperCase().replace('-', '');
   });
 };
@@ -80,7 +80,7 @@ Utils.dashToCamel = function(str) {
  * @summary Convert a string to camelCase and remove spaces.
  * @param {String} str
  */
-Utils.camelCaseify = function(str) {
+Utils.camelCaseify = function (str) {
   str = this.dashToCamel(str.replace(' ', '-'));
   str = str.slice(0, 1).toLowerCase() + str.slice(1);
   return str;
@@ -91,7 +91,7 @@ Utils.camelCaseify = function(str) {
  * @param {String} s - Sentence to trim.
  * @param {Number} numWords - Number of words to trim sentence to.
  */
-Utils.trimWords = function(s, numWords) {
+Utils.trimWords = function (s, numWords) {
   if (!s) return s;
 
   var expString = s.split(/\s+/, numWords);
@@ -103,7 +103,7 @@ Utils.trimWords = function(s, numWords) {
  * @summary Trim a block of HTML code to get a clean text excerpt
  * @param {String} html - HTML to trim.
  */
-Utils.trimHTML = function(html, numWords) {
+Utils.trimHTML = function (html, numWords) {
   var text = Utils.stripHTML(html);
   return Utils.trimWords(text, numWords);
 };
@@ -112,27 +112,27 @@ Utils.trimHTML = function(html, numWords) {
  * @summary Capitalize a string.
  * @param {String} str
  */
-Utils.capitalize = function(str) {
+Utils.capitalize = function (str) {
   return str && str.charAt(0).toUpperCase() + str.slice(1);
 };
 
-Utils.t = function(message) {
+Utils.t = function (message) {
   var d = new Date();
   console.log(
     '### ' + message + ' rendered at ' + d.getHours() + ':' + d.getMinutes() + ':' + d.getSeconds()
   ); // eslint-disable-line
 };
 
-Utils.nl2br = function(str) {
+Utils.nl2br = function (str) {
   var breakTag = '<br />';
   return (str + '').replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1' + breakTag + '$2');
 };
 
-Utils.scrollPageTo = function(selector) {
+Utils.scrollPageTo = function (selector) {
   $('body').scrollTop($(selector).offset().top);
 };
 
-Utils.scrollIntoView = function(selector) {
+Utils.scrollIntoView = function (selector) {
   if (!document) return;
 
   const element = document.querySelector(selector);
@@ -141,7 +141,7 @@ Utils.scrollIntoView = function(selector) {
   }
 };
 
-Utils.getDateRange = function(pageNumber) {
+Utils.getDateRange = function (pageNumber) {
   var now = moment(new Date());
   var dayToDisplay = now.subtract(pageNumber - 1, 'days');
   var range = {};
@@ -159,7 +159,7 @@ Utils.getDateRange = function(pageNumber) {
 /**
  * @summary Returns the user defined site URL or Meteor.absoluteUrl. Add trailing '/' if missing
  */
-Utils.getSiteUrl = function() {
+Utils.getSiteUrl = function () {
   let url = getSetting('siteUrl', Meteor.absoluteUrl());
   if (url.slice(-1) !== '/') {
     url += '/';
@@ -170,7 +170,7 @@ Utils.getSiteUrl = function() {
 /**
  * @summary Returns the user defined site URL or Meteor.absoluteUrl. Remove trailing '/' if it exists
  */
-Utils.getRootUrl = function() {
+Utils.getRootUrl = function () {
   let url = getSetting('siteUrl', Meteor.absoluteUrl());
   if (url.slice(-1) === '/') {
     url = url.slice(0, -1);
@@ -182,11 +182,11 @@ Utils.getRootUrl = function() {
  * @summary The global namespace for Vulcan utils.
  * @param {String} url - the URL to redirect
  */
-Utils.getOutgoingUrl = function(url) {
+Utils.getOutgoingUrl = function (url) {
   return Utils.getSiteUrl() + 'out?url=' + encodeURIComponent(url);
 };
 
-Utils.slugify = function(s) {
+Utils.slugify = function (s) {
   let slug = getSlug(s, {
     truncate: 60,
   });
@@ -208,7 +208,7 @@ Utils.slugify = function(s) {
  * avoid the slug changing
  * @returns {string} The slug passed in the 2nd param, but may be
  */
-Utils.getUnusedSlug = function(collection, slug, documentId) {
+Utils.getUnusedSlug = function (collection, slug, documentId) {
   // test if slug is already in use
   for (let index = 0; index <= Number.MAX_SAFE_INTEGER; index++) {
     const suffix = index ? '-' + index : '';
@@ -243,15 +243,15 @@ Utils.getUnusedSlug = function(collection, slug, documentId) {
  * @param {string} [documentId]
  * @returns {string}
  */
-Utils.getUnusedSlugByCollectionName = function(collectionName, slug, documentId) {
+Utils.getUnusedSlugByCollectionName = function (collectionName, slug, documentId) {
   return Utils.getUnusedSlug(getCollection(collectionName), slug, documentId);
 };
 
-Utils.getShortUrl = function(post) {
+Utils.getShortUrl = function (post) {
   return post.shortUrl || post.url;
 };
 
-Utils.getDomain = function(url) {
+Utils.getDomain = function (url) {
   try {
     return urlObject.parse(url).hostname.replace('www.', '');
   } catch (error) {
@@ -260,7 +260,7 @@ Utils.getDomain = function(url) {
 };
 
 // add http: if missing
-Utils.addHttp = function(url) {
+Utils.addHttp = function (url) {
   try {
     if (url.substring(0, 5) !== 'http:' && url.substring(0, 6) !== 'https:') {
       url = 'http:' + url;
@@ -275,25 +275,25 @@ Utils.addHttp = function(url) {
 // String Helper Functions //
 /////////////////////////////
 
-Utils.cleanUp = function(s) {
+Utils.cleanUp = function (s) {
   return this.stripHTML(s);
 };
 
-Utils.sanitize = function(s) {
+Utils.sanitize = function (s) {
   return s;
 };
 
-Utils.stripHTML = function(s) {
+Utils.stripHTML = function (s) {
   return s.replace(/<(?:.|\n)*?>/gm, '');
 };
 
-Utils.stripMarkdown = function(s) {
+Utils.stripMarkdown = function (s) {
   var htmlBody = marked(s);
   return Utils.stripHTML(htmlBody);
 };
 
 // http://stackoverflow.com/questions/2631001/javascript-test-for-existence-of-nested-object-key
-Utils.checkNested = function(obj /*, level1, level2, ... levelN*/) {
+Utils.checkNested = function (obj /*, level1, level2, ... levelN*/) {
   var args = Array.prototype.slice.call(arguments);
   obj = args.shift();
 
@@ -306,14 +306,14 @@ Utils.checkNested = function(obj /*, level1, level2, ... levelN*/) {
   return true;
 };
 
-Utils.log = function(s) {
+Utils.log = function (s) {
   if (getSetting('debug', false) || process.env.NODE_ENV === 'development') {
     console.log(s); // eslint-disable-line
   }
 };
 
 // see http://stackoverflow.com/questions/8051975/access-object-child-properties-using-a-dot-notation-string
-Utils.getNestedProperty = function(obj, desc) {
+Utils.getNestedProperty = function (obj, desc) {
   var arr = desc.split('.');
   while (arr.length && (obj = obj[arr.shift()]));
   return obj;
@@ -321,9 +321,9 @@ Utils.getNestedProperty = function(obj, desc) {
 
 // see http://stackoverflow.com/a/14058408/649299
 _.mixin({
-  compactObject: function(object) {
+  compactObject: function (object) {
     var clone = _.clone(object);
-    _.each(clone, function(value, key) {
+    _.each(clone, function (value, key) {
       /*
 
         Remove a value if:
@@ -380,7 +380,7 @@ Utils.findIndex = (array, predicate) => {
 };
 
 // adapted from http://stackoverflow.com/a/22072374/649299
-Utils.unflatten = function(array, options, parent, level = 0, tree) {
+Utils.unflatten = function (array, options, parent, level = 0, tree) {
   const {
     idProperty = '_id',
     parentIdProperty = 'parentId',
@@ -519,7 +519,7 @@ Utils.getRoutePath = routeName => {
   return Routes[routeName] && Routes[routeName].path;
 };
 
-String.prototype.replaceAll = function(search, replacement) {
+String.prototype.replaceAll = function (search, replacement) {
   var target = this;
   return target.replace(new RegExp(search, 'g'), replacement);
 };
@@ -559,3 +559,17 @@ Utils.getSchemaFieldAllowedValues = schemaFieldOptionsArray => {
  * @param {Object} field
  */
 Utils.getFieldType = field => get(field, 'type.definitions.0.type');
+
+
+/**
+ * Convert an array of field names into a Mongo fields specifier
+ * @param {Array} fieldsArray
+ */
+Utils.arrayToFields = fieldsArray => {
+  return _.object(
+    fieldsArray,
+    _.map(fieldsArray, function () {
+      return true;
+    })
+  );
+};

--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -3,7 +3,7 @@ import intersection from 'lodash/intersection';
 import compact from 'lodash/compact';
 import map from 'lodash/map';
 import difference from 'lodash/difference';
-import { Utils } from 'meteor/vulcan:lib';
+import { Utils, deprecate } from 'meteor/vulcan:lib';
 
 
 /**
@@ -212,6 +212,7 @@ Users.canReadField = function (user, field, document) {
  * @param {Object} document - Optionally, get a list for a specific document
  */
 Users.getViewableFields = function (user, collection, document) {
+  deprecate('1.13.4', 'getViewableFields is deprecated. Use Users.getReadableProjection to get a Mongo projection, or Users.getReadableFields if you need an array of field.');
   return Users.getReadableProjection(user, collection, document);
 };
 

--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -3,6 +3,8 @@ import intersection from 'lodash/intersection';
 import compact from 'lodash/compact';
 import map from 'lodash/map';
 import difference from 'lodash/difference';
+import { Utils } from 'meteor/vulcan:lib';
+
 
 /**
  * @summary Users.groups object
@@ -13,7 +15,7 @@ Users.groups = {};
  * @summary Group class
  */
 class Group {
-  
+
   constructor() {
     this.actions = [];
   }
@@ -53,19 +55,19 @@ Users.getGroups = (user, document) => {
   if (!user) { // guests user
 
     userGroups = ['guests'];
-  
+
   } else {
-  
+
     userGroups = ['members'];
 
     if (document && Users.owns(user, document)) {
       userGroups.push('owners');
     }
-    
+
     if (user.groups) { // custom groups
       userGroups = userGroups.concat(user.groups);
-    } 
-    
+    }
+
     if (Users.isAdmin(user)) { // admin
       userGroups.push('admins');
     }
@@ -129,7 +131,7 @@ Users.canDo = (user, actionOrActions) => {
 //   // note(apollo): use of `__typename` given by react-apollo
 //   //const collectionName = document.getCollectionName();
 //   const collectionName = document.__typename ? Utils.getCollectionNameFromTypename(document.__typename) : document.getCollectionName();
-  
+
 //   if (!user || !document) {
 //     return false;
 //   }
@@ -186,23 +188,23 @@ export const isAdmin = Users.isAdmin;
  * @param {Object} user - The user performing the action
  * @param {Object} field - The field being edited or inserted
  */
- Users.canReadField = function (user, field, document) {
-   const canRead = field.canRead || field.viewableBy; //OpenCRUD backwards compatibility
-   if (canRead) {
-     if (typeof canRead === 'function') {
-       // if canRead is a function, execute it with user and document passed. it must return a boolean
-       return canRead(user, document);
-     } else if (typeof canRead === 'string') {
-       // if canRead is just a string, we assume it's the name of a group and pass it to isMemberOf
-       return canRead === 'guests' || Users.isMemberOf(user, canRead);
-     } else if (Array.isArray(canRead) && canRead.length > 0) {
-       // if canRead is an array, we do a recursion on every item and return true if one of the items return true
-       return canRead.some(group => Users.canReadField(user, { canRead: group }, document));
+Users.canReadField = function (user, field, document) {
+  const canRead = field.canRead || field.viewableBy; //OpenCRUD backwards compatibility
+  if (canRead) {
+    if (typeof canRead === 'function') {
+      // if canRead is a function, execute it with user and document passed. it must return a boolean
+      return canRead(user, document);
+    } else if (typeof canRead === 'string') {
+      // if canRead is just a string, we assume it's the name of a group and pass it to isMemberOf
+      return canRead === 'guests' || Users.isMemberOf(user, canRead);
+    } else if (Array.isArray(canRead) && canRead.length > 0) {
+      // if canRead is an array, we do a recursion on every item and return true if one of the items return true
+      return canRead.some(group => Users.canReadField(user, { canRead: group }, document));
     }
-   }
-   return false;
- };
- 
+  }
+  return false;
+};
+
 /**
  * @summary Get a list of fields viewable by a user
  * @param {Object} user - The user performing the action
@@ -210,6 +212,10 @@ export const isAdmin = Users.isAdmin;
  * @param {Object} document - Optionally, get a list for a specific document
  */
 Users.getViewableFields = function (user, collection, document) {
+  return Users.getReadableProjection(user, collection, document);
+};
+
+Users.getReadableFields = function (user, collection, document) {
   return compact(map(collection.simpleSchema()._schema,
     (field, fieldName) => {
       if (fieldName.indexOf('.$') > -1) return null;
@@ -217,6 +223,12 @@ Users.getViewableFields = function (user, collection, document) {
     }
   ));
 };
+
+Users.getReadableProjection = function (user, collection, document) {
+  return Utils.arrayToFields(Users.getReadableFields(user, collection, document));
+};
+
+
 
 // collection helper
 Users.helpers({
@@ -232,7 +244,7 @@ Users.helpers({
  * @param {Object} fields - The list of fields
  */
 Users.checkFields = (user, collection, fields) => {
-  const viewableFields = Users.getViewableFields(user, collection);
+  const viewableFields = Users.getReadableFields(user, collection);
   const diff = difference(fields, viewableFields);
 
   if (diff.length) {
@@ -242,6 +254,7 @@ Users.checkFields = (user, collection, fields) => {
       )}.`
     );
   }
+  return true;
 };
 
 /**
@@ -257,20 +270,20 @@ Users.restrictViewableFields = function (user, collection, docOrDocs) {
   const restrictDoc = document => {
 
     // get array of all keys viewable by user
-    const viewableKeys = Users.getViewableFields(user, collection, document);
+    const viewableKeys = Users.getReadableFields(user, collection, document);
     const restrictedDocument = _.clone(document);
-    
+
     // loop over each property in the document and delete it if it's not viewable
     _.forEach(restrictedDocument, (value, key) => {
       if (!viewableKeys.includes(key)) {
         delete restrictedDocument[key];
       }
     });
-  
+
     return restrictedDocument;
-  
+
   };
-  
+
   return Array.isArray(docOrDocs) ? docOrDocs.map(restrictDoc) : restrictDoc(docOrDocs);
 
 };
@@ -335,11 +348,11 @@ Users.createGroup('guests'); // non-logged-in users
 Users.createGroup('members'); // regular users
 
 const membersActions = [
-  'user.create', 
-  'user.update.own', 
+  'user.create',
+  'user.update.own',
   // OpenCRUD backwards compatibility
-  'users.new', 
-  'users.edit.own', 
+  'users.new',
+  'users.edit.own',
   'users.remove.own',
 ];
 Users.groups.members.can(membersActions);
@@ -347,12 +360,12 @@ Users.groups.members.can(membersActions);
 Users.createGroup('admins'); // admin users
 
 const adminActions = [
-  'user.create', 
+  'user.create',
   'user.update.all',
   'user.delete.all',
   'setting.update',
   // OpenCRUD backwards compatibility
-  'users.new', 
+  'users.new',
   'users.edit.all',
   'users.remove.all',
   'settings.edit',

--- a/packages/vulcan-users/test/index.js
+++ b/packages/vulcan-users/test/index.js
@@ -1,0 +1,1 @@
+import './permissions.test';

--- a/packages/vulcan-users/test/permissions.test.js
+++ b/packages/vulcan-users/test/permissions.test.js
@@ -1,0 +1,45 @@
+import Users from '../lib/modules/collection'
+import '../lib/modules/permissions'
+const test = it
+import expect from "expect"
+import { createDummyCollection } from "meteor/vulcan:test"
+
+describe('vulcan:users/permissions', () => {
+    const Dummies = createDummyCollection({
+        schema: {
+            guestField: {
+                type: String,
+                canRead: ['guests']
+            },
+            adminField: {
+                type: String,
+                canRead: ['admins']
+
+            }
+        }
+    })
+    test("getViewableFields as projection (legacy)", () => {
+        const fields = Users.getViewableFields(null, Dummies)
+        expect(fields).toEqual({
+            guestField: true
+        })
+
+    })
+    test('getReadableFields', () => {
+        const fields = Users.getReadableFields(null, Dummies)
+        expect(fields).toEqual(["guestField"])
+    })
+    test('getReadableProjection', () => {
+        const fields = Users.getReadableProjection(null, Dummies)
+        expect(fields).toEqual({ guestField: true })
+
+    })
+    test('checkFields', () => {
+        expect(() => Users.checkFields(null, Dummies, ['adminField'])).toThrow()
+        expect(Users.checkFields(null, Dummies, ['guestField'])).toBe(true)
+    })
+    test('restrictViewableFields', () => {
+        const fields = Users.restrictViewableFields(null, Dummies, { 'adminField': "foo", 'guestField': "bar" })
+        expect(fields).toEqual({ 'guestField': "bar" })
+    })
+})

--- a/packages/vulcan-users/test/server/index.js
+++ b/packages/vulcan-users/test/server/index.js
@@ -1,2 +1,3 @@
 import './callback.test';
 import './mutation.test';
+import '../index';


### PR DESCRIPTION
@SachaG I've ended up creating a `Users.getReadableFields` that does return an array, and `Users.getReadableProjection` for the mongo projection.  I couldn't add an optional args because we already have the optional `document` so it would be messy.
I've deprecated  `getViewableFields` (it used the legacy "viewable" wording anyway) and rolled it back so it returns a Mongo projection.

I've also updated and tested the functions depending on `getViewableFields`.