### PR TITLE
Mailchimp

### DIFF
--- a/packages/vulcan-newsletter/lib/server/integrations/mailchimp.js
+++ b/packages/vulcan-newsletter/lib/server/integrations/mailchimp.js
@@ -53,8 +53,8 @@ if (settings) {
         const message = error.message;
         if (error.code == 214) {
           name = 'has_unsubscribed';
-        } else if (error.code != 214) { //Bug Fix - always false - error code 214 not equal to from equal to
-          name = 'already_subscribed';
+        //} else if (error.code != 214) { // TODO should get the right code for already_subscribed
+        //  name = 'already_subscribed';
         } else {
           name = 'subscription_failed';
         }

--- a/packages/vulcan-newsletter/lib/server/integrations/mailchimp.js
+++ b/packages/vulcan-newsletter/lib/server/integrations/mailchimp.js
@@ -53,7 +53,7 @@ if (settings) {
         const message = error.message;
         if (error.code == 214) {
           name = 'has_unsubscribed';
-        } else if (error.code == 214) {
+        } else if (error.code != 214) { //Bug Fix - always false - error code 214 not equal to from equal to
           name = 'already_subscribed';
         } else {
           name = 'subscription_failed';

--- a/packages/vulcan-users/lib/modules/helpers.js
+++ b/packages/vulcan-users/lib/modules/helpers.js
@@ -31,7 +31,7 @@ Users.getUser = function(userOrUserId) {
  */
 Users.getUserName = function(user) {
   try {
-    if (user.username) return user.username;
+    if (user && user.username) return user.username; //Add null check for user
     if (user && user.services && user.services.twitter && user.services.twitter.screenName)
       return user.services.twitter.screenName;
   } catch (error) {


### PR DESCRIPTION
Issue:
Condition 'error.code == 214' is always false at this point because the false branch of the condition 'error.code == 214' at line 54 has been taken. 

Solution:
packages/vulcan-newsletter/lib/server/integrations/mailchimp.js
CONSTANT_CONDITION
        const message = error.message;
        if (error.code == 214) {
          name = 'has_unsubscribed';
        } else if (error.code != 214) {  //Changed to not equal to
          name = 'already_subscribed';
