### PR TITLE
Condition '!operation' is always false at this point because it is redundant. 

### DIFF
--- a/packages/vulcan-lib/lib/server/utils.js
+++ b/packages/vulcan-lib/lib/server/utils.js
@@ -23,7 +23,7 @@ Utils.performCheck = (operation, user, checkedObject, context, documentId, opera
     throwError({ id: 'app.document_not_found', data: { documentId, operationName } });
   }
 
-  if (!operation(user, checkedObject, context)) { //Bug fix - removed redundant null check for operation
+  if (!operation(user, checkedObject, context)) {
     throwError({ id: 'app.operation_not_allowed', data: { documentId, operationName } });
   }
 

--- a/packages/vulcan-lib/lib/server/utils.js
+++ b/packages/vulcan-lib/lib/server/utils.js
@@ -23,7 +23,7 @@ Utils.performCheck = (operation, user, checkedObject, context, documentId, opera
     throwError({ id: 'app.document_not_found', data: { documentId, operationName } });
   }
 
-  if (!operation || !operation(user, checkedObject, context)) {
+  if (!operation(user, checkedObject, context)) { //Bug fix - removed redundant null check for operation
     throwError({ id: 'app.operation_not_allowed', data: { documentId, operationName } });
   }
 

--- a/packages/vulcan-users/lib/modules/helpers.js
+++ b/packages/vulcan-users/lib/modules/helpers.js
@@ -31,7 +31,7 @@ Users.getUser = function(userOrUserId) {
  */
 Users.getUserName = function(user) {
   try {
-    if (user.username) return user.username;
+    if (user && user.username) return user.username; //Add null check for user
     if (user && user.services && user.services.twitter && user.services.twitter.screenName)
       return user.services.twitter.screenName;
   } catch (error) {

--- a/packages/vulcan-users/lib/modules/helpers.js
+++ b/packages/vulcan-users/lib/modules/helpers.js
@@ -31,7 +31,7 @@ Users.getUser = function(userOrUserId) {
  */
 Users.getUserName = function(user) {
   try {
-    if (user && user.username) return user.username; //Add null check for user
+    if (user.username) return user.username;
     if (user && user.services && user.services.twitter && user.services.twitter.screenName)
       return user.services.twitter.screenName;
   } catch (error) {


### PR DESCRIPTION
Issue: Bug Fix
Condition '!operation' is always false at this point because it is redundant. 

Solution:
 Removed  redundant operation check as it's checked in previous line
packages/vulcan-lib/lib/server/utils.js
CONSTANT_CONDITION
    throwError({ id: 'app.document_not_found', data: { documentId, operationName } });
  }
 
  if (!operation(user, checkedObject, context)) {
    throwError({ id: 'app.operation_not_allowed', data: { documentId, operationName } 


