### PR TITLE
Condition 'value === ''' is always false at this point

### DIFF
--- a/packages/vulcan-core/lib/modules/components/Datatable/DatatableFilter.jsx
+++ b/packages/vulcan-core/lib/modules/components/Datatable/DatatableFilter.jsx
@@ -291,7 +291,7 @@ const DatatableFilterNumbers = ({ filters, setFilters }) => (
       inputProperties={{
         onChange: event => {
           const value = event.target.value;
-          if (!value || value === '') {
+          if (!value) { //Bug fix - Condition 'value === ''' is always false
             const newFilters = Object.assign({}, filters);
             delete newFilters._lte;
             setFilters(newFilters);

--- a/packages/vulcan-users/lib/modules/helpers.js
+++ b/packages/vulcan-users/lib/modules/helpers.js
@@ -31,7 +31,7 @@ Users.getUser = function(userOrUserId) {
  */
 Users.getUserName = function(user) {
   try {
-    if (user.username) return user.username;
+    if (user && user.username) return user.username; //Add null check for user
     if (user && user.services && user.services.twitter && user.services.twitter.screenName)
       return user.services.twitter.screenName;
   } catch (error) {

--- a/packages/vulcan-users/lib/modules/helpers.js
+++ b/packages/vulcan-users/lib/modules/helpers.js
@@ -31,7 +31,7 @@ Users.getUser = function(userOrUserId) {
  */
 Users.getUserName = function(user) {
   try {
-    if (user && user.username) return user.username; //Add null check for user
+    if (user.username) return user.username;
     if (user && user.services && user.services.twitter && user.services.twitter.screenName)
       return user.services.twitter.screenName;
   } catch (error) {


### PR DESCRIPTION
Issue:
Condition 'value === ''' is always false at this point because the false branch of the condition '!value' at line 294 has been taken. 

Solution: //Removed - || value === ''
packages/vulcan-core/lib/modules/components/Datatable/DatatableFilter.jsx 
CONSTANT_CONDITION
      inputProperties={{
        onChange: event => {
          const value = event.target.value;
          if (!value) { //Bug fix - Condition 'value === ''' is always false 
            const newFilters = Object.assign({}, filters);