### PR TITLE
Bugfix/modaltrigger

### DIFF
--- a/packages/vulcan-ui-material/lib/components/ui/ModalTrigger.jsx
+++ b/packages/vulcan-ui-material/lib/components/ui/ModalTrigger.jsx
@@ -50,7 +50,7 @@ class ModalTrigger extends PureComponent {
   };
   
   closeModal = (event) => {
-    if (event) {
+    if (event && event.stopPropagation) {
       event.stopPropagation();
     }
     this.setState({ modalIsOpen: false });

--- a/packages/vulcan-ui-material/lib/components/ui/ModalTrigger.jsx
+++ b/packages/vulcan-ui-material/lib/components/ui/ModalTrigger.jsx
@@ -40,7 +40,7 @@ class ModalTrigger extends PureComponent {
   }
   
   openModal = (event) => {
-    if (event) {
+    if (event && event.stopPropagation) {
       event.stopPropagation();
     }
     this.setState({ modalIsOpen: true });


### PR DESCRIPTION
Sometimes, it can call unexisting event.stopPropagation function.

Example, using EditForm inside a ModalTrigger can cause this. The ModalTrigger passes closeModal as a prop to children and EditForm passes as successCallback this closeModal, so it receives something (data) that does not containt a stopPropagation function.

Other approach would be in EditButton.jsx

```
  const success = successCallback
    ? () => {
      successCallback();
      closeModal();
    }
    : closeModal;
  
  const remove = removeSuccessCallback
    ? () => {
      removeSuccessCallback();
      closeModal();
    }
    : closeModal;
```

change `: closeModal` to `: ()=> closeModal`, if it's better I create the PR asap.

Eloy