### PR TITLE
Bugfix/close modal

### DIFF
--- a/packages/vulcan-core/lib/modules/components/EditButton.jsx
+++ b/packages/vulcan-core/lib/modules/components/EditButton.jsx
@@ -41,14 +41,18 @@ const EditForm = ({ closeModal, successCallback, removeSuccessCallback, formProp
         successCallback(document);
         closeModal();
       }
-    : closeModal;
+    : () => {
+        closeModal();
+      };
 
   const remove = removeSuccessCallback
     ? document => {
         removeSuccessCallback(document);
         closeModal();
       }
-    : closeModal;
+    : () => {
+        closeModal();
+      };
 
   return (
     <Components.SmartForm

--- a/packages/vulcan-core/lib/modules/components/NewButton.jsx
+++ b/packages/vulcan-core/lib/modules/components/NewButton.jsx
@@ -35,7 +35,10 @@ const NewForm = ({ closeModal, successCallback, formProps, ...props }) => {
         successCallback(document);
         closeModal();
       }
-    : closeModal;
+    : () => {
+
+         closeModal();
+      };
 
   return <Components.SmartForm successCallback={success} {...formProps} {...props} />;
 };

--- a/packages/vulcan-core/lib/modules/components/NewButton.jsx
+++ b/packages/vulcan-core/lib/modules/components/NewButton.jsx
@@ -36,7 +36,6 @@ const NewForm = ({ closeModal, successCallback, formProps, ...props }) => {
         closeModal();
       }
     : () => {
-
          closeModal();
       };
 

--- a/packages/vulcan-ui-material/lib/components/core/EditButton.jsx
+++ b/packages/vulcan-ui-material/lib/components/core/EditButton.jsx
@@ -84,14 +84,18 @@ const EditForm = (
       successCallback();
       closeModal();
     }
-    : closeModal;
+    : () => {
+      closeModal();
+    };
   
   const remove = removeSuccessCallback
     ? () => {
       removeSuccessCallback();
       closeModal();
     }
-    : closeModal;
+    : () => {
+      closeModal();
+    };
   
   return (
     <Components.SmartForm


### PR DESCRIPTION
In the version before the closeModal receives the data argument passed to the successCallback, so it can cause an error if closeModal treats this as an event object.