### PR TITLE
joining required and optional props from schema

### DIFF
--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiFormControl.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiFormControl.jsx
@@ -24,7 +24,8 @@ const MuiFormControl = createReactClass({
   },
   
   renderLabel: function () {
-    const { fakeLabel, hideLabel, shrinkLabel, layout, optional, label, value } = this.props;
+    const { fakeLabel, hideLabel, shrinkLabel, layout, label, value } = this.props;
+    const isRequired = !this.props.optional || this.props.required;
     
     if (layout === 'elementOnly' || hideLabel) {
       return null;
@@ -34,9 +35,9 @@ const MuiFormControl = createReactClass({
       return (
         <FormLabel className="control-label legend"
                    component="legend"
-                   data-required={!optional}
+                   data-required={isRequired}
         >
-          {label}<Components.RequiredIndicator optional={optional} value={value}/>
+          {label}<Components.RequiredIndicator optional={!isRequired} value={value}/>
         </FormLabel>
       );
     }
@@ -45,11 +46,11 @@ const MuiFormControl = createReactClass({
     
     return (
       <InputLabel className="control-label"
-                  data-required={!optional}
+                  data-required={isRequired}
                   htmlFor={this.props.htmlFor}
                   shrink={shrink}
       >
-        {label}<Components.RequiredIndicator optional={optional} value={value}/>
+        {label}<Components.RequiredIndicator optional={!isRequired} value={value}/>
       </InputLabel>
     );
   },

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/mixins/component.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/mixins/component.jsx
@@ -25,6 +25,7 @@ export default {
       hasErrors: this.hasErrors(),
       className: this.props.className,
       inputType: this.props.inputType,
+      required: this.props.required,
     };
   },
   


### PR DESCRIPTION
Before if the schema was
optional : true,
form : {required: false}
when shown in the SmartForm it wouldn't be shown with * and the corresponding ui.