### PR TITLE
Bugfix/form component inner prop

### DIFF
--- a/packages/vulcan-ui-material/lib/components/forms/FormComponentInner.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/FormComponentInner.jsx
@@ -126,7 +126,7 @@ FormComponentInner.propTypes = {
   charsRemaining: PropTypes.number,
   charsCount: PropTypes.number,
   max: PropTypes.oneOfType([PropTypes.number, PropTypes.instanceOf(Date)]),
-  formInput: PropTypes.func.isRequired,
+  formInput: PropTypes.oneOfType([PropTypes.func.isRequired, PropTypes.object.isRequired]),
 };
 
 

--- a/packages/vulcan-ui-material/lib/components/forms/FormComponentInner.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/FormComponentInner.jsx
@@ -126,7 +126,7 @@ FormComponentInner.propTypes = {
   charsRemaining: PropTypes.number,
   charsCount: PropTypes.number,
   max: PropTypes.oneOfType([PropTypes.number, PropTypes.instanceOf(Date)]),
-  formInput: PropTypes.oneOfType([PropTypes.func.isRequired, PropTypes.object.isRequired]),
+  formInput: PropTypes.elementType.isRequired,
 };
 
 


### PR DESCRIPTION
When passing 
input: 'MyClassInputRegisteredComponent'
The SmartForm passes a React object instead of a function, throwing a warning. Using PropTypes.elementType both functions and react classes are accepted