### PR TITLE
prevent cacheUpdate from returning variables of a query similar name 

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/cacheUpdate.js
+++ b/packages/vulcan-core/lib/modules/containers/cacheUpdate.js
@@ -36,7 +36,7 @@ export const getVariablesListFromCache = (proxy, queryName) => {
     const matchQueryReducer = (names, name) => {
         // TODO: can be improved with a regex so "customer" matched only "customer(*)"
         // this may match too many items
-        if (name.startsWith(queryName)) {
+        if (name.startsWith(queryName + '(')) {
             names.push(name);
         }
         return names;

--- a/packages/vulcan-core/lib/modules/containers/cacheUpdate.js
+++ b/packages/vulcan-core/lib/modules/containers/cacheUpdate.js
@@ -33,9 +33,9 @@ export const getVariablesListFromCache = (proxy, queryName) => {
     // another cache that doesn't contain the root query.
     if (!rootQuery) return [];
 
+    // Customer(*) will be matched but no customer. This last one would cause an error in
+    // JSON.parse. If wanted to be treated, parseQueryNameToVariables should be adapted
     const matchQueryReducer = (names, name) => {
-        // TODO: can be improved with a regex so "customer" matched only "customer(*)"
-        // this may match too many items
         if (name.startsWith(queryName + '(')) {
             names.push(name);
         }

--- a/packages/vulcan-core/test/containers/mutations.test.js
+++ b/packages/vulcan-core/test/containers/mutations.test.js
@@ -28,7 +28,7 @@ import { mount } from 'enzyme';
 import expect from 'expect';
 import gql from 'graphql-tag';
 import sinon from 'sinon'
-
+import {getVariablesListFromCache} from '../../lib/modules/containers/cacheUpdate'
 const test = it;
 
 describe('vulcan:core/container/mutations', () => {
@@ -63,6 +63,26 @@ describe('vulcan:core/container/mutations', () => {
         fragmentName: fragmentName,
         fragment
     };
+    describe('similar queries in cache', () => {
+        test('return from the cache only the variables which match exactly the query and including variables', async () => {
+          const queryName = 'myCustomQuery';
+          const cacheQueryName = queryName + '({})';
+          const cacheSimilarQueryName = queryName + 'Foo({})';
+          const cacheObject = {
+            data: {
+              data: {
+                ROOT_QUERY: {
+                  [queryName]: { foo: 'bar' },
+                  [cacheQueryName]: { foo: 'bar' },
+                  [cacheSimilarQueryName]: { foo: 'bar' },
+                },
+              },
+            },
+          };
+          const variables = await getVariablesListFromCache(cacheObject, queryName);
+          expect(variables).toHaveLength(1);
+        });
+      });
     describe('common', () => {
         test('export hooks and hocs', () => {
             expect(useCreate).toBeInstanceOf(Function)


### PR DESCRIPTION
Example if we have in cache
myCustomQuery({limit:8}) //The one I want
myCustomQuery //I know I don't want this because causes an error in the line JSON.parse 
myCustomQueryFoo({limit:8}) //I don't want it

The test tries this three cases and asks to return just one, the first. If in the future we would want to manage the second case too.