### PR TITLE
Check if results is non-emtpy, not just present

### DIFF
--- a/packages/vulcan-core/lib/modules/components/Datatable/DatatableContents.jsx
+++ b/packages/vulcan-core/lib/modules/components/Datatable/DatatableContents.jsx
@@ -14,7 +14,7 @@ const getColumns = (columns, results, data) => {
     );
     const sortedColumns = _sortBy(convertedColums, column => column.order);
     return sortedColumns;
-  } else if (results) {
+  } else if (results && results.length > 0) {
     // if no columns are provided, default to using keys of first array item
     return Object.keys(results[0])
       .filter(k => k !== '__typename')


### PR DESCRIPTION
If the collection exists, but is empty, and no columns are specified, the code would fail as results[0] would be undefined.