### PR TITLE
add preventDefault to ui-material ModalTrigger

### DIFF
--- a/packages/vulcan-ui-material/lib/components/ui/ModalTrigger.jsx
+++ b/packages/vulcan-ui-material/lib/components/ui/ModalTrigger.jsx
@@ -41,6 +41,7 @@ class ModalTrigger extends PureComponent {
   
   openModal = (event) => {
     if (event) {
+      event.preventDefault();
       event.stopPropagation();
     }
     this.setState({ modalIsOpen: true });


### PR DESCRIPTION
The lack of a preventDefault is blocking the `a tag` or the Link from working.