### PR TITLE
Field level permissions validation take nested objects into account (read, create, update)

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -8,6 +8,7 @@ Please open an issue or a pull request if you feel this doc is incomplete.
 
 - See migration article from [Vulcan Blog](https://blog.vulcanjs.org/)
 - `serverTimezoneOffset` object is no longer injected in the head during SSR. Use `import { InjectData} from 'meteor/vulcan:lib; ...; await InjectData.getData("utcOffset");` instead. The value is the reverse from `getTimezoneOffset`, see [Moment doc](https://momentjscom.readthedocs.io/en/latest/moment/03-manipulating/09-utc-offset/)
+- `validateModifier` takes `data` as the second param (`validateModifier(modifier, data, document)` instead of `validateModifier(modifier, document)`)
 
 ### Material UI
 - Update to v4 `meteor npm i --save-exact @material-ui/core@4.5.1`

--- a/packages/vulcan-lib/lib/modules/schema_utils.js
+++ b/packages/vulcan-lib/lib/modules/schema_utils.js
@@ -90,7 +90,7 @@ export const forEachDocumentField = (document, schema, callback, currentPath = '
     if (!document) return;
     Object.keys(document).forEach(fieldName => {
         const fieldSchema = schema[fieldName];
-        callback(fieldName, fieldSchema, currentPath, document, schema);
+        callback({ fieldName, fieldSchema, currentPath, document, schema });
         // Check if we need a recursive call
         const value = document[fieldName];
         if (!value) return;

--- a/packages/vulcan-lib/lib/modules/schema_utils.js
+++ b/packages/vulcan-lib/lib/modules/schema_utils.js
@@ -85,12 +85,13 @@ export const isCollectionType = typeName => Collections.some(c => c.options.type
  * @param {*} schema Document schema
  * @param {*} callback Called on each field with the corresponding field schema, including fields of nested objects and arrays of nested object
  * @param {*} currentPath Global path of the document (to track recursive calls)
+ * @param {*} isNested Differentiate nested fields
  */
 export const forEachDocumentField = (document, schema, callback, currentPath = '') => {
     if (!document) return;
     Object.keys(document).forEach(fieldName => {
         const fieldSchema = schema[fieldName];
-        callback({ fieldName, fieldSchema, currentPath, document, schema });
+        callback({ fieldName, fieldSchema, currentPath, document, schema, isNested: !!currentPath });
         // Check if we need a recursive call
         const value = document[fieldName];
         if (!value) return;

--- a/packages/vulcan-lib/lib/modules/schema_utils.js
+++ b/packages/vulcan-lib/lib/modules/schema_utils.js
@@ -1,6 +1,8 @@
 import _reject from 'lodash/reject';
 import _keys from 'lodash/keys';
 import { Collections } from './collections.js';
+import { getNestedSchema, getArrayChild } from 'meteor/vulcan:lib/lib/modules/simpleSchema_utils';
+import _isArray from 'lodash/isArray';
 
 /* getters */
 // filter out fields with "." or "$"
@@ -28,7 +30,7 @@ export const getUpdateableFields = schema => {
 
 /*
 
-Test if the main schema field should be added to the GraphQL schema or not.
+Test if a schema non-nested  field should be added to the GraphQL schema or not.
 Rule: we always add it except if:
 
 1. addOriginalField: false is specified in one or more resolveAs fields
@@ -37,17 +39,17 @@ Rule: we always add it except if:
 
 */
 export const shouldAddOriginalField = (fieldName, field) => {
-  if (!field.resolveAs) return true;
+    if (!field.resolveAs) return true;
 
-  const resolveAsArray = Array.isArray(field.resolveAs) ? field.resolveAs : [field.resolveAs];
+    const resolveAsArray = Array.isArray(field.resolveAs) ? field.resolveAs : [field.resolveAs];
 
-  const removeOriginalField = resolveAsArray.some(
-    resolveAs =>
-      resolveAs.addOriginalField === false ||
-      resolveAs.fieldName === fieldName ||
-      typeof resolveAs.fieldName === 'undefined'
-  );
-  return !removeOriginalField;
+    const removeOriginalField = resolveAsArray.some(
+        resolveAs =>
+            resolveAs.addOriginalField === false ||
+            resolveAs.fieldName === fieldName ||
+            typeof resolveAs.fieldName === 'undefined'
+    );
+    return !removeOriginalField;
 };
 // list fields that can be included in the default fragment for a schema
 export const getFragmentFieldNames = ({ schema, options }) => _reject(_keys(schema), fieldName => {
@@ -75,3 +77,41 @@ is just a regular or custom scalar type.
 
 */
 export const isCollectionType = typeName => Collections.some(c => c.options.typeName === typeName || `[${c.options.typeName}]` === typeName);
+
+/**
+ * Iterate over a document fields and run a callback with side effect
+ * Works recursively for nested fields and arrays
+ * @param {*} document Current document
+ * @param {*} schema Document schema
+ * @param {*} callback Called on each field with the corresponding field schema, including fields of nested objects and arrays of nested object
+ * @param {*} currentPath Global path of the document (to track recursive calls)
+ */
+export const forEachDocumentField = (document, schema, callback, currentPath = '') => {
+    if (!document) return;
+    Object.keys(document).forEach(fieldName => {
+        const fieldSchema = schema[fieldName];
+        callback(fieldName, fieldSchema, currentPath, document, schema);
+        // Check if we need a recursive call
+        const value = document[fieldName];
+        if (!value) return;
+        // if value is an array, validate permissions for all children
+        if (_isArray(value)) {
+            const arrayChildField = getArrayChild(fieldName, schema);
+            if (arrayChildField) {
+                const arrayFieldSchema = getNestedSchema(arrayChildField);
+                // apply only if the field is an array of objects
+                if (arrayFieldSchema) {
+                    value.forEach((item, idx) => {
+                        forEachDocumentField(item, arrayFieldSchema, callback, `${currentPath}${fieldName}[${idx}].`);
+                    });
+                }
+            }
+            // if value is an object, run recursively
+        } else if (typeof value === 'object') {
+            const nestedFieldSchema = getNestedSchema(fieldSchema);
+            if (nestedFieldSchema) {
+                forEachDocumentField(value, nestedFieldSchema, callback, `${currentPath}${fieldName}.`);
+            }
+        }
+    });
+};

--- a/packages/vulcan-lib/lib/modules/schema_utils.js
+++ b/packages/vulcan-lib/lib/modules/schema_utils.js
@@ -1,7 +1,7 @@
 import _reject from 'lodash/reject';
 import _keys from 'lodash/keys';
 import { Collections } from './collections.js';
-import { getNestedSchema, getArrayChild } from 'meteor/vulcan:lib/lib/modules/simpleSchema_utils';
+import { getNestedSchema, getArrayChild, isBlackbox } from 'meteor/vulcan:lib/lib/modules/simpleSchema_utils';
 import _isArray from 'lodash/isArray';
 
 /* getters */
@@ -80,7 +80,7 @@ export const isCollectionType = typeName => Collections.some(c => c.options.type
 
 /**
  * Iterate over a document fields and run a callback with side effect
- * Works recursively for nested fields and arrays
+ * Works recursively for nested fields and arrays of objects (but excluding blackboxed objects, native JSON, and arrays of native values)
  * @param {*} document Current document
  * @param {*} schema Document schema
  * @param {*} callback Called on each field with the corresponding field schema, including fields of nested objects and arrays of nested object
@@ -107,7 +107,7 @@ export const forEachDocumentField = (document, schema, callback, currentPath = '
                 }
             }
             // if value is an object, run recursively
-        } else if (typeof value === 'object') {
+        } else if (typeof value === 'object' && !isBlackbox(fieldSchema)) {
             const nestedFieldSchema = getNestedSchema(fieldSchema);
             if (nestedFieldSchema) {
                 forEachDocumentField(value, nestedFieldSchema, callback, `${currentPath}${fieldName}.`);

--- a/packages/vulcan-lib/lib/modules/simpleSchema_utils.js
+++ b/packages/vulcan-lib/lib/modules/simpleSchema_utils.js
@@ -1,5 +1,6 @@
 /**
- * Helpers for Simple Schema
+ * Helpers specific to Simple Schema
+ * See "schema_utils" for more generic methods
 */
 
 // remove ".$" at the end of array child fieldName
@@ -25,3 +26,4 @@ export const isBlackbox = (field) => field.type.definitions[0].blackbox;
 export const getArrayChild = (fieldName, schema) => schema[`${fieldName}.$`];
 
 export const getNestedSchema = field => field.type.singleType._schema;
+

--- a/packages/vulcan-lib/lib/modules/simpleSchema_utils.js
+++ b/packages/vulcan-lib/lib/modules/simpleSchema_utils.js
@@ -20,3 +20,8 @@ export const hasAllowedValues = field => {
 
 
 export const isBlackbox = (field) => field.type.definitions[0].blackbox;
+
+
+export const getArrayChild = (fieldName, schema) => schema[`${fieldName}.$`];
+
+export const getNestedSchema = field => field.type.singleType._schema;

--- a/packages/vulcan-lib/lib/modules/validation.js
+++ b/packages/vulcan-lib/lib/modules/validation.js
@@ -26,7 +26,7 @@ const validateDocumentPermissions = (document, schema, context, mode = 'create',
   let validationErrors = [];
   const { Users, currentUser } = context;
   forEachDocumentField(document, schema,
-    (fieldName, fieldSchema, currentPath) => {
+    ({ fieldName, fieldSchema, currentPath }) => {
       if (!fieldSchema
         || (mode === 'create' ? !Users.canCreateField(currentUser, fieldSchema) : !Users.canUpdateField(currentUser, fieldSchema, document))
       ) {

--- a/packages/vulcan-lib/lib/modules/validation.js
+++ b/packages/vulcan-lib/lib/modules/validation.js
@@ -26,7 +26,8 @@ const validateDocumentPermissions = (document, schema, context, mode = 'create',
   let validationErrors = [];
   const { Users, currentUser } = context;
   forEachDocumentField(document, schema,
-    ({ fieldName, fieldSchema, currentPath }) => {
+    ({ fieldName, fieldSchema, currentPath, isNested }) => {
+      if (isNested && mode === 'create' ? !fieldSchema.canCreate : !fieldSchema.canUpdate) return; // ignore nested without permission
       if (!fieldSchema
         || (mode === 'create' ? !Users.canCreateField(currentUser, fieldSchema) : !Users.canUpdateField(currentUser, fieldSchema, document))
       ) {

--- a/packages/vulcan-lib/lib/modules/validation.js
+++ b/packages/vulcan-lib/lib/modules/validation.js
@@ -55,7 +55,7 @@ const validateDocumentPermissions = (document, schema, context, mode = 'create',
         if (arrayFieldSchema) {
           value.forEach((item, idx) => {
             validationErrors = validationErrors.concat(
-              validateDocumentPermissions(item, arrayFieldSchema, context, mode, `${key}[${idx}].`)
+              validateDocumentPermissions(item, arrayFieldSchema, context, mode, `${currentPath}${key}[${idx}].`)
             );
           });
         }
@@ -64,7 +64,7 @@ const validateDocumentPermissions = (document, schema, context, mode = 'create',
     } else if (typeof value === 'object') {
       const nestedFieldSchema = getNestedSchema(fieldSchema);
       if (nestedFieldSchema) {
-        validationErrors = validationErrors.concat(validateDocumentPermissions(value, nestedFieldSchema, context, mode, `${key}.`));
+        validationErrors = validationErrors.concat(validateDocumentPermissions(value, nestedFieldSchema, context, mode, `${currentPath}${key}.`));
       }
     }
   });

--- a/packages/vulcan-lib/lib/modules/validation.js
+++ b/packages/vulcan-lib/lib/modules/validation.js
@@ -1,8 +1,10 @@
 import pickBy from 'lodash/pickBy';
 import mapValues from 'lodash/mapValues';
+import _isArray from 'lodash/isArray';
+import { getNestedSchema, getArrayChild } from './simpleSchema_utils';
 
-export const dataToModifier = data => ({ 
-  $set: pickBy(data, f => f !== null), 
+export const dataToModifier = data => ({
+  $set: pickBy(data, f => f !== null),
   $unset: mapValues(pickBy(data, f => f === null), () => true),
 });
 
@@ -11,6 +13,63 @@ export const modifierToData = modifier => ({
   ...mapValues(modifier.$unset, () => null),
 });
 
+
+
+/**
+ * Validate a document permission recursively
+ * @param {*} document document to validate (can be partial in case of update or recursive call)
+ * @param {*} schema Simple schema
+ * @param {*} context Current user and Users collectionœ
+ * @param {*} mode create or update
+ * @param {*} currentPath current path for recursive calls (nested, nested[0].foo, ...)
+ */
+const validateDocumentPermissions = (document, schema, context, mode = 'create', currentPath = '') => {
+  let validationErrors = [];
+  const { Users, currentUser } = context;
+  // Check validity of inserted document
+  Object.keys(document).forEach(key => {
+    const fieldSchema = schema[key];
+
+    // check that the current user has permission to insert the field
+    if (!fieldSchema
+      || (mode === 'create' ? !Users.canCreateField(currentUser, fieldSchema) : !Users.canUpdateField(currentUser, fieldSchema))
+    ) {
+      validationErrors.push({
+        id: 'errors.disallowed_property_detected',
+        properties: {
+          name: `${currentPath}${key}`
+        },
+      });
+      return;
+    }
+
+    // Check if we need a recursive call
+    const value = document[key];
+    if (!value) return;
+    // if value is an array, validate permissions for all children
+    if (_isArray(value)) {
+      const arrayChildField = getArrayChild(key, schema);
+      if (arrayChildField) {
+        const arrayFieldSchema = getNestedSchema(arrayChildField);
+        // apply only if the field is an array of objects
+        if (arrayFieldSchema) {
+          value.forEach((item, idx) => {
+            validationErrors = validationErrors.concat(
+              validateDocumentPermissions(item, arrayFieldSchema, context, mode, `${key}[${idx}].`)
+            );
+          });
+        }
+      }
+      // if value is an object, validate recursively
+    } else if (typeof value === 'object') {
+      const nestedFieldSchema = getNestedSchema(fieldSchema);
+      if (nestedFieldSchema) {
+        validationErrors = validationErrors.concat(validateDocumentPermissions(value, nestedFieldSchema, context, mode, `${key}.`));
+      }
+    }
+  });
+  return validationErrors;
+};
 /*
 
   If document is not trusted, run validation steps:
@@ -20,25 +79,16 @@ export const modifierToData = modifier => ({
 
 */
 export const validateDocument = (document, collection, context) => {
-  const { Users, currentUser } = context;
   const schema = collection.simpleSchema()._schema;
 
   let validationErrors = [];
 
-  // Check validity of inserted document
-  Object.keys(document).forEach(fieldName => {
-    const fieldSchema = schema[fieldName];
+  // validate creation permissions (and other Vulcan-specific constraints)
+  validationErrors = validationErrors.concat(
+    validateDocumentPermissions(document, schema, context, 'create')
+  );
 
-    // 1. check that the current user has permission to insert each field
-    if (!fieldSchema || !Users.canCreateField(currentUser, fieldSchema)) {
-      validationErrors.push({
-        id: 'errors.disallowed_property_detected',
-        properties: { name: fieldName },
-      });
-    }
-  });
-
-  // 5. run SS validation
+  // run simple schema validation (will check the actual types, required fields, etc....)
   const validationContext = collection.simpleSchema().newContext();
   validationContext.validate(document);
 
@@ -75,9 +125,7 @@ export const validateDocument = (document, collection, context) => {
   2. Run SimpleSchema validation step
   
 */
-export const validateModifier = (modifier, document, collection, context) => {
-  
-  const { Users, currentUser } = context;
+export const validateModifier = (modifier, data, document, collection, context) => {
   const schema = collection.simpleSchema()._schema;
   const set = modifier.$set;
   const unset = modifier.$unset;
@@ -85,16 +133,9 @@ export const validateModifier = (modifier, document, collection, context) => {
   let validationErrors = [];
 
   // 1. check that the current user has permission to edit each field
-  const modifiedProperties = _.keys(set).concat(_.keys(unset));
-  modifiedProperties.forEach(function(fieldName) {
-    var field = schema[fieldName];
-    if (!field || !Users.canUpdateField(currentUser, field, document)) {
-      validationErrors.push({
-        id: 'errors.disallowed_property_detected',
-        properties: { name: fieldName },
-      });
-    }
-  });
+  validationErrors = validationErrors.concat(
+    validateDocumentPermissions(data, schema, context, 'update')
+  );
 
   // 2. run SS validation
   const validationContext = collection.simpleSchema().newContext();
@@ -125,7 +166,7 @@ export const validateModifier = (modifier, document, collection, context) => {
 };
 
 export const validateData = (data, document, collection, context) => {
-  return validateModifier(dataToModifier(data), document, collection, context);
+  return validateModifier(dataToModifier(data), data, document, collection, context);
 };
 
 /*
@@ -224,12 +265,12 @@ export const validateModifierNotUsed = (modifier, document, collection, context)
 
   // 1. check that the current user has permission to edit each field
   const modifiedProperties = _.keys(set).concat(_.keys(unset));
-  modifiedProperties.forEach(function(fieldName) {
+  modifiedProperties.forEach(function (fieldName) {
     var field = schema[fieldName];
     if (!field || !Users.canUpdateField(currentUser, field, document)) {
       validationErrors.push({
         id: 'app.disallowed_property_detected',
-        data: {name: fieldName},
+        data: { name: fieldName },
       });
     }
   });

--- a/packages/vulcan-lib/lib/server/graphql/schemaFields.js
+++ b/packages/vulcan-lib/lib/server/graphql/schemaFields.js
@@ -240,7 +240,7 @@ export const getSchemaFields = (schema, typeName) => {
  */
 /* eslint-disable no-console */
 import { isIntlField } from '../../modules/intl.js';
-import { /*hasAllowedValues, getAllowedValues,*/isBlackbox, unarrayfyFieldName } from '../../modules/simpleSchema_utils';
+import { isBlackbox, unarrayfyFieldName, getArrayChild, getNestedSchema } from '../../modules/simpleSchema_utils';
 import { shouldAddOriginalField } from '../../modules/schema_utils';
 import relations from './relations.js';
 
@@ -254,21 +254,6 @@ const capitalize = word => {
 export const getNestedGraphQLType = (typeName, fieldName, isInput) =>
   `${typeName}${capitalize(unarrayfyFieldName(fieldName))}${isInput ? 'Input' : ''}`;
 
-// @see https://graphql.github.io/graphql-spec/June2018/#sec-Enums
-// @see https://graphql.github.io/graphql-spec/June2018/#sec-Names
-/*
-const isValidName = name => {
-  if (typeof name !== 'string') {
-    throw new Error(
-      `Allowed value of field of type String is not a string (value: ${name}, type:${typeof name})`
-    );
-  }
-  return name.match(/^[_A-Za-z][_0-9A-Za-z]*$/);
-};
-*/
-// const isValidEnum = values => !values.find(val => !isValidName(val));
-
-// export const getEnumType = (typeName, fieldName) => `${typeName}${capitalize(unarrayfyFieldName(fieldName))}Enum`;
 
 const getFieldType = field => field.type.singleType;
 const getFieldTypeName = fieldType =>
@@ -348,10 +333,8 @@ export const getGraphQLType = ({ schema, fieldName, typeName, isInput = false })
 const hasTypeName = field => !!(field || {}).typeName;
 
 const hasNestedSchema = field => !!getNestedSchema(field);
-const getNestedSchema = field => field.type.singleType._schema;
 
 const isArrayChildField = fieldName => fieldName.indexOf('$') !== -1;
-const getArrayChild = (fieldName, schema) => schema[`${fieldName}.$`];
 const hasArrayChild = (fieldName, schema) => !!getArrayChild(fieldName, schema);
 
 const getArrayChildSchema = (fieldName, schema) => {

--- a/packages/vulcan-lib/test/documentValidation.test.js
+++ b/packages/vulcan-lib/test/documentValidation.test.js
@@ -1,0 +1,182 @@
+import { createDummyCollection } from "meteor/vulcan:test"
+import { validateDocument, validateData } from "../lib/modules/validation"
+import expect from 'expect'
+import './routes.test';
+import SimpleSchema from "simpl-schema"
+import Users from "meteor/vulcan:users"
+
+const test = it
+
+const defaultContext = { Users }
+describe("vulcan:lib/validation", () => {
+    describe("validate document permissions per field (on creation and update)", () => {
+        test('no error if all fields are creatable', () => {
+            const collection = createDummyCollection({
+                schema: {
+                    foo: {
+                        type: String,
+                        canCreate: ['guests'],
+                        canUpdate: ['guests']
+                    }
+                }
+            })
+            // create
+            const errors = validateDocument({ foo: "bar" }, collection, defaultContext)
+            expect(errors).toHaveLength(0)
+            const updateErrors = validateData({ foo: "bar" }, { foo: "bar" }, collection, defaultContext)
+            expect(updateErrors).toHaveLength(0)
+        })
+        test('create error for non creatable field', () => {
+            const collection = createDummyCollection({
+                schema: {
+                    foo: {
+                        type: String,
+                        canCreate: ['members'],
+                        canUpdate: ['members']
+                    },
+                    bar: {
+                        type: String,
+                        canCreate: ['guests'],
+                        canUpdate: ['guests']
+                    }
+                }
+            })
+            const errors = validateDocument({ foo: "bar", bar: "foo" }, collection, defaultContext)
+            expect(errors).toHaveLength(1)
+            expect(errors[0]).toMatchObject({
+                id: "errors.disallowed_property_detected",
+                properties: { name: "foo" }
+            })
+            const updateErrors = validateData({ foo: "bar", bar: "foo" }, { foo: "bar", bar: "foo" }, collection, defaultContext)
+            expect(updateErrors).toHaveLength(1)
+            expect(updateErrors[0]).toMatchObject({
+                id: "errors.disallowed_property_detected",
+                properties: { name: "foo" }
+            })
+        })
+
+        test('create error for non creatable nested field (object)', () => {
+            const collection = createDummyCollection({
+                schema: {
+                    nested: {
+                        type: new SimpleSchema({
+                            foo: {
+                                type: String,
+                                canCreate: ["members"],
+                                canUpdate: ["members"]
+                            },
+                            zed: {
+                                optional: true,
+                                type: String,
+                                canCreate: ["members"],
+                                canUpdate: ["members"]
+                            },
+                            bar: {
+                                type: String,
+                                canCreate: ["guests"],
+                                canUpdate: ["guests"]
+                            },
+                        }),
+                        canCreate: ["guests"],
+                        canUpdate: ["guests"]
+                    }
+                }
+            })
+            // create
+            const errors = validateDocument({ nested: { foo: "bar", bar: "foo" } }, collection, defaultContext)
+            expect(errors).toHaveLength(1)
+            expect(errors[0]).toMatchObject({
+                id: "errors.disallowed_property_detected",
+                properties: { name: "nested.foo" }
+            })
+            // update with set and unset
+            const updateErrors = validateData({ nested: { foo: "bar", bar: "foo", zed: null } }, { nested: { foo: "bar", bar: "foo", zed: "hello" } }, collection, defaultContext)
+            expect(updateErrors).toHaveLength(2)
+            expect(updateErrors[0]).toMatchObject({
+                id: "errors.disallowed_property_detected",
+                properties: { name: "nested.foo" }
+            },
+                {
+                    id: "errors.disallowed_property_detected",
+                    properties: { name: "nested.zed" }
+                },
+            )
+        })
+        test('create error for non creatable nested field (array)', () => {
+            const collection = createDummyCollection({
+                schema: {
+                    nested: {
+                        type: Array,
+                        canCreate: ["guests"],
+                        canUpdate: ["guests"]
+                    },
+                    "nested.$": {
+                        type: new SimpleSchema({
+                            foo: {
+                                type: String,
+                                canCreate: ["members"],
+                                canUpdate: ["members"]
+                            },
+                            bar: {
+                                type: String,
+                                canCreate: ["guests"],
+                                canUpdate: ["guests"]
+                            }
+                        })
+                    }
+                }
+            })
+            const errors = validateDocument({ nested: [{ foo: "bar", bar: "foo" }] }, collection, defaultContext)
+            expect(errors).toHaveLength(1)
+            expect(errors[0]).toMatchObject({
+                id: "errors.disallowed_property_detected",
+                properties: { name: "nested[0].foo" }
+            })
+
+            const updateErrors = validateData({ nested: [{ foo: "bar", bar: "foo" }] }, { nested: [{ foo: "bar", bar: "foo" }] }, collection, defaultContext)
+            expect(updateErrors).toHaveLength(1)
+            expect(updateErrors[0]).toMatchObject({
+                id: "errors.disallowed_property_detected",
+                properties: { name: "nested[0].foo" }
+            })
+        })
+
+        test('do not check permissions of blackbox JSON', () => {
+            const collection = createDummyCollection({
+                schema: {
+                    nested: {
+                        type: Object,
+                        blackbox: true,
+                        canCreate: ["guests"],
+                        canUpdate: ["guests"],
+                    },
+                }
+            })
+            const errors = validateDocument({ nested: { foo: "bar" } }, collection, defaultContext)
+            expect(errors).toHaveLength(0)
+
+            const updateErrors = validateData({ nested: { foo: "bar" } }, { nested: { foo: "bar" } }, collection, defaultContext)
+            expect(updateErrors).toHaveLength(0)
+        })
+        test('do not check native arrays', () => {
+            const collection = createDummyCollection({
+                schema: {
+                    array: {
+                        type: Array,
+                        canCreate: ["guests"],
+                        canUpdate: ["guests"]
+                    },
+                    "array.$": {
+                        type: Number
+                    }
+                }
+            })
+            const errors = validateDocument({ array: [1, 2, 3] }, collection, defaultContext)
+            expect(errors).toHaveLength(0)
+
+            const updateErrors = validateData({ array: [1, 2, 3] }, { array: [1, 2, 3] }, collection, defaultContext)
+            expect(updateErrors).toHaveLength(0)
+        })
+    })
+
+})

--- a/packages/vulcan-lib/test/documentValidation.test.js
+++ b/packages/vulcan-lib/test/documentValidation.test.js
@@ -141,6 +141,53 @@ describe("vulcan:lib/validation", () => {
             })
         })
 
+
+        test('ignore nested fields without permissions (use parent permissions)', () => {
+            const collection = createDummyCollection({
+                schema: {
+                    nested: {
+                        type: new SimpleSchema({
+                            nok: {
+                                type: String,
+                                canCreate: ["members"],
+                                canUpdate: ["members"]
+                            },
+                            ok: {
+                                type: String,
+                            },
+                            zed: {
+                                optional: true,
+                                type: String,
+                                canCreate: ["members"],
+                                canUpdate: ["members"]
+                            },
+                        }),
+                        canCreate: ["guests"],
+                        canUpdate: ["guests"]
+                    }
+                }
+            })
+            // create
+            const errors = validateDocument({ nested: { nok: "bar", ok: "foo" } }, collection, defaultContext)
+            expect(errors).toHaveLength(1)
+            expect(errors[0]).toMatchObject({
+                id: "errors.disallowed_property_detected",
+                properties: { name: "nested.nok" }
+            })
+            // update with set and unset
+            const updateErrors = validateData({ nested: { nok: "bar", ok: "foo", zed: null } }, { nested: { nok: "bar", ok: "foo", zed: "hello" } }, collection, defaultContext)
+            expect(updateErrors).toHaveLength(2)
+            expect(updateErrors[0]).toMatchObject({
+                id: "errors.disallowed_property_detected",
+                properties: { name: "nested.nok" }
+            },
+                {
+                    id: "errors.disallowed_property_detected",
+                    properties: { name: "nested.zed" }
+                },
+            )
+        })
+
         test('do not check permissions of blackbox JSON', () => {
             const collection = createDummyCollection({
                 schema: {

--- a/packages/vulcan-lib/test/documentValidation.test.js
+++ b/packages/vulcan-lib/test/documentValidation.test.js
@@ -145,7 +145,7 @@ describe("vulcan:lib/validation", () => {
             const collection = createDummyCollection({
                 schema: {
                     nested: {
-                        type: Object,
+                        type: new SimpleSchema({ foo: { type: String, canCreate: ['members'], canUpdate: ['members'] } }),
                         blackbox: true,
                         canCreate: ["guests"],
                         canUpdate: ["guests"],

--- a/packages/vulcan-lib/test/index.js
+++ b/packages/vulcan-lib/test/index.js
@@ -4,3 +4,4 @@ import './components.test.js';
 import './handleOptions.test.js';
 import './utils.test.js';
 import './routes.test';
+import './documentValidation.test';

--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -258,8 +258,11 @@ Users.checkFields = (user, collection, fields) => {
 
 const restrictDocument = (document, schema, currentUser) => {
   let restrictedDocument = cloneDeep(document);
-  forEachDocumentField(document, schema, ({ fieldName, fieldSchema, currentPath }) => {
-    if (!fieldSchema || !Users.canReadField(currentUser, fieldSchema, document)) {
+  forEachDocumentField(document, schema, ({ fieldName, fieldSchema, currentPath, isNested }) => {
+    if (isNested && !fieldSchema.canRead) return; // ignore nested fields without permissions
+    if (!fieldSchema
+      || !Users.canReadField(currentUser, fieldSchema, document)
+    ) {
       unset(restrictedDocument, `${currentPath}${fieldName}`);
     }
   });

--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -258,7 +258,7 @@ Users.checkFields = (user, collection, fields) => {
 
 const restrictDocument = (document, schema, currentUser) => {
   let restrictedDocument = cloneDeep(document);
-  forEachDocumentField(document, schema, (fieldName, fieldSchema, currentPath) => {
+  forEachDocumentField(document, schema, ({ fieldName, fieldSchema, currentPath }) => {
     if (!fieldSchema || !Users.canReadField(currentUser, fieldSchema, document)) {
       unset(restrictedDocument, `${currentPath}${fieldName}`);
     }

--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -4,9 +4,13 @@ import compact from 'lodash/compact';
 import map from 'lodash/map';
 import difference from 'lodash/difference';
 import get from 'lodash/get';
+import unset from 'lodash/unset';
+import cloneDeep from 'lodash/cloneDeep';
 import { getCollection } from 'meteor/vulcan:lib';
 import { Utils, deprecate } from 'meteor/vulcan:lib';
 
+import isArray from 'lodash/isArray';
+import { getNestedSchema, getArrayChild } from 'meteor/vulcan:lib/lib/modules/simpleSchema_utils';
 /**
  * @summary Users.groups object
  */
@@ -254,6 +258,54 @@ Users.checkFields = (user, collection, fields) => {
   return true;
 };
 
+
+/**
+ * Iterate over a document fields and run a callback with side effect
+ * Works recursively for nested fields and arrays
+ * @param {*} document Current document
+ * @param {*} schema Document schema
+ * @param {*} callback Called on each field, with the corresponding field schema
+ * @param {*} currentPath Global path of the document (to track recursive calls)
+ */
+const forEachField = (document, schema, callback, currentPath = '') => {
+  if (!document) return;
+  Object.keys(document).forEach(fieldName => {
+    const fieldSchema = schema[fieldName];
+    callback(fieldName, fieldSchema, currentPath, document, schema);
+    // Check if we need a recursive call
+    const value = document[fieldName];
+    if (!value) return;
+    // if value is an array, validate permissions for all children
+    if (isArray(value)) {
+      const arrayChildField = getArrayChild(fieldName, schema);
+      if (arrayChildField) {
+        const arrayFieldSchema = getNestedSchema(arrayChildField);
+        // apply only if the field is an array of objects
+        if (arrayFieldSchema) {
+          value.forEach((item, idx) => {
+            forEachField(item, arrayFieldSchema, callback, `${currentPath}${fieldName}[${idx}].`);
+          });
+        }
+      }
+      // if value is an object, validate recursively
+    } else if (typeof value === 'object') {
+      const nestedFieldSchema = getNestedSchema(fieldSchema);
+      if (nestedFieldSchema) {
+        forEachField(value, nestedFieldSchema, callback, `${currentPath}${fieldName}.`);
+      }
+    }
+  });
+};
+
+const restrictDocument = (document, schema, currentUser) => {
+  let restrictedDocument = cloneDeep(document);
+  forEachField(document, schema, (fieldName, fieldSchema, currentPath) => {
+    if (!fieldSchema || !Users.canReadField(currentUser, fieldSchema, document)) {
+      unset(restrictedDocument, `${currentPath}${fieldName}`);
+    }
+  });
+  return restrictedDocument;
+};
 /**
  * @summary For a given document or list of documents, keep only fields viewable by current user
  * @param {Object} user - The user performing the action
@@ -262,21 +314,8 @@ Users.checkFields = (user, collection, fields) => {
  */
 Users.restrictViewableFields = function (user, collection, docOrDocs) {
   if (!docOrDocs) return {};
-
-  const restrictDoc = document => {
-    // get array of all keys viewable by user
-    const viewableKeys = Users.getReadableFields(user, collection, document);
-    const restrictedDocument = _.clone(document);
-
-    // loop over each property in the document and delete it if it's not viewable
-    _.forEach(restrictedDocument, (value, key) => {
-      if (!viewableKeys.includes(key)) {
-        delete restrictedDocument[key];
-      }
-    });
-
-    return restrictedDocument;
-  };
+  const schema = collection.simpleSchema()._schema;
+  const restrictDoc = (document) => restrictDocument(document, schema, user);
 
   return Array.isArray(docOrDocs) ? docOrDocs.map(restrictDoc) : restrictDoc(docOrDocs);
 };

--- a/packages/vulcan-users/test/permissions.test.js
+++ b/packages/vulcan-users/test/permissions.test.js
@@ -95,5 +95,26 @@ describe('vulcan:users/permissions', () => {
             const fields = Users.restrictViewableFields(null, Dummies, { "array": [{ ok: "foo", nok: "bar" }] })
             expect(fields).toEqual({ array: [{ ok: "foo" }] })
         })
+        test('ignore fields without read permission (parent permissions are used)', () => {
+            const Dummies = createDummyCollection({
+                schema: {
+                    nested: {
+                        canRead: ['guests'],
+                        type: new SimpleSchema({
+                            ok: {
+                                type: String,
+                            },
+                            nok: {
+                                type: String,
+                                canRead: ['members']
+                            }
+
+                        })
+                    }
+                }
+            })
+            const fields = Users.restrictViewableFields(null, Dummies, { "nested": { ok: "foo", nok: "bar" } })
+            expect(fields).toEqual({ nested: { ok: "foo" } })
+        })
     })
 })

--- a/packages/vulcan-users/test/permissions.test.js
+++ b/packages/vulcan-users/test/permissions.test.js
@@ -3,6 +3,7 @@ import '../lib/modules/permissions'
 const test = it
 import expect from "expect"
 import { createDummyCollection } from "meteor/vulcan:test"
+import SimpleSchema from "simpl-schema"
 
 describe('vulcan:users/permissions', () => {
     const Dummies = createDummyCollection({
@@ -41,5 +42,58 @@ describe('vulcan:users/permissions', () => {
     test('restrictViewableFields', () => {
         const fields = Users.restrictViewableFields(null, Dummies, { 'adminField': "foo", 'guestField': "bar" })
         expect(fields).toEqual({ 'guestField': "bar" })
+    })
+
+    describe('nested fields', () => {
+        test('remove unreadable field of nested object', () => {
+            const Dummies = createDummyCollection({
+                schema: {
+                    nested: {
+                        canRead: ['guests'],
+                        type: new SimpleSchema({
+                            ok: {
+                                type: String,
+                                canRead: ['guests']
+
+                            },
+                            nok: {
+                                type: String,
+                                canRead: ['members']
+                            }
+
+                        })
+                    }
+                }
+            })
+            const fields = Users.restrictViewableFields(null, Dummies, { "nested": { ok: "foo", nok: "bar" } })
+            expect(fields).toEqual({ nested: { ok: "foo" } })
+        })
+        test('remove unreadable field of array of nested objects', () => {
+            const Dummies = createDummyCollection({
+                schema: {
+                    array: {
+                        type: Array,
+                        canRead: ['guests']
+                    },
+                    "array.$": {
+                        canRead: ['guests'],
+                        type: new SimpleSchema({
+                            ok: {
+                                type: String,
+                                canRead: ['guests']
+
+                            },
+                            nok: {
+                                type: String,
+                                canRead: ['members']
+                            }
+
+                        })
+                    }
+                }
+            })
+            const fields = Users.restrictViewableFields(null, Dummies, { "array": [{ ok: "foo", nok: "bar" }] })
+            expect(fields).toEqual({ array: [{ ok: "foo" }] })
+        })
     })
 })


### PR DESCRIPTION
Behaviour before PR:
```
const fooSchema = {
  nested: {
    type: new SimpleSchema({
      foo: {
         type: String,
         canCreate:["admins"] // this is ignored => members can actually create foo
    })
   canCreate: ["members"]   // this is validated, only members can create the "nested" object
}
```
The obvious issue is that nested permissions are ignored. This is not a bad beahviour per se, but it could confuse users.

After the PR:
```
const fooSchema = {
  nested: {
    type: new SimpleSchema({
      foo: {
         optional: true,
         type: String,
         canCreate:["admins"] // this is also taken into account
    })
   canCreate: ["members"]   // you still need this
}
```
So "members" could create an empty "nested", but not "nested.foo".
This is better. 

However, if you remove the `canCreate: ["members"']` at the root of the object, the whole object can't be created. You need both a permission at the root, and a permission per nested field.

So my question is: should we drop the check of the root of the nested object, and expect user to only provide a permission per nested field? Or is the current behaviour ok?
It feels a bit redundant. Same with array of objects, right now you may need to add a `canCreate` to `array`, `array.$`, and `array.$.yourNestedField`...

