### PR TITLE
Set non-null to false for data input type on update/upsert

### DIFF
--- a/packages/vulcan-lib/lib/modules/graphql_templates/mutations.js
+++ b/packages/vulcan-lib/lib/modules/graphql_templates/mutations.js
@@ -244,7 +244,7 @@ mutation updateMovie($selector: MovieSelectorUniqueInput!, $data: UpdateMovieDat
 export const updateClientTemplate = ({ typeName, fragmentName }) =>
   `mutation ${updateMutationType(typeName)}($input: ${updateInputType(typeName)}, $selector: ${selectorUniqueInputType(
     typeName
-  )}, $data: ${updateDataInputType(typeName, true)}) {
+  )}, $data: ${updateDataInputType(typeName, false)}) {
   ${updateMutationType(typeName)}(input: $input, selector: $selector, data: $data) {
     ${mutationReturnProperty} {
       ...${fragmentName}
@@ -271,7 +271,7 @@ mutation upsertMovie($selector: MovieSelectorUniqueInput!, $data: UpdateMovieDat
 export const upsertClientTemplate = ({ typeName, fragmentName }) =>
   `mutation ${upsertMutationType(typeName)}($input: ${upsertInputType(typeName)}, $selector: ${selectorUniqueInputType(
     typeName
-  )}, $data: ${updateDataInputType(typeName, true)}) {
+  )}, $data: ${updateDataInputType(typeName, false)}) {
   ${upsertMutationType(typeName)}(input: $input, selector: $selector, data: $data) {
     ${mutationReturnProperty} {
       ...${fragmentName}


### PR DESCRIPTION
Before this patch, the new single variable `input` API was causing the following error when used with `useUpdate2`. 

```
[GraphQL error]: Message: Variable "$data" of required type "UpdateGroupDataInput!" was not provided., Location: line 1, col 85, Path: undefined
```

This patch fixes the issue for update & upsert.