### PR TITLE
Add support for `itemProperties` in schemas

### DIFF
--- a/packages/vulcan-forms/lib/modules/schema_utils.js
+++ b/packages/vulcan-forms/lib/modules/schema_utils.js
@@ -170,6 +170,7 @@ export const schemaProperties = [
   'mustComplete', // mustComplete: true means the field is required to have a complete profile
   'form', // form placeholder
   'inputProperties', // form placeholder
+  'itemProperties',
   'control', // SmartForm control (String or React component)
   'input', // SmartForm control (String or React component)
   'autoform', // legacy form placeholder; backward compatibility (not used anymore)
@@ -218,6 +219,7 @@ export const formProperties = [
   'mustComplete', // mustComplete: true means the field is required to have a complete profile
   'form', // form placeholder
   'inputProperties', // form placeholder
+  'itemProperties',
   'control', // SmartForm control (String or React component)
   'input', // SmartForm control (String or React component)
   'order', // position in the form

--- a/packages/vulcan-lib/lib/modules/config.js
+++ b/packages/vulcan-lib/lib/modules/config.js
@@ -18,6 +18,7 @@ SimpleSchema.extendOptions([
   'mustComplete', // mustComplete: true means the field is required to have a complete profile
   'form', // extra form properties
   'inputProperties', // extra form properties
+  'itemProperties', // extra properties for the form row
   'input', // SmartForm control (String or React component)
   'control', // SmartForm control (String or React component) (legacy)
   'order', // position in the form


### PR DESCRIPTION
These edits allow you to use `itemProperties` in a schema.js file, like:

```...
input: 'textarea',
itemProperties: {
  layout: 'inputOnly'
},
...
```

See Slack discussion at https://vulcanjs.slack.com/archives/C02L990AF/p1574895832425900 thru https://vulcanjs.slack.com/archives/C02L990AF/p1574900591428300