### PR TITLE
check options.input.limit and loadMoreInc accepts input

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/multi2.js
+++ b/packages/vulcan-core/lib/modules/containers/multi2.js
@@ -46,7 +46,7 @@ export const buildMultiQuery = ({ typeName, fragmentName, extraQueries, fragment
 
 const initialPaginationInput = (options, props) => {
   // get initial limit from props, or else options, or else default value
-  const limit = (props.input && props.input.limit) || options.limit || defaultInput.limit;
+  const limit = (props.input && props.input.limit) || (options.input && options.input.limit) || options.limit || defaultInput.limit;
   const paginationInput = {
     limit,
   };
@@ -147,19 +147,16 @@ const buildResult = (
     // incremental loading version (only load new content)
     // note: not compatible with polling
     // TODO
-    loadMoreInc(providedTerms) {
+    loadMoreInc(providedInput) {
       // get terms passed as argument or else just default to incrementing the offset
 
-      const newTerms =
-        typeof providedTerms === 'undefined'
-          ? {
-            ...paginationInput,
-            offset: results.length,
-          }
-          : providedTerms;
+      const newInput = providedInput || {
+        ...paginationInput,
+        offset: results.length,
+      }
 
       return fetchMore({
-        variables: { input: { terms: newTerms } }, // ??? not sure about 'terms: newTerms'
+        variables: { input: newInput },
         updateQuery(previousResults, { fetchMoreResult }) {
           // no more post to fetch
           if (


### PR DESCRIPTION
Fixes two issues I'm running into using `withMulti2({input: ...})`:

1. The limit that is provided as part of the input (`options.input.limit`) was not being used, instead the limit was always `defaultInput.limit`.

This is because `options.input.limit` is not one of the values that the function `initialPaginationInput` looks for, so it ends up going with the default for paginationInput.

This will now check for a provided `options.input.limit`.

2. `loadMoreInc` was returning duplicate values.

This seems to be because `fetchMore` changes the input variable of the original query to use terms: `variables: { input: { terms: newTerms } }`.

Instead of overriding the input like this, I've changed loadMoreInc to accept an input (which user can set as desired, including offset) or default to an input that contains the pagination input and a new offset.