### PR TITLE
Add Vulcan.generateGraphQLQueries to debug.js

### DIFF
--- a/packages/vulcan-lib/lib/server/debug.js
+++ b/packages/vulcan-lib/lib/server/debug.js
@@ -60,6 +60,13 @@ if (Meteor.isServer) {
     });
   };
 
+  /*
+  This function is aimed at enabling generation of typescript definitions
+  for the default queries provided by Vulcan.
+
+  Tools like apollo codegen:generate generate typescript definitions when
+  provided with a schema and queries/fragments.
+  */
   Vulcan.generateGraphQLQueries = fileName => {
     let fd;
 

--- a/packages/vulcan-lib/lib/server/debug.js
+++ b/packages/vulcan-lib/lib/server/debug.js
@@ -2,13 +2,22 @@ import { GraphQLSchema, generateTypeDefs } from './graphql';
 import Vulcan from '../modules/config.js';
 import fs from 'fs';
 
+import { Collections } from '../modules/collections.js';
+import { extractCollectionInfo, extractFragmentInfo } from '../modules/handleOptions';
+
+import { multiClientTemplate, singleClientTemplate } from '../modules/graphql_templates';
+import { Fragments } from '../modules/fragments';
+import { Utils } from '../modules/utils';
+
+import get from 'lodash/get';
+
 if (Meteor.isServer) {
   /*
 
   Can be called from the Meteor shell (type `meteor shell` in your app repo)
 
   */
-  Vulcan.getGraphQLSchema = () => {
+  Vulcan.getGraphQLSchema = fileName => {
     let schema;
     if (!GraphQLSchema.finalSchema) {
       schema = generateTypeDefs(GraphQLSchema)[0];
@@ -20,11 +29,12 @@ if (Meteor.isServer) {
       schema = GraphQLSchema.finalSchema[0];
     }
 
+    const name = fileName ? fileName : 'schema.graphql';
     // the server path is of type "/Users/foo/bar/appName/.meteor/local/build/programs/server"
     // we remove the last five segments to get the app directory
     // eslint-disable-next-line no-undef
     const path = __meteor_bootstrap__.serverDir.split('/').slice(1,-5).join('/');
-    const fullPath = `/${path}/schema.graphql`;
+    const fullPath = `/${path}/${name}`;
 
     fs.writeFile(fullPath, schema, error => {
       // throws an error, you could also catch it here
@@ -49,5 +59,54 @@ if (Meteor.isServer) {
       console.log(`Object saved to ${fullPath}`);
     });
   };
-  
+
+  Vulcan.generateGraphQLQueries = fileName => {
+    let fd;
+
+    const name = fileName ? fileName : 'queries.graphql';
+
+    try {
+      // eslint-disable-next-line no-undef
+      const path = __meteor_bootstrap__.serverDir
+        .split('/')
+        .slice(1, -5)
+        .join('/');
+      const fullPath = `/${path}/${name}`;
+      fd = fs.openSync(fullPath, 'w');
+
+      Object.keys(Fragments).forEach(fragment => fs.appendFileSync(fd, Fragments[fragment].fragmentText + '\n'));
+
+      fs.appendFileSync(fd, '\n');
+
+      Collections.forEach(collection => {
+        const { collectionName } = extractCollectionInfo({ collection });
+        const { fragmentName } = extractFragmentInfo({}, collectionName);
+
+        const typeName = collection.options.typeName;
+
+
+        if (get(GraphQLSchema.resolvers, `Query.${Utils.camelCaseify(typeName)}`)) {
+          const singleQueryString = singleClientTemplate({
+            typeName,
+            fragmentName,
+          });
+          fs.appendFileSync(fd, singleQueryString + '\n');
+        }
+
+        if (get(GraphQLSchema.resolvers, `Query.${Utils.camelCaseify(Utils.pluralize(typeName))}`)) {
+
+          const multiQueryString = multiClientTemplate({
+            typeName,
+            fragmentName,
+          });
+          fs.appendFileSync(fd, multiQueryString + '\n');
+        }
+
+      });
+    } catch (err) {
+      console.log(err);
+    } finally {
+      if (fd !== undefined) fs.closeSync(fd);
+    }
+  };
 }


### PR DESCRIPTION
**Context:** 
This function is aimed at enabling generation of typescript definitions for the default queries provided by Vulcan. Tools like [apollo codegen:generate](https://github.com/apollographql/apollo-tooling) generate typescript definitions when provided with a schema and queries/fragments. These definitions can be used to strongly type `useQuery`, `useMulti2`, and `useSingle2`. We're leveraging this currently at TradeWing and it really improves the developer experience. However, apollo codegen:generate needs a file that specifies the queries in order to generate the definitions.

**Changes:** 
* Adds an optional fileName argument to Vulcan.getGraphQLSchema - this helps with the auxiliary typescript generation scripts.

* Adds the Vulcan.generateGraphQLQueries function - this writes all of the default queries & default fragments for each collection to the path specified by the argument. 

**Feedback Welcome:**

There's almost certainly room for improvement here. I'm very open to feedback, particularly the substantive part in lines 81-105. But even this naive 1st pass has already provided some really solid benefits to us. 