### PR TITLE
Enforce required graphql fields where appropriate.

### DIFF
--- a/packages/vulcan-lib/lib/modules/graphql_templates/queries.js
+++ b/packages/vulcan-lib/lib/modules/graphql_templates/queries.js
@@ -133,7 +133,7 @@ type MultiMovieOuput{
 export const multiOutputType = typeName => ` Multi${typeName}Output`;
 export const multiOutputTemplate = ({ typeName }) =>
   `type ${multiOutputType(typeName)}{
-  ${multiReturnProperty}: [${typeName}]
+  ${multiReturnProperty}: [${typeName}!]
   totalCount: Int
 }`;
 

--- a/packages/vulcan-lib/lib/modules/graphql_templates/types.js
+++ b/packages/vulcan-lib/lib/modules/graphql_templates/types.js
@@ -21,14 +21,8 @@ export const getArguments = args => {
 
 /* ------------------------------------- Generic Field Template ------------------------------------- */
 
-// export const fieldTemplate = ({ name, type, args, directive, description, required }, indentation = '') =>
-// `${description ?  `${indentation}# ${description}\n` : ''}${indentation}${name}${getArguments(args)}: ${type}${required ? '!' : ''} ${directive ? directive : ''}`;
-
-// version that does not make any fields required
 export const fieldTemplate = ({ name, type, args, directive, description, required }, indentation = '') =>
-  `${description ? `${indentation}# ${description}\n` : ''}${indentation}${name}${getArguments(args)}: ${type} ${
-    directive ? directive : ''
-  }`;
+  `${description ?  `${indentation}# ${description}\n` : ''}${indentation}${name}${getArguments(args)}: ${type}${required ? '!' : ''} ${directive ? directive : ''}`;
 
 /* ------------------------------------- Main Type ------------------------------------- */
 

--- a/packages/vulcan-lib/lib/server/graphql/schemaFields.js
+++ b/packages/vulcan-lib/lib/server/graphql/schemaFields.js
@@ -402,6 +402,7 @@ export const getResolveAsFields = ({
       args: fieldArguments,
       type: fieldType,
       directive: fieldDirective,
+      required: !field.optional,
     });
   }
 
@@ -412,6 +413,9 @@ export const getResolveAsFields = ({
     // use specified GraphQL type or else convert schema type
     const fieldGraphQLType = resolveAs.type || fieldType;
 
+    // if either is optional, do not make required
+    const required = !field.optional && !resolveAs.optional;
+
     // if resolveAs is an object, first push its type definition
     // include arguments if there are any
     // note: resolved fields are not internationalized
@@ -420,6 +424,7 @@ export const getResolveAsFields = ({
       name: resolverName,
       args: resolveAs.arguments,
       type: fieldGraphQLType,
+      required,
     });
 
     // then build actual resolver object and pass it to addGraphQLResolvers
@@ -619,6 +624,7 @@ export const getSchemaFields = (schema, typeName) => {
             args: fieldArguments,
             type: fieldType,
             directive: fieldDirective,
+            required: !field.optional
           });
         }
       }


### PR DESCRIPTION
* In multiOutputTemplate, it is never expected to have null as an array element in the returned result.

* In fieldTemplate, respect the value of `required` 
