### PR TITLE
Rewrite client side date converter to handle nesting

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/multi2.js
+++ b/packages/vulcan-core/lib/modules/containers/multi2.js
@@ -107,7 +107,7 @@ const buildResult = (
 ) => {
   //console.log('returnedProps', returnedProps);
   const { refetch, networkStatus, error, fetchMore, data } = returnedProps;
-  // results = Utils.convertDates(collection, props.data[listResolverName]),
+  // Note: Scalar types like Dates are NOT converted. It should be done at the UI level.
   const results = data && data[resolverName] && data[resolverName].results;
   const totalCount = data && data[resolverName] && data[resolverName].totalCount;
   // see https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/networkStatus.ts
@@ -153,7 +153,7 @@ const buildResult = (
       const newInput = providedInput || {
         ...paginationInput,
         offset: results.length,
-      }
+      };
 
       return fetchMore({
         variables: { input: newInput },

--- a/packages/vulcan-core/lib/modules/containers/single2.js
+++ b/packages/vulcan-core/lib/modules/containers/single2.js
@@ -78,7 +78,7 @@ const buildResult = (
   const propertyName = options.propertyName || 'document';
   const props = {
     ...returnedProps,
-    // document: Utils.convertDates(collection, data[singleResolverName]),
+    // Note: Scalar types like Dates are NOT converted. It should be done at the UI level.
     [propertyName]: data && data[resolverName] && data[resolverName].result,
     fragmentName,
     fragment,

--- a/packages/vulcan-lib/lib/modules/simpleSchema_utils.js
+++ b/packages/vulcan-lib/lib/modules/simpleSchema_utils.js
@@ -20,3 +20,11 @@ export const hasAllowedValues = field => {
 
 
 export const isBlackbox = (field) => field.type.definitions[0].blackbox;
+
+export const getFieldType = field => field.type.singleType;
+export const getFieldTypeName = fieldType =>
+    typeof fieldType === 'object'
+        ? 'Object'
+        : typeof fieldType === 'function'
+            ? fieldType.name
+            : fieldType;

--- a/packages/vulcan-lib/lib/modules/utils.js
+++ b/packages/vulcan-lib/lib/modules/utils.js
@@ -15,6 +15,8 @@ import set from 'lodash/set';
 import get from 'lodash/get';
 import isFunction from 'lodash/isFunction';
 import pluralize from 'pluralize';
+import { getFieldType } from './simpleSchema_utils';
+import { forEachDocumentField } from './schema_utils';
 
 registerSetting('debug', false, 'Enable debug mode (more verbose logging)');
 
@@ -451,12 +453,27 @@ Utils.getComponentDisplayName = WrappedComponent => {
  * @param {Array} list
  */
 Utils.convertDates = (collection, listOrDocument) => {
+  // TODO: should be rewritten with forEachDocumentField (see other examples in the code) in order to support nested objects
   // if undefined, just return
-  if (!listOrDocument || !listOrDocument.length) return listOrDocument;
-
+  if (!(listOrDocument || listOrDocument.length)) return listOrDocument;
   const list = Array.isArray(listOrDocument) ? listOrDocument : [listOrDocument];
   const schema = collection.simpleSchema()._schema;
-  const dateFields = _.filter(_.keys(schema), fieldName => schema[fieldName].type === Date);
+  /*
+  //Nested version
+    return list.map((document) => {
+      forEachDocumentField(document, schema, (fieldName, fieldSchema, currentPath) => {
+        if (fieldSchema && getFieldType(fieldSchema) === Date) {
+          const valuePath = `̂${currentPath}${fieldName}`;
+          const value = get(document, valuePath);
+          set(document, valuePath, new Date(value));
+        }
+      });
+      return document
+    });
+    */
+  // TODO: legacy version don't work with nested
+  // comment this and uncomment the forEachDocumentField version
+  const dateFields = _.filter(_.keys(schema), fieldName => getFieldType(schema[fieldName]) === Date);
   const convertedList = list.map(result => {
     dateFields.forEach(fieldName => {
       if (result[fieldName] && typeof result[fieldName] === 'string') {

--- a/packages/vulcan-lib/lib/modules/utils.js
+++ b/packages/vulcan-lib/lib/modules/utils.js
@@ -458,31 +458,17 @@ Utils.convertDates = (collection, listOrDocument) => {
   if (!(listOrDocument || listOrDocument.length)) return listOrDocument;
   const list = Array.isArray(listOrDocument) ? listOrDocument : [listOrDocument];
   const schema = collection.simpleSchema()._schema;
-  /*
   //Nested version
-    return list.map((document) => {
-      forEachDocumentField(document, schema, (fieldName, fieldSchema, currentPath) => {
-        if (fieldSchema && getFieldType(fieldSchema) === Date) {
-          const valuePath = `̂${currentPath}${fieldName}`;
-          const value = get(document, valuePath);
-          set(document, valuePath, new Date(value));
-        }
-      });
-      return document
-    });
-    */
-  // TODO: legacy version don't work with nested
-  // comment this and uncomment the forEachDocumentField version
-  const dateFields = _.filter(_.keys(schema), fieldName => getFieldType(schema[fieldName]) === Date);
-  const convertedList = list.map(result => {
-    dateFields.forEach(fieldName => {
-      if (result[fieldName] && typeof result[fieldName] === 'string') {
-        result[fieldName] = new Date(result[fieldName]);
+  const convertedList = list.map((document) => {
+    forEachDocumentField(document, schema, ({ fieldName, fieldSchema, currentPath }) => {
+      if (fieldSchema && getFieldType(fieldSchema) === Date) {
+        const valuePath = `̂${currentPath}${fieldName}`;
+        const value = get(document, valuePath);
+        set(document, valuePath, new Date(value));
       }
     });
-    return result;
+    return document;
   });
-
   return Array.isArray(listOrDocument) ? convertedList : convertedList[0];
 };
 

--- a/packages/vulcan-lib/lib/modules/utils.js
+++ b/packages/vulcan-lib/lib/modules/utils.js
@@ -453,23 +453,24 @@ Utils.getComponentDisplayName = WrappedComponent => {
  * @param {Array} list
  */
 Utils.convertDates = (collection, listOrDocument) => {
-  // TODO: should be rewritten with forEachDocumentField (see other examples in the code) in order to support nested objects
   // if undefined, just return
-  if (!(listOrDocument || listOrDocument.length)) return listOrDocument;
-  const list = Array.isArray(listOrDocument) ? listOrDocument : [listOrDocument];
+  if (!listOrDocument) return listOrDocument;
+  const isArray = listOrDocument && Array.isArray(listOrDocument);
+  if (isArray && !listOrDocument.length) return listOrDocument;
+  const list = isArray ? listOrDocument : [listOrDocument];
   const schema = collection.simpleSchema()._schema;
   //Nested version
   const convertedList = list.map((document) => {
     forEachDocumentField(document, schema, ({ fieldName, fieldSchema, currentPath }) => {
       if (fieldSchema && getFieldType(fieldSchema) === Date) {
-        const valuePath = `̂${currentPath}${fieldName}`;
+        const valuePath = `${currentPath}${fieldName}`;
         const value = get(document, valuePath);
         set(document, valuePath, new Date(value));
       }
     });
     return document;
   });
-  return Array.isArray(listOrDocument) ? convertedList : convertedList[0];
+  return isArray ? convertedList : convertedList[0];
 };
 
 Utils.encodeIntlError = error => (typeof error !== 'object' ? error : JSON.stringify(error));

--- a/packages/vulcan-lib/lib/server/graphql/schemaFields.js
+++ b/packages/vulcan-lib/lib/server/graphql/schemaFields.js
@@ -240,7 +240,7 @@ export const getSchemaFields = (schema, typeName) => {
  */
 /* eslint-disable no-console */
 import { isIntlField } from '../../modules/intl.js';
-import { /*hasAllowedValues, getAllowedValues,*/isBlackbox, unarrayfyFieldName } from '../../modules/simpleSchema_utils';
+import { /*hasAllowedValues, getAllowedValues,*/isBlackbox, unarrayfyFieldName, getFieldType, getFieldTypeName } from '../../modules/simpleSchema_utils';
 import { shouldAddOriginalField } from '../../modules/schema_utils';
 import relations from './relations.js';
 
@@ -270,13 +270,6 @@ const isValidName = name => {
 
 // export const getEnumType = (typeName, fieldName) => `${typeName}${capitalize(unarrayfyFieldName(fieldName))}Enum`;
 
-const getFieldType = field => field.type.singleType;
-const getFieldTypeName = fieldType =>
-  typeof fieldType === 'object'
-    ? 'Object'
-    : typeof fieldType === 'function'
-      ? fieldType.name
-      : fieldType;
 
 // get GraphQL type for a given schema and field name
 export const getGraphQLType = ({ schema, fieldName, typeName, isInput = false }) => {

--- a/packages/vulcan-lib/test/utils.test.js
+++ b/packages/vulcan-lib/test/utils.test.js
@@ -1,12 +1,14 @@
 import { Utils } from '../lib/modules/utils';
 import expect from 'expect';
+import { createDummyCollection } from "meteor/vulcan:test"
+import SimpleSchema from "simpl-schema"
 
 
 describe('vulcan:lib/utils', function () {
-  
+
   const collection = {
     findOne: function ({ slug }) {
-      switch(slug) {
+      switch (slug) {
         case 'duplicate-name':
           return {
             _id: 'duplicate-name',
@@ -36,45 +38,96 @@ describe('vulcan:lib/utils', function () {
       }
     }
   };
-  
+
   it('returns the same slug when there are no conflicts', function () {
     const slug = 'unique-name';
     const unusedSlug = Utils.getUnusedSlug(collection, slug);
 
     expect(unusedSlug).toEqual(slug);
   });
-  
+
   it('appends integer to slug when there is a conflict', function () {
     const slug = 'duplicate-name';
     const unusedSlug = Utils.getUnusedSlug(collection, slug);
 
     expect(unusedSlug).toEqual(slug + '-1');
   });
-  
+
   it('appends incremented integer to slug when there is a conflict', function () {
     const slug = 'triplicate-name';
     const unusedSlug = Utils.getUnusedSlug(collection, slug);
 
     expect(unusedSlug).toEqual(slug + '-2');
   });
-  
+
   it('returns the same slug when the conflict has the same _id', function () {
     // This tests the case where a document is renamed, but its slug remains the same
     // For example 'RENAMED NAME' is changed to 'Renamed name'; the slug should not increment
     const slug = 'renamed-name';
     const documentId = 'renamed-name';
     const unusedSlug = Utils.getUnusedSlug(collection, slug, documentId);
-    
+
     expect(unusedSlug).toEqual(slug);
   });
-  
+
   it('appends integer to slug when the conflict has the same _id, but it’s not passed to getUnusedSlug', function () {
     // This tests the case where a document is renamed, but its slug remains the same
     // For example 'RENAMED NAME' is changed to 'Renamed name'; the slug should not increment
     const slug = 'renamed-name';
     const unusedSlug = Utils.getUnusedSlug(collection, slug);
-    
+
     expect(unusedSlug).toEqual(slug + '-1');
   });
-  
+
+
+  describe("convertDates", () => {
+    it("convert date string to object", () => {
+      const Dummies = createDummyCollection({
+        schema: {
+          begin: {
+            type: Date,
+          }
+        }
+      })
+      const now = new Date()
+      const res = Utils.convertDates(Dummies, { begin: now.toISOString() })
+      expect(res.begin).toBeInstanceOf(Date)
+    })
+    it("convert date string in nested objects", () => {
+      const Dummies = createDummyCollection({
+        schema: {
+          nested: {
+            type: new SimpleSchema({
+              begin: {
+                type: Date,
+              }
+            })
+          }
+        }
+      })
+      const now = new Date()
+      const res = Utils.convertDates(Dummies, { nested: { begin: now.toISOString() } })
+      expect(res.nested.begin).toBeInstanceOf(Date)
+
+    })
+    it("convert date string in arrays of nested objects", () => {
+      const Dummies = createDummyCollection({
+        schema: {
+          array: {
+            type: Array,
+          },
+          "array.$": {
+            type: new SimpleSchema({
+              begin: {
+                type: Date,
+              }
+            })
+          }
+        }
+      })
+      const now = new Date()
+      const res = Utils.convertDates(Dummies, { array: [{ begin: now.toISOString() }] })
+      expect(res.array[0].begin).toBeInstanceOf(Date)
+    })
+  })
 });


### PR DESCRIPTION
Update Utils.convertDates, that transform date isostring to native `Date` object on the client (scalar handles this server side but not client side).

Need https://github.com/VulcanJS/Vulcan/pull/2451 to be merged beforehand, as it includes a `forEachDocumentField` helper to loop over nested fields.

