### PR TITLE
Omit username from schema validation after deleting it from options

### DIFF
--- a/packages/vulcan-users/lib/server/on_create_user.js
+++ b/packages/vulcan-users/lib/server/on_create_user.js
@@ -26,7 +26,8 @@ function onCreateUserCallback(options, user) {
   options = runCallbacks('users.new.validate.before', options);
 
   // validate options since they can't be trusted
-  Users.simpleSchema().validate(options);
+  // omit username since we deleted it above
+  Users.simpleSchema().omit('username').validate(options);
 
   // check that the current user has permission to insert each option field
   _.keys(options).forEach(fieldName => {


### PR DESCRIPTION
When username is non-optional, the current code throws a validation error. 

If this function is going to delete username from options, then username should be omitted from the schema validation. 