### PR TITLE
Add buildResult functionality to useCreate2 to directly access created document

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/create2.js
+++ b/packages/vulcan-core/lib/modules/containers/create2.js
@@ -82,6 +82,16 @@ export const multiQueryUpdater = ({
   });
 };
 
+const buildResult = (options, resolverName, executionResult) => {
+  const { data } = executionResult;
+  const propertyName = options.propertyName || 'document';
+  const props = {
+    ...executionResult,
+    [propertyName]: data && data[resolverName] && data[resolverName].data,
+  };
+  return props;
+};
+
 export const useCreate2 = (options) => {
   const { mutationOptions = {} } = options;
   const { collectionName, collection } = extractCollectionInfo(options);
@@ -99,7 +109,12 @@ export const useCreate2 = (options) => {
   });
 
   // so the syntax is useCreate({collection: ...}, {data: ...})
-  const extendedCreateFunc = (args) => createFunc({ variables: { data: args.data } });
+  const extendedCreateFunc = async (args) => {
+    const executionResult = await createFunc({
+      variables: { data: args.data },
+    });
+    return buildResult(options, resolverName, executionResult);
+  };
   return [extendedCreateFunc, ...rest];
 };
 


### PR DESCRIPTION
This allows the client to access the created document without providing the resolverName, similar to the logic in useMulti2 and useSingle2. 