### PR TITLE
Add a password component

### DIFF
--- a/packages/vulcan-forms/lib/components/FormComponent.jsx
+++ b/packages/vulcan-forms/lib/components/FormComponent.jsx
@@ -77,6 +77,7 @@ class FormComponent extends Component {
       'date',
       'time',
       'text',
+      'password',
     ].includes(inputType);
     return !isStandardInput;
   };
@@ -230,6 +231,9 @@ class FormComponent extends Component {
       switch (inputType) {
         case 'text':
           return FormComponents.FormComponentDefault;
+
+        case 'password':
+          return FormComponents.FormComponentPassword;
 
         case 'number':
           return FormComponents.FormComponentNumber;

--- a/packages/vulcan-ui-bootstrap/lib/components/forms/Password.jsx
+++ b/packages/vulcan-ui-bootstrap/lib/components/forms/Password.jsx
@@ -4,7 +4,7 @@ import { Components, registerComponent } from 'meteor/vulcan:core';
 
 const Password = ({ refFunction, inputProperties, itemProperties }) => (
   <Components.FormItem path={inputProperties.path} label={inputProperties.label} {...itemProperties}>
-    <Form.Control {...inputProperties} ref={refFunction} type="text" />
+    <Form.Control {...inputProperties} ref={refFunction} type="password" />
   </Components.FormItem>
 );
 

--- a/packages/vulcan-ui-bootstrap/lib/components/forms/Password.jsx
+++ b/packages/vulcan-ui-bootstrap/lib/components/forms/Password.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Form from 'react-bootstrap/Form';
+import { Components, registerComponent } from 'meteor/vulcan:core';
+
+const Password = ({ refFunction, inputProperties, itemProperties }) => (
+  <Components.FormItem path={inputProperties.path} label={inputProperties.label} {...itemProperties}>
+    <Form.Control {...inputProperties} ref={refFunction} type="text" />
+  </Components.FormItem>
+);
+
+registerComponent('FormComponentPassword', Password);

--- a/packages/vulcan-ui-bootstrap/lib/modules/components.js
+++ b/packages/vulcan-ui-bootstrap/lib/modules/components.js
@@ -4,6 +4,7 @@ import '../components/forms/Date.jsx';
 import '../components/forms/Date2.jsx';
 import '../components/forms/Datetime.jsx';
 import '../components/forms/Default.jsx';
+import '../components/forms/Password.jsx';
 import '../components/forms/Email.jsx';
 import '../components/forms/FormComponentInner.jsx';
 import '../components/forms/FormControl.jsx'; // note: only used by old accounts package, remove soon?

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Password.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Password.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import MuiInput from '../base-controls/MuiInput';
+import { registerComponent } from 'meteor/vulcan:core';
+
+
+const Password = ({ refFunction, ...properties }) =>
+  <MuiInput {...properties} ref={refFunction} type='password'/>;
+
+
+registerComponent('FormComponentPassword', Password);

--- a/packages/vulcan-ui-material/lib/components/index.js
+++ b/packages/vulcan-ui-material/lib/components/index.js
@@ -39,6 +39,7 @@ import './forms/controls/DateRdt';
 import './forms/controls/DateTime';
 import './forms/controls/DateTimeRdt';
 import './forms/controls/Default';
+import './forms/controls/Password';
 import './forms/controls/Email';
 import './forms/controls/Number';
 import './forms/controls/PostalCode';

--- a/stories/form/formControls.stories.js
+++ b/stories/form/formControls.stories.js
@@ -68,6 +68,7 @@ const formComponents = [
   },
   { name: 'FormComponentDefault' },
   { name: 'FormComponentText' },
+  { name: 'FormComponentPassword' },
   {
     name: 'FormComponentEmail',
     props: {


### PR DESCRIPTION
Add a password component for both bootstrap and materialize.

Based on the Default (text) input, I just added a `type='password'`.