### PR TITLE
Add GraphQLSchema.context to context in runGraphQL

### DIFF
--- a/packages/vulcan-lib/lib/server/query.js
+++ b/packages/vulcan-lib/lib/server/query.js
@@ -37,8 +37,10 @@ export const runGraphQL = async (query, variables = {}, context) => {
     queryContext[collection.options.collectionName] = collection;
   });
 
+  const fullQueryContext = merge({}, queryContext, GraphQLSchema.context);
+
   // see http://graphql.org/graphql-js/graphql/#graphql
-  const result = await graphql(executableSchema, query, {}, queryContext, variables);
+  const result = await graphql(executableSchema, query, {}, fullQueryContext, variables);
 
   if (result.errors) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
This was causing a TypeError in vulcan-files because the file collection was not being added to the context that is passed to the resolvers in that package when querying with `runGraphQL`