### PR TITLE
Fix datatable-loading crash in the storybook

### DIFF
--- a/stories/datatable.stories.js
+++ b/stories/datatable.stories.js
@@ -62,7 +62,10 @@ DatatableContentsStories
         );
     })
     .add('DatatableContents - loading', () => (
-        <Components.DatatableContents loading={true} />
+        <Components.DatatableContents
+          {...defaultProps.DatatableContents}
+          loading={true}
+        />
     ))
     .add('DatatableContents - error', () => (
         <Components.DatatableContents


### PR DESCRIPTION
Pass default propos to the datatable-loading component to prevent component crash.

Closes #2481