### PR TITLE
Remove hardcoded head tag in template-web.browser

### DIFF
--- a/packages/vulcan-lib/lib/server/apollo-ssr/components/Head.jsx
+++ b/packages/vulcan-lib/lib/server/apollo-ssr/components/Head.jsx
@@ -6,11 +6,11 @@ const Head = () => {
   //@see https://github.com/nfl/react-helmet/releases/tag/5.0.0
   const helmet = Helmet.renderStatic();
   return (
-    <head>
+    <React.Fragment>
       {helmet.title.toComponent()}
       {helmet.meta.toComponent()}
       {helmet.link.toComponent()}
-    </head>
+    </React.Fragment>
   );
 };
 export default Head;


### PR DESCRIPTION
This is done to avoid two generated opening head tags. The dynamicHead
passed as a paramter to the headTemplate already contains the opening
tag.

Related issue: VulcanJS/Vulcan#2443