### PR TITLE
add connection remoteAdress in context

### DIFF
--- a/packages/vulcan-lib/lib/server/apollo-server/context.js
+++ b/packages/vulcan-lib/lib/server/apollo-server/context.js
@@ -109,13 +109,8 @@ export const computeContextFromReq = (currentContext, customContextFromReq) => {
 
     //add the headers to the context
     context.headers = headers;
-    // add a relevant infos from the request (eg connection adress to get the IP)
-    context.req = {};
-    if (req.connection) {
-      context.req.connection = {
-        remoteAddress: req.connection.remoteAddress
-      };
-    }
+    // pass the whole req for advanced usage, like fetching IP from connection
+    context.req = req;
 
     // if apiKey is present, assign "fake" currentUser with admin rights
     if (headers.apikey && headers.apikey === getSetting('vulcan.apiKey')) {

--- a/packages/vulcan-lib/lib/server/apollo-server/context.js
+++ b/packages/vulcan-lib/lib/server/apollo-server/context.js
@@ -109,6 +109,13 @@ export const computeContextFromReq = (currentContext, customContextFromReq) => {
 
     //add the headers to the context
     context.headers = headers;
+    // add a relevant infos from the request (eg connection adress to get the IP)
+    context.req = {};
+    if (req.connection) {
+      context.req.connection = {
+        remoteAddress: req.connection.remoteAddress
+      };
+    }
 
     // if apiKey is present, assign "fake" currentUser with admin rights
     if (headers.apikey && headers.apikey === getSetting('vulcan.apiKey')) {


### PR DESCRIPTION
I've added `context.req.connection.remoteAdress`, which usually includes the user IP.

I have some question though: is it a good practice to pass the full HTTP request to resolver context? That would solves some issues, as the user can freely access HTTP request, eg to get user ip or similar low level features.

But at which point the `context` becomes bloated?

Also we lack a pattern to enhance the GraphQL context, maybe an additional callback would be appropriate if many users want to enhance it.

Closes #1819

