### PR TITLE
Add extendedUpdateFunc in create2 (#15)

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/create2.js
+++ b/packages/vulcan-core/lib/modules/containers/create2.js
@@ -105,6 +105,18 @@ const buildResult = (options, resolverName, executionResult) => {
   return props;
 };
 
+const extendUpdateFunc = (originalUpdate, options, resolverName) => {
+  const propertyName = options.propertyName || 'document';
+  return (cache, executionResult) => {
+    const {data} = executionResult;
+    executionResult.extensions = {
+      ...executionResult.extensions,
+      [propertyName]: data && data[resolverName] && data[resolverName].data,
+    }
+    return originalUpdate(cache, executionResult);
+  }
+}
+
 export const useCreate2 = (options) => {
   const { mutationOptions = {} } = options;
   const { collectionName, collection } = extractCollectionInfo(options);
@@ -116,10 +128,13 @@ export const useCreate2 = (options) => {
 
   const resolverName = `create${typeName}`;
 
-  const [createFunc, ...rest] = useMutation(query, {
-    update: multiQueryUpdater({ typeName, fragment, fragmentName, collection, resolverName }),
-    ...mutationOptions
-  });
+  if (mutationOptions.update) {
+    mutationOptions.update = extendUpdateFunc(mutationOptions.update, options, resolverName);
+  } else {
+    mutationOptions.update = multiQueryUpdater({ typeName, fragment, fragmentName, collection, resolverName });
+  }
+
+  const [createFunc, ...rest] = useMutation(query, mutationOptions);
 
   // so the syntax is useCreate({collection: ...}, {data: ...})
   const extendedCreateFunc = async (args) => {


### PR DESCRIPTION
Currently, `useCreate2` will place the created document at `options.propertyName || 'document'` in the returned result. This is nice because the client of the hook doesn't have to know about the structure of the executionResult/resolverName to access the created document.

This PR adds basically the same functionality to the update function so that clients of the hook can access the created document at at `options.propertyName || 'document'` 