### PR TITLE
For create mutation, move onCreate to before validation to avoid vali…

### DIFF
--- a/packages/vulcan-lib/lib/server/mutators.js
+++ b/packages/vulcan-lib/lib/server/mutators.js
@@ -98,6 +98,30 @@ export const createMutator = async ({
 
   /*
 
+  onCreate
+
+  note: cannot use forEach with async/await.
+  See https://stackoverflow.com/a/37576787/649299
+
+  note: clone arguments in case callbacks modify them
+
+  */
+  for (let fieldName of Object.keys(schema)) {
+    let autoValue;
+    if (schema[fieldName].onCreate) {
+      // OpenCRUD backwards compatibility: keep both newDocument and data for now, but phase out newDocument eventually
+      autoValue = await schema[fieldName].onCreate(properties); // eslint-disable-line no-await-in-loop
+    } else if (schema[fieldName].onInsert) {
+      // OpenCRUD backwards compatibility
+      autoValue = await schema[fieldName].onInsert(clone(document), currentUser); // eslint-disable-line no-await-in-loop
+    }
+    if (typeof autoValue !== 'undefined') {
+      document[fieldName] = autoValue;
+    }
+  }
+
+  /*
+
   Validation
 
   */
@@ -151,30 +175,6 @@ export const createMutator = async ({
   if (currentUser) {
     const userIdInSchema = Object.keys(schema).find(key => key === 'userId');
     if (!!userIdInSchema && !document.userId) document.userId = currentUser._id;
-  }
-
-  /* 
-  
-  onCreate
-
-  note: cannot use forEach with async/await. 
-  See https://stackoverflow.com/a/37576787/649299
-
-  note: clone arguments in case callbacks modify them
-
-  */
-  for (let fieldName of Object.keys(schema)) {
-    let autoValue;
-    if (schema[fieldName].onCreate) {
-      // OpenCRUD backwards compatibility: keep both newDocument and data for now, but phase out newDocument eventually
-      autoValue = await schema[fieldName].onCreate(properties); // eslint-disable-line no-await-in-loop
-    } else if (schema[fieldName].onInsert) {
-      // OpenCRUD backwards compatibility
-      autoValue = await schema[fieldName].onInsert(clone(document), currentUser); // eslint-disable-line no-await-in-loop
-    }
-    if (typeof autoValue !== 'undefined') {
-      document[fieldName] = autoValue;
-    }
   }
 
   // TODO: find that info in GraphQL mutations


### PR DESCRIPTION
…dation errors. (#14)

Currently Vulcan does not support a required field that is created via `onCreate`. A really common example is `dateCreated`, but in general it should be possible to have fields that are required but generated by the server in `onCreate`.

One could argue that passing a dummy value would solve the problem. While this might be reasonable for `dateCreated`, it is not a general solution, since there may very well be fields whose purpose/existence is completely hidden from the client. 