### PR TITLE
fix bugs in extendCollection (#16)

### DIFF
--- a/packages/vulcan-lib/lib/modules/collections.js
+++ b/packages/vulcan-lib/lib/modules/collections.js
@@ -150,13 +150,17 @@ Mongo.Collection.prototype.helpers = function (helpers) {
 };
 
 export const extendCollection = (collection, options) => {
-  collection.options = mergeWith({}, collection.options, options, 
-    (a, b) => {
-      if (Array.isArray(a)) {
-        return b.concat(a);
-      }
+  collection.options = mergeWith({}, collection.options, options, (a, b) => {
+    if (Array.isArray(a) && Array.isArray(b)) {
+      return a.concat(b);
     }
-  );
+    if (Array.isArray(a) && b) {
+      return a.concat([b]);
+    }
+    if (Array.isArray(b) && a) {
+      return b.concat([a]);
+    }
+  });
 };
 
 /*


### PR DESCRIPTION
The current implementation is buggy when Array.isArray(a) !== Array.isArray(b)

This can be the case for permissions `['members']` vs.  `() => ....` for example