### PR TITLE
Use multiQueryUpdater in update2 to properly sort/filter

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/update2.js
+++ b/packages/vulcan-core/lib/modules/containers/update2.js
@@ -37,6 +37,8 @@ import {
 } from 'meteor/vulcan:lib';
 import { computeQueryVariables } from './variables';
 
+import { multiQueryUpdater } from './create';
+
 export const buildUpdateQuery = ({ typeName, fragmentName, fragment }) => (
   gql`
     ${updateClientTemplate({ typeName, fragmentName })}
@@ -58,6 +60,7 @@ export const useUpdate2 = (options) => {
   const [updateFunc, ...rest] = useMutation(query, {
     // see https://www.apollographql.com/docs/react/features/error-handling/#error-policies
     errorPolicy: 'all',
+    update: multiQueryUpdater({ typeName, fragment, fragmentName, collection, resolverName: `update{typeName}` }),
     ...mutationOptions
   });
 

--- a/packages/vulcan-core/lib/modules/containers/update2.js
+++ b/packages/vulcan-core/lib/modules/containers/update2.js
@@ -60,7 +60,7 @@ export const useUpdate2 = (options) => {
   const [updateFunc, ...rest] = useMutation(query, {
     // see https://www.apollographql.com/docs/react/features/error-handling/#error-policies
     errorPolicy: 'all',
-    update: multiQueryUpdater({ typeName, fragment, fragmentName, collection, resolverName: `update{typeName}` }),
+    update: multiQueryUpdater({ typeName, fragment, fragmentName, collection, resolverName: `update${typeName}` }),
     ...mutationOptions
   });
 


### PR DESCRIPTION
This needs to be properly tested before getting merged. Based on Unit
Tests it does not break anyting.

When building the demo application for the new datatable with @loustak,
we will make sure to try this commit out.