### PR TITLE
fix field permission validation bug

### DIFF
--- a/packages/vulcan-lib/lib/modules/validation.js
+++ b/packages/vulcan-lib/lib/modules/validation.js
@@ -28,7 +28,7 @@ const validateDocumentPermissions = (fullDocument, documentToValidate, schema, c
   const { Users, currentUser } = context;
   forEachDocumentField(documentToValidate, schema,
     ({ fieldName, fieldSchema, currentPath, isNested }) => {
-      if (isNested && mode === 'create' ? !fieldSchema.canCreate : !fieldSchema.canUpdate) return; // ignore nested without permission
+      if (isNested && (mode === 'create' ? !fieldSchema.canCreate : !fieldSchema.canUpdate)) return; // ignore nested without permission
       if (!fieldSchema
         || (mode === 'create' ? !Users.canCreateField(currentUser, fieldSchema) : !Users.canUpdateField(currentUser, fieldSchema, fullDocument))
       ) {


### PR DESCRIPTION
Fixes a bug I ran into when `isNested === false` and `mode === create` and `fieldSchema.canUpdate === undefined`. Surprisingly, the `if` on this line was evaluating to true leading to the early return.

Adding the parentheses fixes the operator precedence issue on this line and runs as intended. Verified that it fixes the issue we were seeing.