### PR TITLE
Semantized classname

### DIFF
--- a/packages/vulcan-accounts/imports/ui/components/Button.jsx
+++ b/packages/vulcan-accounts/imports/ui/components/Button.jsx
@@ -10,15 +10,24 @@ export class AccountsButton extends PureComponent {
       // href = null,
       type,
       disabled = false,
+      id,
       className,
       onClick
     } = this.props;
 
     return type === 'link' ? 
-      <a href="#" className={className} onClick={onClick} style={{marginRight: '10px'}}>{label}</a> :
+      <a
+        href="#"
+        id={id}
+        className={className}
+        onClick={onClick}
+        style={{marginRight: '10px'}}>
+        {label}
+      </a> :
       <Components.Button
         style={{marginRight: '10px'}}
         variant="primary"
+        id={id}
         className={className}
         type={type}
         disabled={disabled}

--- a/packages/vulcan-core/lib/modules/components/Card/Card.jsx
+++ b/packages/vulcan-core/lib/modules/components/Card/Card.jsx
@@ -95,8 +95,15 @@ const Card = ({ title, className, collection, document, currentUser, fields, sho
     canUpdate = check && check(currentUser, document, { Users });
   }
 
+  const collectionName = `datacard-${collection.typeName.toLowerCase()}`
+  const semantizedClassName = classNames(
+    className,
+    'datacard',
+    collection && collectionName,
+    document && collection && `${collectionName}-${document._id}`);
+
   return (
-    <div className={classNames(className, 'datacard', collection && `datacard-${collection._name}`)}>
+    <div className={semantizedClassName}>
       {title && <div className="datacard-title">{title}</div>}
       <table className="table table-bordered" style={{ maxWidth: '100%' }}>
         <tbody>

--- a/packages/vulcan-core/lib/modules/components/Datatable/Datatable.jsx
+++ b/packages/vulcan-core/lib/modules/components/Datatable/Datatable.jsx
@@ -314,7 +314,7 @@ registerComponent({
 export default Datatable;
 
 const DatatableLayout = ({ collectionName, children }) => (
-  <div className={`datatable datatable-${collectionName}`}>{children}</div>
+  <div className={`datatable datatable-${collectionName.toLowerCase()}`}>{children}</div>
 );
 registerComponent({ name: 'DatatableLayout', component: DatatableLayout });
 

--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -1004,15 +1004,20 @@ class SmartForm extends Component {
   // ------------------------- Props to Pass ----------------------------- //
   // --------------------------------------------------------------------- //
 
-  getFormProps = () => ({
-    className: `document-${this.getFormType()}-${this.props.typeName.toLowerCase()}`,
-    id: this.props.id,
-    onSubmit: this.submitForm,
-    onKeyDown: this.formKeyDown,
-    ref: e => {
-      this.form = e;
-    },
-  });
+  getFormProps = () => {
+    const docClassName = `document-${this.getFormType()}`
+    const typeName = this.props.typeName.toLowerCase()
+
+    return {
+      className: `${docClassName} ${docClassName}-${typeName}`,
+      id: this.props.id,
+      onSubmit: this.submitForm,
+      onKeyDown: this.formKeyDown,
+      ref: e => {
+        this.form = e;
+      },
+    }
+  };
 
   getFormErrorsProps = () => ({
     errors: this.state.errors,

--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -1005,7 +1005,7 @@ class SmartForm extends Component {
   // --------------------------------------------------------------------- //
 
   getFormProps = () => ({
-    className: 'document-' + this.getFormType(),
+    className: `document-${this.getFormType()}-${this.props.typeName.toLowerCase()}`,
     id: this.props.id,
     onSubmit: this.submitForm,
     onKeyDown: this.formKeyDown,


### PR DESCRIPTION
Classnames of wrapper component such as datatable and forms are now semantized. (In particular buttons and links to sign in and register)
It's possible to access each part of the component with a unique class or id name.

This PR is linked with this one: https://github.com/VulcanJS/Vulcan-Starter/pull/156

Closes #2423 

