### PR TITLE
fix material ui seletmultiple

### DIFF
--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiSelect.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiSelect.jsx
@@ -73,7 +73,7 @@ const MuiSelect = createReactClass({
   handleChange: function (event) {
     const target = event.target;
     let value;
-    if (this.props.multiple) {
+    if (this.props.multiple && this.props.native) {
       value = [];
       for (let i = 0; i < target.length; i++) {
         const option = target.options[i];


### PR DESCRIPTION
official selectmulti example:
https://codesandbox.io/s/hzojf

the special handling of a change is relevant only while `native` and `multiple` are selected 