### PR TITLE
Enhancement/mui radio

### DIFF
--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiRadioGroup.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiRadioGroup.jsx
@@ -22,6 +22,7 @@ const styles = theme => ({
   },
   twoColumn: {
     display: 'block',
+
     [theme.breakpoints.down('md')]: {
       '& > label': {
         marginRight: theme.spacing(5),
@@ -35,6 +36,26 @@ const styles = theme => ({
   },
   threeColumn: {
     display: 'block',
+
+    [theme.breakpoints.down('xs')]: {
+      '& > label': {
+        marginRight: theme.spacing(5),
+      },
+    },
+
+    [theme.breakpoints.up('sm')]: {
+      '& > label': {
+        width: '48%',
+      },
+    },
+    [theme.breakpoints.up('md')]: {
+      '& > label': {
+        width: '32%',
+      },
+    },
+  },
+  fiveColumn: {
+    display: 'block',
     [theme.breakpoints.down('xs')]: {
       '& > label': {
         marginRight: theme.spacing(5),
@@ -42,12 +63,65 @@ const styles = theme => ({
     },
     [theme.breakpoints.up('xs')]: {
       '& > label': {
-        width: '49%',
+        width: '38%',
+      },
+    },
+    [theme.breakpoints.up('sm')]: {
+      '& > label': {
+        width: '32%',
       },
     },
     [theme.breakpoints.up('md')]: {
       '& > label': {
+        width: '19%',
+      },
+    },
+  },
+  eightColumn: {
+    display: 'block',
+
+    [theme.breakpoints.down('xs')]: {
+      '& > label': {
+        marginRight: theme.spacing(1),
+      },
+    },
+    [theme.breakpoints.up('xs')]: {
+      '& > label': {
+        width: '49%',
+      },
+    },
+    [theme.breakpoints.up('sm')]: {
+      '& > label': {
         width: '32%',
+      },
+    },
+    [theme.breakpoints.up('md')]: {
+      '& > label': {
+        width: '12%',
+      },
+    },
+  },
+  tenColumn: {
+    display: 'block',
+
+    [theme.breakpoints.down('xs')]: {
+      '& > label': {
+        marginRight: theme.spacing(1),
+      },
+    },
+    [theme.breakpoints.up('xs')]: {
+      '& > label': {
+        width: '24%',
+      },
+    },
+    [theme.breakpoints.up('sm')]: {
+      '& > label': {
+        width: '14%',
+      },
+    },
+    [theme.breakpoints.up('md')]: {
+      '& > label': {
+        width: '9%',
       },
     },
   },
@@ -128,7 +202,27 @@ const MuiRadioGroup = createReactClass({
       0
     );
 
-    let columnClass = maxLength < 18 ? 'threeColumn' : maxLength < 30 ? 'twoColumn' : '';
+
+    const getColumnClass = maxLength => {
+      if (maxLength < 3) {
+        return 'tenColumn';
+      }
+      if (maxLength < 7) {
+        return 'eightColumn';
+      }
+      if (maxLength < 12) {
+        return 'fiveColumn';
+      }
+      if (maxLength < 18) {
+        return 'threeColumn';
+      }
+      if (maxLength < 30) {
+        return 'twoColumn';
+      }
+    };
+
+    let columnClass = getColumnClass(maxLength);
+
     if (this.props.type === 'inline') columnClass = 'inline';
 
     return (

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiRadioGroup.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiRadioGroup.jsx
@@ -59,6 +59,9 @@ const styles = theme => ({
   line: {
     marginBottom: '12px',
   },
+  label: {
+    marginBottom: '0px',
+  },
   inputDisabled: {},
 });
 
@@ -114,6 +117,7 @@ const MuiRadioGroup = createReactClass({
             />
           }
           className={this.props.classes.line}
+          classes={{ label: this.props.classes.label }}
           label={radio.label}
         />
       );


### PR DESCRIPTION
Hello, I added 3 new views for the MuiRadioGroup to display : 
- 10 columns of MuiRadio (if the max length of the label is < 3) 
- 8 columns of MuiRadio (if the max length of the label is <7 ) 
- 5 columns of MuiRadio (if the max length of the label is <12 ) 
and made some minors changes to the responsivity of already existing views. 

Also, I fixed some margin issue with the label. The label had a 12px margin, and the radio none. So, the label was higher than the radio.

You can find here screenshot of a SmartForm with radiogroup on different devices: 
https://ibb.co/WKzyHTM
https://ibb.co/ZgzJyC9
https://ibb.co/bv4SJCV
https://ibb.co/Sxsy52t
https://ibb.co/4fNFPtN
https://ibb.co/vDqKz9r
https://ibb.co/6rqDK1q
https://ibb.co/p0B3fGm

Thanks in advance!
