### PR TITLE
Prevent calling forEachDocumentField on fields without a schema

### DIFF
--- a/packages/vulcan-lib/lib/modules/schema_utils.js
+++ b/packages/vulcan-lib/lib/modules/schema_utils.js
@@ -93,6 +93,7 @@ export const forEachDocumentField = (document, schema, callback, currentPath = '
         const fieldSchema = schema[fieldName];
         callback({ fieldName, fieldSchema, currentPath, document, schema, isNested: !!currentPath });
         // Check if we need a recursive call
+        if (!fieldSchema) return; // field has no corresponding schema, we are done
         const value = document[fieldName];
         if (!value) return;
         // if value is an array, validate permissions for all children


### PR DESCRIPTION
Avoid failing when a field is present in a JSON document but is not declared in the schema.

Theoretically this is not a valid pattern, however as `forEachDocumentField` is a generic helper we can reasonnably expect it not to fail on invalid documents and let the user decide what to do with missing fieldSchema instead 

@kevinashworth for feedback