### PR TITLE
Allow itemProperties to be passed on to FormComponent

### DIFF
--- a/packages/vulcan-forms/lib/components/FormGroup.jsx
+++ b/packages/vulcan-forms/lib/components/FormGroup.jsx
@@ -77,6 +77,7 @@ class FormGroup extends PureComponent {
             <FormComponents.FormComponent
               key={field.name}
               disabled={this.props.disabled}
+              itemProperties={this.props.itemProperties}
               {...field}
               errors={this.props.errors}
               throwError={this.props.throwError}
@@ -89,7 +90,6 @@ class FormGroup extends PureComponent {
               currentUser={this.props.currentUser}
               prefilledProps={this.props.prefilledProps}
               formComponents={FormComponents}
-              itemProperties={this.props.itemProperties}
             />
           ))}
   


### PR DESCRIPTION
Move `itemProperties` above `field` inside `FormComponents.FormComponent`

It seems that destructing `{...field}` effectively removes itemProperties from getting sent to FormComponent because `{...field}` includes an itemProperties

So for me, this change gets `itemProperties: { layout: 'inputOnly' }` working again in `schema.js` use