### PR TITLE
Add useSignout hook to the accounts package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     }
   },
   "dependencies": {
+    "@apollo/react-hooks": "^3.1.3",
     "@babel/runtime": "7.1.2",
     "analytics-node": "^2.1.1",
     "apollo-cache-inmemory": "^1.4.2",

--- a/packages/vulcan-accounts/imports/useMeteorLogout.js
+++ b/packages/vulcan-accounts/imports/useMeteorLogout.js
@@ -7,7 +7,7 @@ import { useApolloClient } from '@apollo/react-hooks';
  * @returns {function} a function to execute when you log the user out
  */
 
-const useSignOut = (callback = () => {}) => {
+const useMeteorLogout = (callback = () => {}) => {
   const client = useApolloClient();
   return () =>
     Meteor.logout(() => {
@@ -20,4 +20,4 @@ const useSignOut = (callback = () => {}) => {
     });
 };
 
-export default useSignOut;
+export default useMeteorLogout;

--- a/packages/vulcan-accounts/imports/useSignout.js
+++ b/packages/vulcan-accounts/imports/useSignout.js
@@ -1,0 +1,23 @@
+import { useApolloClient } from '@apollo/react-hooks';
+
+/**
+ *  Hook used to sign the user out.
+ *
+ * @param {function} callback called after the logout and the Apollo store reset
+ * @returns {function} a function to execute when you log the user out
+ */
+
+const useSignOut = (callback = () => {}) => {
+  const client = useApolloClient();
+  return () =>
+    Meteor.logout(() => {
+      const resetStoreCallback = () => {
+        callback();
+        removeResetStoreCallback(resetStoreCallback);
+      };
+      const removeResetStoreCallback = client.onResetStore(resetStoreCallback);
+      client.resetStore();
+    });
+};
+
+export default useSignOut;

--- a/packages/vulcan-accounts/main_client.js
+++ b/packages/vulcan-accounts/main_client.js
@@ -4,9 +4,9 @@ import './imports/components.js';
 import './imports/login_session.js';
 import './imports/routes.js';
 import { STATES } from './imports/helpers.js';
-import useSignout from './imports/useSignout.js';
+import useMeteorLogout from './imports/useMeteorLogout.js';
 
 import './imports/ui/components/LoginForm.jsx';
 
-export { Accounts, STATES, useSignout };
+export { Accounts, STATES, useMeteorLogout };
 export default Accounts;

--- a/packages/vulcan-accounts/main_client.js
+++ b/packages/vulcan-accounts/main_client.js
@@ -4,8 +4,9 @@ import './imports/components.js';
 import './imports/login_session.js';
 import './imports/routes.js';
 import { STATES } from './imports/helpers.js';
+import useSignout from './imports/useSignout.js';
 
 import './imports/ui/components/LoginForm.jsx';
 
-export { Accounts, STATES };
+export { Accounts, STATES, useSignout };
 export default Accounts;

--- a/packages/vulcan-accounts/main_server.js
+++ b/packages/vulcan-accounts/main_server.js
@@ -7,8 +7,9 @@ import './imports/oauth_config.js';
 import './imports/emailTemplates.js';
 import { redirect, STATES } from './imports/helpers.js';
 import './imports/api/server/servicesListPublication.js';
+import useSignout from './imports/useSignout.js';
 
 import './imports/ui/components/LoginForm.jsx';
 
-export { Accounts, redirect, STATES };
+export { Accounts, redirect, STATES, useSignout };
 export default Accounts;

--- a/packages/vulcan-accounts/main_server.js
+++ b/packages/vulcan-accounts/main_server.js
@@ -7,9 +7,9 @@ import './imports/oauth_config.js';
 import './imports/emailTemplates.js';
 import { redirect, STATES } from './imports/helpers.js';
 import './imports/api/server/servicesListPublication.js';
-import useSignout from './imports/useSignout.js';
+import useMeteorLogout from './imports/useMeteorLogout.js';
 
 import './imports/ui/components/LoginForm.jsx';
 
-export { Accounts, redirect, STATES, useSignout };
+export { Accounts, redirect, STATES, useMeteorLogout };
 export default Accounts;


### PR DESCRIPTION
Also added `@apollo/react-hooks` as a dependency since it's also used elsewhere in the codebase.
The hook simply takes a callback and does the same as the already existing logout function from `LoginFormInner` from the same package