### PR TITLE
getGroups changes

### DIFF
--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -78,10 +78,10 @@ Users.getGroups = (user, document) => {
  */
 Users.getActions = user => {
   let userGroups = Users.getGroups(user);
-  if (!userGroups.includes('guests')) {
-    // always give everybody permission for guests actions, too
-    userGroups.push('guests');
-  }
+
+  // always give everybody permission for guests actions, too
+  userGroups.push('guests');
+  
   let groupActions = userGroups.map(groupName => {
     // note: make sure groupName corresponds to an actual group
     const group = Users.groups[groupName];

--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -91,13 +91,28 @@ Users.getActions = user => {
 };
 
 /**
- * @summary check if a user is a member of a group
+ * @summary check if a user is at least member of one group
+ * @param {Array} user
+ * @param {String} group or array of groups
+ */
+Users.isAtLeastMemberOfOne = (user, groupOrGroups, document) => {
+  const groups = Array.isArray(groupOrGroups) ? groupOrGroups : [groupOrGroups];
+  return intersection(Users.getGroups(user, document), groups).length > 0;
+};
+
+// DEPRECATED
+// TODO: remove this
+/**
+ * @summary check if a user is at least member of one group
  * @param {Array} user
  * @param {String} group or array of groups
  */
 Users.isMemberOf = (user, groupOrGroups, document) => {
-  const groups = Array.isArray(groupOrGroups) ? groupOrGroups : [groupOrGroups];
-  return intersection(Users.getGroups(user, document), groups).length > 0;
+  deprecate(
+    '1.14.2',
+    'getViewableFields is deprecated. Use Users.isAtLeastMemberOfOne to check if a user is at least member of one group'
+  );
+  return Users.isAtLeastMemberOfOne(user, groupOrGroups, document);
 };
 
 /**

--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -78,9 +78,6 @@ Users.getGroups = (user, document) => {
  */
 Users.getActions = user => {
   let userGroups = Users.getGroups(user);
-
-  // always give everybody permission for guests actions, too
-  userGroups.push('guests');
   
   let groupActions = userGroups.map(groupName => {
     // note: make sure groupName corresponds to an actual group


### PR DESCRIPTION
Hy everybody ! 

The **Users.getGroups** function changed with the new version 1.14.1.
Now, it is returning all the groups from guests to admin like : 

- I am a guest : return ["guests"]
- I am a member : return ["guests", "members"]
- I am an admin : return ["guests", "members", "admin"]

So, the name of the **Users.isMemberOf** function sounds confusing for me, because if I am checking if a member **isMemberOf(["guests"])**, it will return **true**, where I am expecting a **false**.

So, I changed the name to **isAtLeastMemberOfOne** which is sounding better for me.
What are you thinking about this ? Do you have another name idea ? 

Also, I a little bit disagree with the new behavior of the **getGroups** function because, for me, guests and members are 2 distinct groups, there is no relation of superiority between them.
Maybe I am expecting two different worklow for guests and members, and I do not want to mix them.
What do you think ? 

Anyway, with the new **Users.getGroups** function, we have to change the **Users.getActions**, because the `!userGroups.includes('guests')` verification is now **false** all the time. I changed it in the PR.

I let you thinking about this ;) 

Have a good day and thank you for your work :) 