### PR TITLE
Update to current valid strikethrough tags

### DIFF
--- a/packages/vulcan-lib/lib/server/utils.js
+++ b/packages/vulcan-lib/lib/server/utils.js
@@ -6,7 +6,7 @@ Utils.sanitize = function(s) {
   return sanitizeHtml(s, {
     allowedTags: [
       'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul',
-      'ol', 'nl', 'li', 'b', 'i', 'strong', 'em', 'strike',
+      'ol', 'nl', 'li', 'b', 'i', 'strong', 'em', 's', 'del', 'ins',
       'code', 'hr', 'br', 'div', 'table', 'thead', 'caption',
       'tbody', 'tr', 'th', 'td', 'pre', 'img'
     ]


### PR DESCRIPTION
The `strike` tag is no longer a valid HTML tag. See https://www.w3schools.com/tags/tag_strike.asp

Two very similar tags are its replacement, `s` and `del` -- and `del` has a corresponding `ins` tag. See https://www.w3schools.com/tags/tag_del.asp and https://www.w3schools.com/tags/tag_s.asp

So take out the old `strike` tag and add in `s`, `del` and `ins`.