### PR TITLE
Bugfix/modaltrigger

### DIFF
--- a/packages/vulcan-core/lib/modules/components/Datatable/DatatableFilter.jsx
+++ b/packages/vulcan-core/lib/modules/components/Datatable/DatatableFilter.jsx
@@ -62,7 +62,7 @@ const DatatableFilter = props => {
           />
         }
         size="small"
-        trigger={<Filter count={getCount(columnFilters)} />}>
+        trigger={Filter({ count: getCount(columnFilters) })}>
         {query ? (
           <Components.DatatableFilterContentsWithData {...props} />
         ) : (

--- a/packages/vulcan-ui-material/lib/components/ui/ModalTrigger.jsx
+++ b/packages/vulcan-ui-material/lib/components/ui/ModalTrigger.jsx
@@ -70,6 +70,7 @@ class ModalTrigger extends PureComponent {
       dialogProps,
       labelId,
       component,
+      trigger,
       titleId,
       type,
       children,
@@ -81,9 +82,9 @@ class ModalTrigger extends PureComponent {
     const label = labelId ? intl.formatMessage({ id: labelId }) : this.props.label;
     const title = titleId ? intl.formatMessage({ id: titleId }) : this.props.title;
     
-    const triggerComponent = component
+    const triggerComponent = component || trigger
       ?
-      React.cloneElement(component, {
+      React.cloneElement(component || trigger, {
         className: classNames('modal-trigger', classes.root, className),
         onClick: this.openModal
       })
@@ -143,6 +144,7 @@ ModalTrigger.propTypes = {
   label: PropTypes.string,
   labelId: PropTypes.string,
   component: PropTypes.object,
+  trigger: PropTypes.object,
   title: PropTypes.node,
   titleId: PropTypes.string,
   type: PropTypes.oneOf(['link', 'button']),


### PR DESCRIPTION
Changes
a) The way the DatatableFilter passed the filter symbol react object didn't let add onClick, now it can
b) Material UI ModalTrigger accepts trigger as prop ass bootstrap's does
