### PR TITLE
Enable OpenCRUD backwards compatibility

### DIFF
--- a/packages/vulcan-lib/lib/server/mutators.js
+++ b/packages/vulcan-lib/lib/server/mutators.js
@@ -423,7 +423,7 @@ export const updateMutator = async ({
       // eslint-disable-next-line no-await-in-loop
       autoValue = await schema[fieldName].onEdit(
         dataToModifier(clone(data)),
-        document,
+        oldDocument || document,
         currentUser,
         document
       );


### PR DESCRIPTION
When using onEdit we should get as args : cf. https://github.com/VulcanJS/Vulcan/blob/51acfa7ffcec844cab882f661ca314df19f56fa4/packages/vulcan-lib/lib/server/mutators.js#L193 
- modifier
- oldDocument
- currentUser
- document
Nevertheless, in the current version we get document twice which prevents us from verifying oldDocument properties. I think at some commit document became oldDocument and newDocument became document.