### PR TITLE
Don't run `options` function until `loading` is false, and `data` is populated

### DIFF
--- a/packages/vulcan-forms/lib/components/FormComponentLoader.jsx
+++ b/packages/vulcan-forms/lib/components/FormComponentLoader.jsx
@@ -26,7 +26,7 @@ const FormComponentLoader = props => {
     }
   }
 
-  if (loading) return <Components.Loading />;
+  if (loading) return <div className="form-component-loader"><Components.Loading /></div>;
 
   // pass newly loaded data (and options if needed) to child component
   const extraProps = { data, queryData: data, queryError: error, queryLoading: loading };

--- a/packages/vulcan-forms/lib/components/FormComponentLoader.jsx
+++ b/packages/vulcan-forms/lib/components/FormComponentLoader.jsx
@@ -26,6 +26,8 @@ const FormComponentLoader = props => {
     }
   }
 
+  if (loading) return <Components.Loading />;
+
   // pass newly loaded data (and options if needed) to child component
   const extraProps = { data, queryData: data, queryError: error, queryLoading: loading };
   if (typeof options === 'function') {
@@ -35,7 +37,7 @@ const FormComponentLoader = props => {
 
   const fci = React.cloneElement(children, extraProps);
 
-  return <div className="form-component-loader">{loading ? <Components.Loading /> : fci}</div>;
+  return <div className="form-component-loader">{fci}</div>;
 };
 
 FormComponentLoader.propTypes = {};


### PR DESCRIPTION
This structure is necessary for my app to not crash when it loads a SmartForm. 
It is also in keeping with the code in Apollo example. See https://www.apollographql.com/docs/react/api/react-hooks/#example