### PR TITLE
feature/update react-helmet

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "react-datetime": "^2.11.1",
     "react-dom": "16.12.0",
     "react-dropzone": "10.1.5",
-    "react-helmet": "^5.2.1",
+    "react-helmet": "^6.0.0",
     "react-intl": "^2.1.3",
     "react-loadable": "^4.0.3",
     "react-markdown": "^3.1.5",

--- a/packages/vulcan-core/lib/modules/components/HeadTags.jsx
+++ b/packages/vulcan-core/lib/modules/components/HeadTags.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { registerComponent, Utils, getSetting, registerSetting, Head } from 'meteor/vulcan:lib';
 import compose from 'recompose/compose';
 


### PR DESCRIPTION
The NFL has released version 6.0.0 of react-helmet. It has one breaking change re named import/export: https://github.com/nfl/react-helmet/wiki/Upgrade-from-5.x.x----6.x.x-beta