### PR TITLE
Bugfix/2550 readable fields with document

### DIFF
--- a/packages/vulcan-lib/lib/server/default_resolvers.js
+++ b/packages/vulcan-lib/lib/server/default_resolvers.js
@@ -103,7 +103,9 @@ export function getDefaultResolvers(options) {
 
         // check again that the fields used for filtering were all valid, this time based on documents
         // this second check is necessary for document based permissions like canRead:["owners", customFunctionThatNeedDoc]
-        viewableDocs.forEach(document => Users.checkFields(currentUser, collection, filteredFields, document));
+        if (filteredFields.length) {
+          viewableDocs = viewableDocs.filter(document => Users.canFilterDocument(currentUser, collection, filteredFields, document));
+        }
 
         // take the remaining documents and remove any fields that shouldn't be accessible
         const restrictedDocs = Users.restrictViewableFields(currentUser, collection, viewableDocs);

--- a/packages/vulcan-lib/lib/server/default_resolvers2.js
+++ b/packages/vulcan-lib/lib/server/default_resolvers2.js
@@ -156,7 +156,7 @@ export function getNewDefaultResolvers({ typeName, collectionName, options }) {
           } else {
             throwError({
               id: 'app.missing_document',
-              data: { documentId: doc._id, input },
+              data: { documentId: _id, input },
             });
           }
         }

--- a/packages/vulcan-lib/lib/server/default_resolvers2.js
+++ b/packages/vulcan-lib/lib/server/default_resolvers2.js
@@ -85,7 +85,9 @@ export function getNewDefaultResolvers({ typeName, collectionName, options }) {
 
         // check again that the fields used for filtering were all valid, this time based on documents
         // this second check is necessary for document based permissions like canRead:["owners", customFunctionThatNeedDoc]
-        viewableDocs.forEach(document => Users.checkFields(currentUser, collection, filteredFields, document));
+        if (filteredFields.length) {
+          viewableDocs = viewableDocs.filter(document => Users.canFilterDocument(currentUser, collection, filteredFields, document));
+        }
 
         // take the remaining documents and remove any fields that shouldn't be accessible
         const restrictedDocs = Users.restrictViewableFields(currentUser, collection, viewableDocs);
@@ -147,7 +149,9 @@ export function getNewDefaultResolvers({ typeName, collectionName, options }) {
 
           // check again that the fields used for filtering were all valid, this time based on retrieved document
           // this second check is necessary for document based permissions like canRead:["owners", customFunctionThatNeedDoc]
-          Users.checkFields(currentUser, collection, filteredFields, doc);
+          if (filteredFields.length) {
+            doc = Users.canFilterDocument(currentUser, collection, filteredFields, doc) ? doc : null;
+          }
         }
 
         if (!doc) {

--- a/packages/vulcan-lib/test/server/resolvers.test.js
+++ b/packages/vulcan-lib/test/server/resolvers.test.js
@@ -1,25 +1,21 @@
-import { createDummyCollection, isoCreateCollection } from 'meteor/vulcan:test'
-import { createCollection } from 'meteor/vulcan:lib';
-import Users from 'meteor/vulcan:users'
+import { createDummyCollection, isoCreateCollection } from 'meteor/vulcan:test';
+//import { createCollection } from 'meteor/vulcan:lib';
+import Users from 'meteor/vulcan:users';
 import expect from 'expect';
 import { getNewDefaultResolvers } from '../../lib/server/default_resolvers2';
-import sinon from 'sinon'
+import sinon from 'sinon';
 
-describe('vulcan:core/default_resolvers', function () {
+describe('vulcan:core/default_resolvers', function() {
   const resolversOptions = {
     typeName: 'Dummy',
     collectionName: 'Dummies',
-    options: {}
+    options: {},
   };
   // TODO: build helpers to mock collections
-  const buildContext = ({
-    usersMocks = {},
-    currentUser = adminUser,
-    ...otherProps
-  }) => ({
+  const buildContext = ({ usersMocks = {}, currentUser = adminUser, ...otherProps }) => ({
     Users,
     currentUser,
-    ...otherProps
+    ...otherProps,
   });
   // TODO: what's the name of this argument? handles cache
   const lastArg = { cacheControl: {} };
@@ -30,8 +26,8 @@ describe('vulcan:core/default_resolvers', function () {
   const getSingleResolver = () => getNewDefaultResolvers(resolversOptions).single.resolver;
   const getMultiResolver = () => getNewDefaultResolvers(resolversOptions).multi.resolver;
 
-  describe('single', function () {
-    it('defines the correct fields', function () {
+  describe('single', function() {
+    it('defines the correct fields', function() {
       const { single } = getNewDefaultResolvers(resolversOptions);
       const { description, resolver } = single;
       expect(description).toBeDefined();
@@ -41,20 +37,20 @@ describe('vulcan:core/default_resolvers', function () {
 
     // TODO: the current behaviour is not consistent, could be improved
     // @see https://github.com/VulcanJS/Vulcan/issues/2118
-    it.skip('return null if documentId is undefined in selector', function () {
+    it.skip('return null if documentId is undefined in selector', function() {
       const resolver = getSingleResolver();
       // no documentId
       const input = { selector: {} };
       // non empty db
       const context = buildContext({
         Dummies: createDummyCollection({
-          results: { load: { _id: 'my-document' } }
-        })
+          results: { load: { _id: 'my-document' } },
+        }),
       });
       const res = resolver(null, { input }, context, lastArg);
       return expect(res).resolves.toEqual({ result: null });
     });
-    it('return document in case of success', function () {
+    it('return document in case of success', function() {
       const resolver = getSingleResolver();
       const documentId = 'my-document';
       const document = { _id: documentId };
@@ -62,37 +58,98 @@ describe('vulcan:core/default_resolvers', function () {
       // non empty db
       const context = buildContext({
         Dummies: createDummyCollection({
-          results: { findOne: document }
-        })
+          results: { findOne: document },
+        }),
       });
       const res = resolver(null, { input }, context, lastArg);
       return expect(res).resolves.toEqual({ result: document });
     });
-    it('return null if failure to find doc but allowNull is true', function () {
+    it('return null if failure to find doc but allowNull is true', function() {
       const resolver = getSingleResolver();
       const documentId = 'bad-document';
       const input = { selector: { documentId }, allowNull: true };
       // empty db
       const context = buildContext({
-        Dummies: createDummyCollection({})
+        Dummies: createDummyCollection({}),
       });
       const res = resolver(null, { input }, context, lastArg);
       return expect(res).resolves.toEqual({ result: null });
     });
-    it('throws if documentId is defined but does not match any document', function () {
+    it('throws if documentId is defined but does not match any document', function() {
       const resolver = getSingleResolver();
       const documentId = 'bad-document';
       const input = { selector: { documentId } };
       // empty db
       const context = buildContext({
-        Dummies: createDummyCollection({})
+        Dummies: createDummyCollection({}),
       });
       return expect(resolver(null, { input }, context, lastArg)).rejects.toThrow();
+    });
+    describe('filtering', () => {
+      it('throws if filtering on field readable by owners and user is not owner', () => {
+        const resolver = getSingleResolver();
+        const filter = {
+          year: { _gte: 1, _lte: 5 },
+        };
+        const input = { selector: {}, filter };
+        const doc = { userId: '1', year: 3 };
+        // empty db
+        const context = buildContext({
+          Dummies: createDummyCollection({
+            schema: {
+              year: {
+                type: Number,
+                canRead: 'owners',
+              },
+              userId: {
+                type: String,
+                canRead: ['guests'],
+              },
+            },
+            results: {
+              load: doc, // load is used when using _id
+              findOne: doc, // get is used with custom selectors => uses findOne under the hood
+            },
+          }),
+          currentUser: { _id: '2' },
+        });
+        return expect(resolver(null, { input }, context, lastArg)).rejects.toThrow();
+      });
+      it('return doc if filtering on field readable by owners and user is not owner', () => {
+        const resolver = getSingleResolver();
+        const filter = {
+          year: { _gte: 1, _lte: 5 },
+        };
+        const input = { selector: {}, filter };
+        const doc = { userId: '1', year: 3 };
+        // empty db
+        const context = buildContext({
+          Dummies: createDummyCollection({
+            schema: {
+              year: {
+                type: Number,
+                canRead: 'owners',
+              },
+              userId: {
+                type: String,
+                canRead: ['guests'],
+              },
+            },
+            results: {
+              load: doc, // load is used when using _id
+              findOne: doc, // get is used with custom selectors => uses findOne under the hood
+            },
+          }),
+          currentUser: { _id: '1' },
+        });
+        const res = resolver(null, { input }, context, lastArg);
+        return expect(res).resolves.toEqual({ result: doc });
+      });
     });
   });
 
   describe('multi', () => {
-    it('defines the correct fields', function () {
+    it('defines the correct fields', function() {
       const { multi } = getNewDefaultResolvers(resolversOptions);
       const { description, resolver } = multi;
       expect(description).toBeDefined();
@@ -101,30 +158,35 @@ describe('vulcan:core/default_resolvers', function () {
     });
     it('get documents', () => {
       const resolver = getMultiResolver();
-      const dbDocuments = [{
-        _id: '1'
-      }, {
-        _id: '2'
-      }]
+      const dbDocuments = [
+        {
+          _id: '1',
+        },
+        {
+          _id: '2',
+        },
+      ];
       const input = { terms: {} };
       // non empty db
       const context = buildContext({
         Dummies: createDummyCollection({
-          results: { find: dbDocuments }
+          results: { find: dbDocuments },
         }),
-        currentUser: adminUser
+        currentUser: adminUser,
       });
       const res = resolver(null, { input }, context, lastArg);
       return expect(res).resolves.toMatchObject({ results: dbDocuments });
-
-    })
+    });
     describe('security', () => {
       it('filter out unallowed documents', () => {
         const resolver = getMultiResolver();
-        const doc2 = { _id: '2' }
-        const dbDocuments = [{
-          _id: '1'
-        }, doc2]
+        const doc2 = { _id: '2' };
+        const dbDocuments = [
+          {
+            _id: '1',
+          },
+          doc2,
+        ];
         const input = { terms: {} };
         const context = buildContext({
           // non empty db
@@ -135,38 +197,92 @@ describe('vulcan:core/default_resolvers', function () {
             options: {
               permissions: {
                 // filter out doc 1
-                canRead: ({ document: { _id } }) => _id !== '1'
-              }
+                canRead: ({ document: { _id } }) => _id !== '1',
+              },
             },
           }),
         });
         const res = resolver(null, { input }, context, lastArg);
         return expect(res).resolves.toMatchObject({ results: [doc2] });
-      })
+      });
       it('filter out restricted fields from retrieved documents', () => {
         const resolver = getMultiResolver();
         // foo does not exist in the schema
-        const doc1 = { _id: '1', foo: 'bar' }
-        const doc2 = { _id: '2', foo: 'bar' }
-        const dbDocuments = [doc1, doc2]
+        const doc1 = { _id: '1', foo: 'bar' };
+        const doc2 = { _id: '2', foo: 'bar' };
+        const dbDocuments = [doc1, doc2];
         const input = { terms: {} };
         const context = buildContext({
           // non empty db
           Dummies: createDummyCollection({
             results: {
               find: dbDocuments,
-            }
-          })
+            },
+          }),
         });
         const res = resolver(null, { input }, context, lastArg);
         return expect(res).resolves.toMatchObject({
-          results: [
-            { _id: '1' }, { _id: '2' }
-          ]
+          results: [{ _id: '1' }, { _id: '2' }],
         });
-      })
-
-    })
+      });
+      it('throws if filtering on field readable by owners and user is not owner', () => {
+        const resolver = getMultiResolver();
+        const doc = { userId: '1', year: 3 };
+        const filter = {
+          year: { _gte: 1, _lte: 5 },
+        };
+        const input = { selector: {}, filter };
+        // empty db
+        const context = buildContext({
+          Dummies: createDummyCollection({
+            schema: {
+              year: {
+                type: Number,
+                canRead: 'owners',
+              },
+              userId: {
+                type: String,
+                canRead: ['guests'],
+              },
+            },
+            results: {
+              find: [doc],
+            },
+          }),
+          currentUser: { _id: '2' },
+        });
+        return expect(resolver(null, { input }, context, lastArg)).rejects.toThrow();
+      });
+      it('return doc if filtering on field readable by owners and user is not owner', () => {
+        const resolver = getMultiResolver();
+        const filter = {
+          year: { _gte: 1, _lte: 5 },
+        };
+        const input = { selector: {}, filter };
+        const doc = { userId: '1', year: 3 };
+        // empty db
+        const context = buildContext({
+          Dummies: createDummyCollection({
+            schema: {
+              year: {
+                type: Number,
+                canRead: 'owners',
+              },
+              userId: {
+                type: String,
+                canRead: ['guests'],
+              },
+            },
+            results: {
+              find: [doc],
+            },
+          }),
+          currentUser: { _id: '1' },
+        });
+        const res = resolver(null, { input }, context, lastArg);
+        return expect(res).resolves.toEqual({ results: [doc] });
+      });
+    });
     // @see https://5da5072ecae7f900081d6d9a--happy-villani-6ca506.netlify.com/
     describe('user defined search', () => {
       // TODO: this is a unit test based on props but an integration test
@@ -174,74 +290,64 @@ describe('vulcan:core/default_resolvers', function () {
       it('filter documents based on user input', async () => {
         const resolver = getMultiResolver();
         const input = {
-          filter: { year: { _gte: 2000 } }
-        }
+          filter: { year: { _gte: 2000 } },
+        };
         // TODO: creating a spy on find is tedious, use integration test instead
-        const findSpy = sinon.spy(
-          () => ({ fetch: () => [], count: () => 0 })
-        )
+        const findSpy = sinon.spy(() => ({ fetch: () => [], count: () => 0 }));
         const context = buildContext({
           Dummies: createDummyCollection({
             schema: {
               _id: { type: String, canRead: ['admins'] },
-              year: { type: Number, canRead: ['admins'] }
+              year: { type: Number, canRead: ['admins'] },
             },
             find: findSpy,
-          })
-        })
-        const res = await resolver(null, { input }, context, lastArg)
-        // TODO: 
+          }),
+        });
+        const res = await resolver(null, { input }, context, lastArg);
+        // TODO:
         expect(findSpy.getCall(0).args[0]).toMatchObject({
-          year: { $gte: 2000 }
-        })
-      })
+          year: { $gte: 2000 },
+        });
+      });
       // TODO: API changed, this test is not valid anymore
       it.skip('detect invalid filters', async () => {
         const resolver = getMultiResolver();
         const input = {
           // gte is not valid, _gte is correct
-          filter: { year: { gte: 2000 } }
-        }
+          filter: { year: { gte: 2000 } },
+        };
         // TODO: creating a spy on find is tedious, use integration test instead
-        const findSpy = sinon.spy(
-          () => ({ fetch: () => [], count: () => 0 })
-        )
+        const findSpy = sinon.spy(() => ({ fetch: () => [], count: () => 0 }));
         const context = buildContext({
           Dummies: createDummyCollection({
             schema: {
               _id: { type: String, canRead: ['guests'] },
-              year: { type: Number, canRead: ['guests'] }
+              year: { type: Number, canRead: ['guests'] },
             },
             find: findSpy,
           }),
-        })
-        await expect(
-          resolver(null, { input }, context, lastArg)
-        ).rejects.toThrow()
-      })
+        });
+        await expect(resolver(null, { input }, context, lastArg)).rejects.toThrow();
+      });
       // important to avoid indirect access to the value (filtering is indirectly equivalent to reading)
       it('detect non viewable field in filter', async () => {
         const resolver = getMultiResolver();
         const input = {
-          filter: { year: { _gte: 2000 } }
-        }
-        const findSpy = sinon.spy(
-          () => ({ fetch: () => [], count: () => 0 })
-        )
+          filter: { year: { _gte: 2000 } },
+        };
+        const findSpy = sinon.spy(() => ({ fetch: () => [], count: () => 0 }));
         const context = buildContext({
           Dummies: createDummyCollection({
             schema: {
               _id: { type: String, canRead: ['admins', 'members'] },
-              year: { type: Number, canRead: ['admins'] }
+              year: { type: Number, canRead: ['admins'] },
             },
             find: findSpy,
           }),
           currentUser: loggedInUser, // not an admin so can't filter on year,
-        })
-        await expect(
-          resolver(null, { input }, context, lastArg)
-        ).rejects.toThrow()
-      })
+        });
+        await expect(resolver(null, { input }, context, lastArg)).rejects.toThrow();
+      });
       // seems to work eventually...
       /*
       it('runs integration test', async () => {
@@ -256,7 +362,6 @@ describe('vulcan:core/default_resolvers', function () {
         await Foobars.rawCollection().drop()
       })
       */
-
-    })
-  })
+    });
+  });
 });

--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -279,11 +279,15 @@ Users.helpers({
  */
 Users.checkFields = (user, collection, fields) => {
   const viewableFields = Users.getReadableFields(user, collection);
-  const diff = difference(fields, viewableFields);
+  const ambiguousFields = Users.getDocumentBasedPermissionFieldNames(collection); // these fields need to wait for the document to be present before being checked
+  const fieldsToTest = difference(fields, ambiguousFields);
+  const diff = difference(fieldsToTest, viewableFields);
 
   if (diff.length) {
     throw new Error(
-      `You don't have permission to filter collection ${collection.options.collectionName} by the following fields: ${diff.join(', ')}.`
+      `You don't have permission to filter collection ${collection.options.collectionName} by the following fields: ${diff.join(
+        ', '
+      )}. Field is not readable or do not exist.`
     );
   }
   return true;

--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -277,10 +277,14 @@ Users.helpers({
  * @param {Object} collection - The collection
  * @param {Object} fields - The list of fields
  */
-Users.checkFields = (user, collection, fields) => {
+Users.checkFields = (user, collection, fields, document) => {
   const viewableFields = Users.getReadableFields(user, collection);
-  const ambiguousFields = Users.getDocumentBasedPermissionFieldNames(collection); // these fields need to wait for the document to be present before being checked
-  const fieldsToTest = difference(fields, ambiguousFields);
+  let fieldsToTest = fields;
+  // Initial case without document => we ignore fields that need the document to be checked
+  if (!document) {
+    const ambiguousFields = Users.getDocumentBasedPermissionFieldNames(collection); // these fields need to wait for the document to be present before being checked
+    fieldsToTest = difference(fields, ambiguousFields); // we only check non-ambiguous fields (canRead: ["guests", "admins"] for instance)
+  }
   const diff = difference(fieldsToTest, viewableFields);
 
   if (diff.length) {

--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -278,10 +278,12 @@ Users.helpers({
  * @param {Object} fields - The list of fields
  */
 Users.checkFields = (user, collection, fields, document) => {
-  const viewableFields = Users.getReadableFields(user, collection);
+  const viewableFields =
+    typeof document === 'undefined' ? Users.getReadableFields(user, collection) : Users.getReadableFields(user, collection, document);
   let fieldsToTest = fields;
   // Initial case without document => we ignore fields that need the document to be checked
-  if (!document) {
+  // Note: undefined !== null, a null document should be checked
+  if (typeof document === 'undefined') {
     const ambiguousFields = Users.getDocumentBasedPermissionFieldNames(collection); // these fields need to wait for the document to be present before being checked
     fieldsToTest = difference(fields, ambiguousFields); // we only check non-ambiguous fields (canRead: ["guests", "admins"] for instance)
   }

--- a/packages/vulcan-users/test/permissions.test.js
+++ b/packages/vulcan-users/test/permissions.test.js
@@ -57,7 +57,7 @@ describe('vulcan:users/permissions', () => {
       expect(Users.checkFields(null, Dummies, ['guestField'])).toBe(true);
     });
     test('checkFields with document-based permissions do not throw for ambigous fields (those field need the document to be checked)', () => {
-      const res = Users.checkFields(null, Dummies, ['guestFields', 'ownerField', 'customField']);
+      const res = Users.checkFields(null, Dummies, ['guestField', 'ownerField', 'customField']);
       expect(res).toEqual(true);
     });
   });

--- a/packages/vulcan-users/test/permissions.test.js
+++ b/packages/vulcan-users/test/permissions.test.js
@@ -1,120 +1,138 @@
-import Users from '../lib/modules/collection'
-import '../lib/modules/permissions'
-const test = it
-import expect from "expect"
-import { createDummyCollection } from "meteor/vulcan:test"
-import SimpleSchema from "simpl-schema"
+import Users from '../lib/modules/collection';
+import '../lib/modules/permissions';
+const test = it;
+import expect from 'expect';
+import { createDummyCollection } from 'meteor/vulcan:test';
+import SimpleSchema from 'simpl-schema';
 
 describe('vulcan:users/permissions', () => {
-    const Dummies = createDummyCollection({
+  const Dummies = createDummyCollection({
+    schema: {
+      guestField: {
+        type: String,
+        canRead: ['guests'],
+      },
+      adminField: {
+        type: String,
+        canRead: ['admins'],
+      },
+      ownerField: {
+        type: String,
+        canRead: ['owners'], // => need a document to be passed in order to check if the field is readable/filterable
+      },
+      customField: {
+        type: String,
+        canRead: [document => document && document.canRead], // => need a document to be passed in order to check if the field is readable/filterable
+      },
+    },
+  });
+  test('getViewableFields as projection (legacy)', () => {
+    const fields = Users.getViewableFields(null, Dummies);
+    expect(fields).toEqual({
+      guestField: true,
+    });
+  });
+  test('getReadableFields', () => {
+    const fields = Users.getReadableFields(null, Dummies);
+    expect(fields).toEqual(['guestField']);
+  });
+  test('getReadableFields with document-based permissions excludes ambiguous fields', () => {
+    const fields = Users.getReadableFields(null, Dummies);
+    expect(fields).not.toContain('ownerField');
+    expect(fields).not.toContain('customField');
+  });
+  test('getReadableProjection', () => {
+    const fields = Users.getReadableProjection(null, Dummies);
+    expect(fields).toEqual({ guestField: true });
+  });
+
+  describe('fields allowed for filtering', () => {
+    test('get fields that needs to be checked against the document to be tested', () => {
+      const documentBasedPermissionFields = Users.getDocumentBasedPermissionFieldNames(Dummies);
+      expect(documentBasedPermissionFields).toContain('ownerField');
+      expect(documentBasedPermissionFields).toContain('customField');
+    });
+    test('checkFields throw on wrong permission', () => {
+      expect(() => Users.checkFields(null, Dummies, ['adminField'])).toThrow();
+      expect(Users.checkFields(null, Dummies, ['guestField'])).toBe(true);
+    });
+    test('checkFields with document-based permissions do not throw for ambigous fields (those field need the document to be checked)', () => {
+      const res = Users.checkFields(null, Dummies, ['guestFields', 'ownerField', 'customField']);
+      expect(res).toEqual(true);
+    });
+  });
+
+  test('restrictViewableFields', () => {
+    const fields = Users.restrictViewableFields(null, Dummies, { adminField: 'foo', guestField: 'bar' });
+    expect(fields).toEqual({ guestField: 'bar' });
+  });
+
+  describe('nested fields', () => {
+    test('remove unreadable field of nested object', () => {
+      const Dummies = createDummyCollection({
         schema: {
-            guestField: {
+          nested: {
+            canRead: ['guests'],
+            type: new SimpleSchema({
+              ok: {
                 type: String,
-                canRead: ['guests']
-            },
-            adminField: {
+                canRead: ['guests'],
+              },
+              nok: {
                 type: String,
-                canRead: ['admins']
-
-            }
-        }
-    })
-    test("getViewableFields as projection (legacy)", () => {
-        const fields = Users.getViewableFields(null, Dummies)
-        expect(fields).toEqual({
-            guestField: true
-        })
-
-    })
-    test('getReadableFields', () => {
-        const fields = Users.getReadableFields(null, Dummies)
-        expect(fields).toEqual(["guestField"])
-    })
-    test('getReadableProjection', () => {
-        const fields = Users.getReadableProjection(null, Dummies)
-        expect(fields).toEqual({ guestField: true })
-
-    })
-    test('checkFields', () => {
-        expect(() => Users.checkFields(null, Dummies, ['adminField'])).toThrow()
-        expect(Users.checkFields(null, Dummies, ['guestField'])).toBe(true)
-    })
-    test('restrictViewableFields', () => {
-        const fields = Users.restrictViewableFields(null, Dummies, { 'adminField': "foo", 'guestField': "bar" })
-        expect(fields).toEqual({ 'guestField': "bar" })
-    })
-
-    describe('nested fields', () => {
-        test('remove unreadable field of nested object', () => {
-            const Dummies = createDummyCollection({
-                schema: {
-                    nested: {
-                        canRead: ['guests'],
-                        type: new SimpleSchema({
-                            ok: {
-                                type: String,
-                                canRead: ['guests']
-
-                            },
-                            nok: {
-                                type: String,
-                                canRead: ['members']
-                            }
-
-                        })
-                    }
-                }
-            })
-            const fields = Users.restrictViewableFields(null, Dummies, { "nested": { ok: "foo", nok: "bar" } })
-            expect(fields).toEqual({ nested: { ok: "foo" } })
-        })
-        test('remove unreadable field of array of nested objects', () => {
-            const Dummies = createDummyCollection({
-                schema: {
-                    array: {
-                        type: Array,
-                        canRead: ['guests']
-                    },
-                    "array.$": {
-                        canRead: ['guests'],
-                        type: new SimpleSchema({
-                            ok: {
-                                type: String,
-                                canRead: ['guests']
-
-                            },
-                            nok: {
-                                type: String,
-                                canRead: ['members']
-                            }
-
-                        })
-                    }
-                }
-            })
-            const fields = Users.restrictViewableFields(null, Dummies, { "array": [{ ok: "foo", nok: "bar" }] })
-            expect(fields).toEqual({ array: [{ ok: "foo" }] })
-        })
-        test('ignore fields without read permission (parent permissions are used)', () => {
-            const Dummies = createDummyCollection({
-                schema: {
-                    nested: {
-                        canRead: ['guests'],
-                        type: new SimpleSchema({
-                            ok: {
-                                type: String,
-                            },
-                            nok: {
-                                type: String,
-                                canRead: ['members']
-                            }
-
-                        })
-                    }
-                }
-            })
-            const fields = Users.restrictViewableFields(null, Dummies, { "nested": { ok: "foo", nok: "bar" } })
-            expect(fields).toEqual({ nested: { ok: "foo" } })
-        })
-    })
-})
+                canRead: ['members'],
+              },
+            }),
+          },
+        },
+      });
+      const fields = Users.restrictViewableFields(null, Dummies, { nested: { ok: 'foo', nok: 'bar' } });
+      expect(fields).toEqual({ nested: { ok: 'foo' } });
+    });
+    test('remove unreadable field of array of nested objects', () => {
+      const Dummies = createDummyCollection({
+        schema: {
+          array: {
+            type: Array,
+            canRead: ['guests'],
+          },
+          'array.$': {
+            canRead: ['guests'],
+            type: new SimpleSchema({
+              ok: {
+                type: String,
+                canRead: ['guests'],
+              },
+              nok: {
+                type: String,
+                canRead: ['members'],
+              },
+            }),
+          },
+        },
+      });
+      const fields = Users.restrictViewableFields(null, Dummies, { array: [{ ok: 'foo', nok: 'bar' }] });
+      expect(fields).toEqual({ array: [{ ok: 'foo' }] });
+    });
+    test('ignore fields without read permission (parent permissions are used)', () => {
+      const Dummies = createDummyCollection({
+        schema: {
+          nested: {
+            canRead: ['guests'],
+            type: new SimpleSchema({
+              ok: {
+                type: String,
+              },
+              nok: {
+                type: String,
+                canRead: ['members'],
+              },
+            }),
+          },
+        },
+      });
+      const fields = Users.restrictViewableFields(null, Dummies, { nested: { ok: 'foo', nok: 'bar' } });
+      expect(fields).toEqual({ nested: { ok: 'foo' } });
+    });
+  });
+});


### PR DESCRIPTION
This makes filtering secure for fields whose `canRead` permission require the document to be tested. Beforehand security was too agressive and disallowed filtering altogether for those fields.

To solve this, we need a 3-step check:

- check that the user do not try to filter on readable field, when `canRead` only need to know the current user
- get the document(s)
- check again, for fields whose `canRead` also need to know the document, eg `owners` that check `userId` or any custom function. Documents that do not match are removed from the results, because we actually shouldn't have been able to filter them in the first place.

Thanks to this we don't need a specific `canFilter`, as filtering behaves likes reading.

Other way to phrase is that now filtering can work, even if a filter field  `canRead` is true for certain documents and false for other documents. Before, it would have forbidden filtering on such fields.

You can't do that only with Mongo, so we need an additional JS function that iterates on document to remove unfilterable ones.

We still throw an error before querying the database when user try to filter on fields that he can never read, like trying to filter on an admin only field.

Closes https://github.com/VulcanJS/Vulcan/issues/2550
Closes https://github.com/VulcanJS/Vulcan/issues/2542

@yairtal Review and more testing would be welcome as you initially pointed this issue
@SachaG Review welcome as this is a bit tricky and concerns security