### PR TITLE
Forms submit target verification

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -935,7 +935,7 @@ class SmartForm extends Component {
     event && event.preventDefault();
 
     // Check event.target.id is equal to this.props.id
-    if(this.props.id !== event.target.id) {
+    if(this.props.id && this.props.id !== event.target.id) {
       return;
     }
 
@@ -1008,8 +1008,7 @@ class SmartForm extends Component {
   // --------------------------------------------------------------------- //
   // ------------------------- Props to Pass ----------------------------- //
   // --------------------------------------------------------------------- //
-  genId = () => Math.random().toString(36).substr(2, 9) + Math.random().toString(36).substr(2, 9);
-
+  
   getCommonProps = () => {
     const { errors, currentValues, deletedValues, disabled } = this.state;
     const { currentUser, prefilledProps, formComponents, itemProperties } = this.props;
@@ -1038,7 +1037,7 @@ class SmartForm extends Component {
 
     return {
       className: `${docClassName} ${docClassName}-${typeName}`,
-      id: this.props.id ? this.props.id : this.genId(),
+      id: this.props.id,
       onSubmit: this.submitForm,
       ref: e => {
         this.form = e;

--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -933,11 +933,7 @@ class SmartForm extends Component {
   */
   submitForm = async event => {
     event && event.preventDefault();
-
-    // Check event.target.id is equal to this.props.id
-    if(this.props.id && this.props.id !== event.target.id) {
-      return;
-    }
+    event && event.stopPropagation();
 
     // if form is disabled (there is already a submit handler running) don't do anything
     if (this.state.disabled) {

--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -934,6 +934,11 @@ class SmartForm extends Component {
   submitForm = async event => {
     event && event.preventDefault();
 
+    // Check event.target.id is equal to this.props.id
+    if(this.props.id !== event.target.id) {
+      return;
+    }
+
     // if form is disabled (there is already a submit handler running) don't do anything
     if (this.state.disabled) {
       return;
@@ -1003,6 +1008,7 @@ class SmartForm extends Component {
   // --------------------------------------------------------------------- //
   // ------------------------- Props to Pass ----------------------------- //
   // --------------------------------------------------------------------- //
+  genId = () => Math.random().toString(36).substr(2, 9) + Math.random().toString(36).substr(2, 9);
 
   getCommonProps = () => {
     const { errors, currentValues, deletedValues, disabled } = this.state;
@@ -1032,7 +1038,7 @@ class SmartForm extends Component {
 
     return {
       className: `${docClassName} ${docClassName}-${typeName}`,
-      id: this.props.id,
+      id: this.props.id ? this.props.id : this.genId(),
       onSubmit: this.submitForm,
       ref: e => {
         this.form = e;


### PR DESCRIPTION
When I open multiple SmartForms, submit one submits all forms.

For example, I open a first form to edit/create an object, then open another form to create another object to fill the first form.

As the SmartForm id prop is passed to the form node, I added a check for id equality between target and form in submitForm only if an id is passed to the smartForm.
