### PR TITLE
bugfix - SmartForm cannot update nested input fields

### DIFF
--- a/packages/vulcan-forms/lib/components/FormComponent.jsx
+++ b/packages/vulcan-forms/lib/components/FormComponent.jsx
@@ -125,12 +125,13 @@ class FormComponent extends Component {
   Get value from Form state through document and currentValues props
 
   */
-  getValue = (props) => {
+  getValue = (props, context) => {
     const p = props || this.props;
-    const { locale, defaultValue, deletedValues, formType, datatype, document } = p;
+    const c = context || this.context;
+    const { locale, defaultValue, deletedValues, formType, datatype } = p;
     const path = locale ? `${getPath(p)}.value` : getPath(p);
-    let value = get(document, path);
-
+    const currentDocument = c.getDocument();
+    let value = get(currentDocument, path);
     // note: force intl fields to be treated like strings
     const nullValue = locale ? '' : getNullValue(datatype);
 
@@ -332,6 +333,7 @@ class FormComponent extends Component {
       inputType: this.getInputType(),
       value: this.getValue(),
       errors: this.getErrors(),
+      document: this.context.getDocument(),
       showCharsRemaining: !!this.showCharsRemaining(),
       handleChange: this.handleChange,
       clearField: this.clearField,
@@ -367,6 +369,10 @@ FormComponent.propTypes = {
   clearFieldErrors: PropTypes.func.isRequired,
   currentUser: PropTypes.object,
   prefilledProps: PropTypes.object,
+};
+
+FormComponent.contextTypes = {
+  getDocument: PropTypes.func.isRequired,
 };
 
 //module.exports = FormComponent;

--- a/packages/vulcan-forms/lib/components/FormGroup.jsx
+++ b/packages/vulcan-forms/lib/components/FormGroup.jsx
@@ -49,7 +49,7 @@ class FormGroup extends PureComponent {
       return null;
     }
 
-    const { name, fields, formComponents, label, group, document } = this.props;
+    const { name, fields, formComponents, label, group } = this.props;
     const { collapsed } = this.state;
 
     const FormComponents = mergeWithComponents(formComponents);
@@ -72,7 +72,6 @@ class FormGroup extends PureComponent {
             key={field.name}
             disabled={this.props.disabled}
             {...field}
-            document={document}
             itemProperties={{ ...this.props.itemProperties, ...field.itemProperties }}
             errors={this.props.errors}
             throwError={this.props.throwError}


### PR DESCRIPTION
Reverse commit 594bf423bc86aa83061b53866f6fcefa6415be03

SmartForm changes from a week ago cause an error — cannot create or update nested inputs, like those in the Addresses subschema of VulcanStarter example-forms.

Commit 594bf423bc86aa83061b53866f6fcefa6415be03 introduced the error. When I reverse just this one commit, I am once again able to update nested fields.