### PR TITLE
Jun2020BugFixes1

### DIFF
--- a/packages/vulcan-lib/lib/client/auth.js
+++ b/packages/vulcan-lib/lib/client/auth.js
@@ -16,6 +16,8 @@ function setToken(loginToken, expires) {
     cookie.set('meteor_login_token', loginToken, {
       path: '/',
       expires,
+      sameSite: 'lax',
+      secure: true,
     });
   } else {
     cookie.remove('meteor_login_token', {

--- a/packages/vulcan-lib/lib/modules/components.js
+++ b/packages/vulcan-lib/lib/modules/components.js
@@ -219,6 +219,9 @@ export const instantiateComponent = (component, props) => {
     return <Component {...props} />;
   } else if (typeof component === 'function') {
     return component(props);
+  } else if (typeof component === 'object' && component.$$typeof && component.render) {
+    const Component = component;
+    return <Component {...props} />;
   } else {
     return component;
   }

--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -310,7 +310,7 @@ Users.canFilterDocument = (user, collection, fields, document) => {
 const restrictDocument = (document, schema, currentUser) => {
   let restrictedDocument = cloneDeep(document);
   forEachDocumentField(document, schema, ({ fieldName, fieldSchema, currentPath, isNested }) => {
-    if (isNested && !fieldSchema.canRead) return; // ignore nested fields without permissions
+    if (isNested && !fieldSchema?.canRead) return; // ignore nested fields without permissions
     if (!fieldSchema || !Users.canReadField(currentUser, fieldSchema, document)) {
       unset(restrictedDocument, `${currentPath}${fieldName}`);
     }


### PR DESCRIPTION
 * `meteor_login_token` was not set with the correct sameSite attribute
 * `instantiateComponent()` did not handle `React.forwardRef` components correctly
 * `restrictDocument()` would fail for nested fields without a fieldSchema