### PR TITLE
change cookie secure to false on localhost

### DIFF
--- a/packages/vulcan-lib/lib/client/auth.js
+++ b/packages/vulcan-lib/lib/client/auth.js
@@ -17,7 +17,7 @@ function setToken(loginToken, expires) {
       path: '/',
       expires,
       sameSite: 'lax',
-      secure: true,
+      secure: document.domain !== 'localhost',
     });
   } else {
     cookie.remove('meteor_login_token', {


### PR DESCRIPTION
fix for: on localhost, on chrome, after refreshing the browser, user will get logged out
see: https://github.com/reactivestack/cookies/issues/233 