### PR TITLE
add itemProperties openNested option for nested schema

### DIFF
--- a/packages/vulcan-forms/lib/components/FormNestedArray.jsx
+++ b/packages/vulcan-forms/lib/components/FormNestedArray.jsx
@@ -28,7 +28,7 @@ class FormNestedArray extends PureComponent {
   }
 
   addItem = () => {
-    const { prefilledProps, path } = this.props;
+    const {prefilledProps, path } = this.props;
     const value = this.getCurrentValue();
     this.props.updateCurrentValues(
       { [`${path}.${value.length}`]: _get(prefilledProps, `${path}.$`) || {} },
@@ -62,6 +62,10 @@ class FormNestedArray extends PureComponent {
     });
     return visibleIndexes;
   };
+
+  componentDidMount() {
+    if (this.props.itemProperties.openNested) this.addItem();
+  }
 
   render() {
     const value = this.getCurrentValue();
@@ -131,6 +135,7 @@ FormNestedArray.propTypes = {
   errors: PropTypes.array.isRequired,
   deletedValues: PropTypes.array.isRequired,
   formComponents: PropTypes.object.isRequired,
+  itemProperties: PropTypes.object,
 };
 
 export default FormNestedArray;


### PR DESCRIPTION
Add the option to have a nested schema on mount, this way the user doesn't have to click the + button in order to add the first item, he/she can just start typing in the data.
```
itemProperties: {
   openNested: true
}
````