### PR TITLE
Bugfix/add correct selector to delete

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -999,7 +999,11 @@ class SmartForm extends Component {
     const deleteDocumentConfirm = this.context.intl.formatMessage({ id: 'forms.delete_confirm' }, { title: documentTitle });
 
     if (window.confirm(deleteDocumentConfirm)) {
-      this.props[`delete${this.props.typeName}`]({ documentId })
+      this.props[`delete${this.props.typeName}`]({
+          input: {
+            id: documentId
+          }
+        })
         .then(mutationResult => {
           // the mutation result looks like {data:{collectionRemove: null}} if succeeded
           if (this.props.removeSuccessCallback) this.props.removeSuccessCallback({ documentId, documentTitle });

--- a/packages/vulcan-lib/lib/modules/graphql_templates/mutations.js
+++ b/packages/vulcan-lib/lib/modules/graphql_templates/mutations.js
@@ -153,8 +153,6 @@ export const deleteInputTemplate = ({ typeName }) =>
   `input ${deleteInputType(typeName)}{
   filter: ${filterInputType(typeName)}
   id: String
-  # An identifier to name the mutation's execution context
-  contextName: String
 }`;
 
 /*


### PR DESCRIPTION
Deleting documents currently doesn't happen. I get an error in the console: "Error: GraphQL error: Selector cannot be empty". 

(It can easily be replicated by running the `example-forums` package, adding a comment to a post, then trying to delete that comment.)

I am guessing that this error stems from [this commit](https://github.com/VulcanJS/Vulcan/commit/314e1d99800cb366c403c59fa5c168a3f175ff16), where the delete mutator didn't get the correct selector. So here is a quick edit to `Form.jsx` to resolve this error.

NOTE: I also removed `contextName` for deletions in `mutations.js`, because I couldn't see how contextName is used when you delete a document. I could be wrong about this, but pretty sure about the need for the other edit to Form.jsx