### PR TITLE
MaterialUiMinorChanges7

### DIFF
--- a/packages/vulcan-lib/lib/modules/components.js
+++ b/packages/vulcan-lib/lib/modules/components.js
@@ -207,7 +207,7 @@ export const instantiateComponent = (component, props) => {
   if (!component) {
     return null;
   } else if (typeof component === 'string') {
-    const Component = getComponent(component);
+    const Component = Components[component];
     return <Component {...props} />;
   } else if (React.isValidElement(component)) {
     return React.cloneElement(component, props);

--- a/packages/vulcan-ui-material/history.md
+++ b/packages/vulcan-ui-material/history.md
@@ -1,3 +1,9 @@
+1.13.2_2 / 2020-01-20
+=====================
+
+ * MuiSuggest: Removed `selectedOption` and `inputFormatted` from the component state
+ * TooltipIntl: Fixed bug: `titleValues` prop was not implemented
+
 1.13.2_1 / 2019-10-02
 =====================
 

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/EndAdornment.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/EndAdornment.jsx
@@ -6,7 +6,9 @@ import withStyles from '@material-ui/core/styles/withStyles';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from 'mdi-material-ui/CloseCircle';
+import MenuDownIcon from 'mdi-material-ui/MenuDown';
 import classNames from 'classnames';
+import _omit from 'lodash/omit';
 
 
 export const styles = theme => ({
@@ -25,7 +27,21 @@ export const styles = theme => ({
     },
     height: 'auto',
   },
-  
+
+  menuIndicator: {
+    padding: 10,
+    marginRight: -40,
+    marginLeft: -16,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: theme.palette.common.midBlack,
+    pointerEvents: 'none',
+    transition: theme.transitions.create(['opacity'], {
+      duration: theme.transitions.duration.short,
+    }),
+  },
+
   clearButton: {
     opacity: 0,
     '& svg': {
@@ -57,7 +73,7 @@ export const styles = theme => ({
 
 
 const EndAdornment = (props, context) => {
-  const { classes, value, addonAfter, changeValue, hideClear, disabled } = props;
+  const { classes, value, addonAfter, changeValue, showMenuIndicator, hideClear, disabled } = props;
   const { intl } = context;
 
   if (!addonAfter && (!changeValue || hideClear || disabled)) return null;
@@ -74,10 +90,16 @@ const EndAdornment = (props, context) => {
     >
       <CloseIcon/>
     </IconButton>;
-  
+
+  const menuIndicator = showMenuIndicator && !disabled &&
+    <div className={classNames('menu-indicator', classes.menuIndicator, hasValue && 'has-value')}>
+      <MenuDownIcon/>
+    </div>;
+
   return (
     <InputAdornment classes={{ root: classes.inputAdornment }} position="end">
-      {instantiateComponent(addonAfter)}
+      {instantiateComponent(addonAfter, _omit(props, ['classes']))}
+      {menuIndicator}
       {clearButton}
     </InputAdornment>
   );
@@ -88,6 +110,7 @@ EndAdornment.propTypes = {
   classes: PropTypes.object.isRequired,
   value: PropTypes.any,
   changeValue: PropTypes.func,
+  showMenuIndicator: PropTypes.bool,
   hideClear: PropTypes.bool,
   addonAfter: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.func]),
 };

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiFormControl.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiFormControl.jsx
@@ -9,7 +9,7 @@ import { Components, registerComponent } from 'meteor/vulcan:core';
 
 //noinspection JSUnusedGlobalSymbols
 const MuiFormControl = createReactClass({
-  
+
   propTypes: {
     label: PropTypes.node,
     children: PropTypes.node,
@@ -18,18 +18,18 @@ const MuiFormControl = createReactClass({
     fakeLabel: PropTypes.bool,
     hideLabel: PropTypes.bool,
     shrinkLabel: PropTypes.bool,
-    layout: PropTypes.oneOf(['horizontal', 'vertical', 'elementOnly']),
+    layout: PropTypes.oneOf(['horizontal', 'vertical', 'elementOnly', 'shrink']),
     htmlFor: PropTypes.string,
     inputType: PropTypes.string,
   },
-  
+
   renderLabel: function () {
     const { fakeLabel, hideLabel, shrinkLabel, layout, optional, label, value } = this.props;
-    
+
     if (layout === 'elementOnly' || hideLabel) {
       return null;
     }
-    
+
     if (fakeLabel) {
       return (
         <FormLabel className="control-label legend"
@@ -40,9 +40,9 @@ const MuiFormControl = createReactClass({
         </FormLabel>
       );
     }
-    
+
     const shrink = shrinkLabel || ['date', 'time', 'datetime'].includes(this.props.inputType) ? true : undefined;
-    
+
     return (
       <InputLabel className="control-label"
                   data-required={!optional}
@@ -53,22 +53,22 @@ const MuiFormControl = createReactClass({
       </InputLabel>
     );
   },
-  
+
   render: function () {
     const { layout, className, children, hasErrors } = this.props;
-    
+
     if (layout === 'elementOnly') {
       return <span>{children}</span>;
     }
-    
+
     return (
-      <FormControl component="fieldset" error={hasErrors} fullWidth={true} className={className}>
+      <FormControl component="fieldset" error={hasErrors} fullWidth={layout !== 'shrink'} className={className}>
         {this.renderLabel()}
         {children}
       </FormControl>
     );
   }
-  
+
 });
 
 

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiSelect.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiSelect.jsx
@@ -1,6 +1,7 @@
 import withStyles from '@material-ui/core/styles/withStyles';
 import React from 'react';
 import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import ComponentMixin from './mixins/component';
 import MuiFormControl from './MuiFormControl';
 import MuiFormHelper from './MuiFormHelper';
@@ -12,36 +13,8 @@ import ListSubheader from '@material-ui/core/ListSubheader';
 import StartAdornment, { hideStartAdornment } from './StartAdornment';
 import EndAdornment from './EndAdornment';
 import _isArray from 'lodash/isArray';
-
-
-export const styles = theme => ({
-
-  inputRoot: {
-    '& .clear-enabled': { opacity: 0 },
-    '&:hover .clear-enabled': { opacity: 0.54 },
-  },
-
-  inputFocused: {
-    '& .clear-enabled': { opacity: 0.54 }
-  },
-
-  menuItem: {
-    paddingTop: 4,
-    paddingBottom: 4,
-    paddingLeft: 9,
-    fontFamily: theme.typography.fontFamily,
-    color: theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.87)' : theme.palette.common.white,
-    fontSize: theme.typography.pxToRem(16),
-    lineHeight: '1.1875em',
-  },
-
-  input: {
-    //paddingLeft: 8,
-  },
-  
-  inputDisabled: {},
-  
-});
+import classNames from 'classnames';
+import { styles } from './MuiSuggest';
 
 
 const MuiSelect = createReactClass({
@@ -49,6 +22,21 @@ const MuiSelect = createReactClass({
   element: null,
 
   mixins: [ComponentMixin],
+
+  propTypes: {
+    options: PropTypes.arrayOf(PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    })),
+    classes: PropTypes.object.isRequired,
+    showMenuIndicator: PropTypes.bool,
+  },
+
+  getDefaultProps: function () {
+    return {
+      showMenuIndicator: true,
+    };
+  },
 
   getInitialState: function () {
     return {
@@ -112,7 +100,7 @@ const MuiSelect = createReactClass({
         ?
         <option key={key} {...rest}>{label}</option>
         :
-        <MenuItem key={key} {...rest} className={classes.menuItem}>{label}</MenuItem>;
+        <MenuItem key={key} {...rest} className={classes.selectItem}>{label}</MenuItem>;
     };
 
     const renderGroup = (label, key, nodes) => {
@@ -176,11 +164,13 @@ const MuiSelect = createReactClass({
       <StartAdornment {...this.props}
                       value={value}
                       classes={null}
+                      changeValue={this.changeValue}
       />;
     const endAdornment =
       <EndAdornment {...this.props}
                     value={value}
-                    classes={null}
+                    classes={{ inputAdornment: classes.inputAdornment }}
+                    changeValue={this.changeValue}
       />;
 
     return (

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/mixins/component.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/mixins/component.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _omit from 'lodash/omit';
+import classNames from 'classnames';
 
 
 export default {
@@ -23,7 +24,7 @@ export default {
       optional: this.props.optional,
       value: this.props.value,
       hasErrors: this.hasErrors(),
-      className: this.props.className,
+      className: classNames(this.props.className, this.props.classes?.root),
       inputType: this.props.inputType,
     };
   },
@@ -77,20 +78,19 @@ export default {
   cleanProps: function (props) {
     const removedFields = [
       'addItem',
+      'addToDeletedValues',
       'addonAfter',
       'addonBefore',
-      'addToDeletedValues',
       'afterComponent',
       'allowedValues',
       'arrayField',
       'arrayFieldSchema',
       'autoValue',
       'beforeComponent',
-      'blackbox',
       'charsCount',
       'charsRemaining',
-      'classes',
       'className',
+      'classes',
       'clearField',
       'clearFieldErrors',
       'currentUser',
@@ -100,10 +100,11 @@ export default {
       'description',
       'document',
       'errors',
-      'formatValue',
       'formComponents',
       'formInput',
       'formType',
+      'formatValue',
+      'getUrl',
       'handleChange',
       'hasErrors',
       'help',
@@ -112,17 +113,20 @@ export default {
       'hideLink',
       'inputClassName',
       'inputProperties',
+      'inputProps',
       'inputType',
       'itemDataType',
       'itemIndex',
       'itemProperties',
       'label',
+      'labelId',
       'layout',
       'maxCount',
       'minCount',
       'mustComplete',
       'nestedArrayErrors',
       'nestedSchema',
+      'networkId',
       'optional',
       'options',
       'parentFieldName',
@@ -131,6 +135,8 @@ export default {
       'renderComponent',
       'scrubValue',
       'showCharsRemaining',
+      'showMenuIndicator',
+      'submitForm',
       'throwError',
       'updateCurrentValues',
       'validateOnSubmit',


### PR DESCRIPTION
 * EndAdornment: refactored the menu indicator
 * MuiFormControl: new `layout` prop value of 'shrink' turns off the `fullWidth` option for the control
 * MuiSelect: added clear button to select controls the same as input and suggest controls
 * MuiSwitch: added support for `addonBefore` and `addonAfter` the same as input and suggest controls
 * Fixed bug in in `instantiateComponent` that prevented React from reusing the component