### PR TITLE
MuiModalChanges

### DIFF
--- a/packages/vulcan-ui-material/lib/components/ui/Modal.jsx
+++ b/packages/vulcan-ui-material/lib/components/ui/Modal.jsx
@@ -18,22 +18,17 @@ const styles = theme => ({
   dialogTitleEmpty: {
     padding: 0,
     height: theme.spacing(3),
+    borderBottomStyle: 'none',
   },
 
-  dialogContent: {
-    paddingTop: '4px',
-  },
+  dialogContent: {},
 
   dialogOverflow: {
     overflowY: 'visible',
   },
 
-  closeButton: {
-    display: 'block !important',
-    position: 'absolute',
-    right: theme.spacing(1),
-    top: theme.spacing(1),
-  },
+  closeButton: theme.utils.closeButton,
+
 });
 
 const Modal = props => {
@@ -44,6 +39,7 @@ const Modal = props => {
     onHide,
     title,
     showCloseButton = true,
+    dontWrapDialogContent,
     dialogOverflow,
     dialogProps,
     classes,
@@ -62,24 +58,33 @@ const Modal = props => {
       }}
       fullWidth={true}
       classes={{ paper: classNames(classes.dialogPaper, overflowClass) }}
-      {...dialogProps}>
+      {...dialogProps}
+    >
       <DialogTitle className={title ? classes.dialogTitle : classes.dialogTitleEmpty}>
         {title}
 
-        {showCloseButton && (
+        {
+          showCloseButton &&
+
           <Components.TooltipButton
             className={classes.closeButton}
-            icon={<Close />}
+            icon={<Close/>}
             titleId="global.close"
             onClick={onHide}
             aria-label="Close"
           />
-        )}
+        }
       </DialogTitle>
 
-      <DialogContent className={classNames(classes.dialogContent, overflowClass)}>
-        {children}
-      </DialogContent>
+      {
+        dontWrapDialogContent
+          ?
+          children
+          :
+          <DialogContent className={classNames(classes.dialogContent, overflowClass)}>
+            {children}
+          </DialogContent>
+      }
     </Dialog>
   );
 };
@@ -91,6 +96,7 @@ Modal.propTypes = {
   onHide: PropTypes.func,
   title: PropTypes.node,
   showCloseButton: PropTypes.bool,
+  dontWrapDialogContent: PropTypes.bool,
   dialogOverflow: PropTypes.bool,
   dialogProps: PropTypes.object,
   classes: PropTypes.object,

--- a/packages/vulcan-ui-material/lib/modules/sampleTheme.js
+++ b/packages/vulcan-ui-material/lib/modules/sampleTheme.js
@@ -20,9 +20,9 @@ import warning from '@material-ui/core/colors/orange';
 
 
 const theme = {
-  
+
   palette: {
-    
+
     primary: {
       light: primary[200],
       main: primary[500],
@@ -30,7 +30,7 @@ const theme = {
       contrastText: '#fff',
       ...primary
     },
-  
+
     secondary: {
       light: secondary[200],
       main: secondary[500],
@@ -38,7 +38,7 @@ const theme = {
       contrastText: '#fff',
       ...secondary
     },
-  
+
     error: {
       light: error[200],
       main: error[500],
@@ -46,7 +46,7 @@ const theme = {
       contrastText: '#fff',
       ...error
     },
-  
+
     warning: {
       light: warning[100],
       main: warning[500],
@@ -54,7 +54,7 @@ const theme = {
       contrastText: '#fff',
       ...warning
     },
-  
+
     success: {
       light: success[100],
       main: success[500],
@@ -62,7 +62,7 @@ const theme = {
       contrastText: '#fff',
       ...success
     },
-  
+
     info: {
       light: info[100],
       main: info[500],
@@ -70,13 +70,13 @@ const theme = {
       contrastText: '#fff',
       ...info
     },
-  
+
   },
-  
+
   utils: {
-    
+
     tooltipEnterDelay: 700,
-    
+
     errorMessage: {
       textAlign: 'center',
       backgroundColor: error[500],
@@ -84,7 +84,7 @@ const theme = {
       borderRadius: '4px',
       fontWeight: 'bold',
     },
-    
+
     denseTable: {
       '& > thead > tr > th, & > tbody > tr > td': {
         padding: '4px 16px 4px 16px',
@@ -93,7 +93,7 @@ const theme = {
         paddingRight: '16px',
       },
     },
-    
+
     flatTable: {
       '& > thead > tr > th, & > tbody > tr > td': {
         padding: '4px 16px 4px 16px',
@@ -103,7 +103,7 @@ const theme = {
         paddingRight: '16px',
       },
     },
-    
+
     denserTable: {
       '& > thead > tr, & > tbody > tr': {
         height: '40px',
@@ -116,9 +116,16 @@ const theme = {
         paddingRight: '16px',
       },
     },
-    
+
+    closeButton: {
+      display: 'block !important',
+      position: 'absolute',
+      right: 8,
+      top: 8,
+    },
+
   },
-  
+
   overrides: {
     MuiButton: {
       root: {
@@ -152,7 +159,7 @@ const theme = {
       },
     },
   },
-  
+
 };
 
 


### PR DESCRIPTION
 * Removed bottom border when `Modal` dialog title is empty
 * Moved `closeButton` style to `theme.utils`
 * New `dontWrapDialogContent` prop prevents wrapping the children in a `DialogContent` component
 * `DialogTrigger`'s content is now lazy rendered
 * Added deprecation warning: __ModalTrigger’s "dialogProperties" prop has been renamed "dialogProps"__