### PR TITLE
GenericMutationWrappersResponse

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/create.js
+++ b/packages/vulcan-core/lib/modules/containers/create.js
@@ -94,8 +94,10 @@ export const useCreate = (options) => {
     ...mutationOptions
   });
 
-  const extendedCreateFunc = (args) => createFunc({ variables: { input: args.input, data: args.data } });
-  return [extendedCreateFunc, ...rest];
+  const extendedCreateFunc = {
+    [resolverName]: (args) => createFunc({ variables: { input: args.input, data: args.data } })
+  };
+  return [extendedCreateFunc[resolverName], ...rest];
 };
 
 export const withCreate = options => C => {

--- a/packages/vulcan-core/lib/modules/containers/delete.js
+++ b/packages/vulcan-core/lib/modules/containers/delete.js
@@ -69,6 +69,7 @@ export const useDelete = (options) => {
   const { collectionName, collection } = extractCollectionInfo(options);
   const { fragmentName, fragment } = extractFragmentInfo(options, collectionName);
   const typeName = collection.options.typeName;
+  const resolverName = `delete${typeName}`;
   const { mutationOptions = {} } = options;
 
   const query = buildDeleteQuery({
@@ -81,13 +82,16 @@ export const useDelete = (options) => {
     update: multiQueryUpdater({ collection, typeName, fragment, fragmentName }),
     ...mutationOptions
   });
-  const extendedDeleteFunc = (args) => {
-    // support legacy syntax mistake
-    // @see https://github.com/VulcanJS/Vulcan/issues/2417
-    const selector = (args && args.selector) || args;
-    return deleteFunc({ variables: { selector } });
-  };
-  return [extendedDeleteFunc, ...rest];
+
+  const extendedDeleteFunc = {
+    [resolverName]: (args) => {
+      // support legacy syntax mistake
+      // @see https://github.com/VulcanJS/Vulcan/issues/2417
+      const selector = (args && args.selector) || args;
+      return deleteFunc({ variables: { selector } });
+    }
+  }
+  return [extendedDeleteFunc[resolverName], ...rest];
 };
 
 export const withDelete = options => C => {

--- a/packages/vulcan-core/lib/modules/containers/update.js
+++ b/packages/vulcan-core/lib/modules/containers/update.js
@@ -49,6 +49,7 @@ export const useUpdate = (options) => {
   const { mutationOptions = {} } = options;
 
   const typeName = collection.options.typeName;
+  const resolverName = `update${typeName}`;
   const query = buildUpdateQuery({ typeName, fragmentName, fragment });
 
   const [updateFunc, ...rest] = useMutation(query, {
@@ -57,10 +58,13 @@ export const useUpdate = (options) => {
     ...mutationOptions
   }
   );
-  const extendedUpdateFunc = ({ data, selector }) => updateFunc({
-    variables: { data, selector },
-  });
-  return [extendedUpdateFunc, ...rest];
+
+  const extendedUpdateFunc = {
+    [resolverName]: ({ data, selector }) => updateFunc({
+      variables: { data, selector },
+    })
+  }
+  return [extendedUpdateFunc[resolverName], ...rest];
 };
 
 export const withUpdate = options => C => {


### PR DESCRIPTION
The generic create, update, and delete mutation (HoC/Hooks) wrappers would return their result in `response.data.<resolverName>`. This commit restored the name of those fields.