### PR TITLE
ValidateDocumentPermissionsBugFix

### DIFF
--- a/packages/vulcan-lib/lib/modules/validation.js
+++ b/packages/vulcan-lib/lib/modules/validation.js
@@ -28,7 +28,7 @@ const validateDocumentPermissions = (fullDocument, documentToValidate, schema, c
   const { Users, currentUser } = context;
   forEachDocumentField(documentToValidate, schema,
     ({ fieldName, fieldSchema, currentPath, isNested }) => {
-      if (isNested && (mode === 'create' ? !fieldSchema.canCreate : !fieldSchema.canUpdate)) return; // ignore nested without permission
+      if (isNested && (mode === 'create' ? !fieldSchema?.canCreate : !fieldSchema?.canUpdate)) return; // ignore nested without permission
       if (!fieldSchema
         || (mode === 'create' ? !Users.canCreateField(currentUser, fieldSchema) : !Users.canUpdateField(currentUser, fieldSchema, fullDocument))
       ) {
@@ -96,7 +96,7 @@ export const validateDocument = (document, collection, context, validationContex
 
   1. Check that the current user has permission to insert each field
   2. Run SimpleSchema validation step
-  
+
 */
 export const validateModifier = (modifier, data, document, collection, context, validationContextName = 'defaultContext') => {
   const schema = collection.simpleSchema()._schema;
@@ -226,7 +226,7 @@ export const validateDocumentNotUsed = (document, collection, context) => {
   3. Check field types
   4. Check for missing fields
   5. Run SimpleSchema validation step (for now)
-  
+
 */
 export const validateModifierNotUsed = (modifier, document, collection, context) => {
   const { Users, currentUser } = context;


### PR DESCRIPTION
`validateDocumentPermissions` would throw an error when the document field was `isNested` but had no `fieldSchema`