### PR TITLE
MuiDatatableUpgrades

### DIFF
--- a/packages/vulcan-ui-material/lib/components/bonus/DatatableFromArray.jsx
+++ b/packages/vulcan-ui-material/lib/components/bonus/DatatableFromArray.jsx
@@ -1,0 +1,58 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { Components as C, registerComponent } from 'meteor/vulcan:core';
+
+
+class DatatableFromArray extends PureComponent {
+  
+  
+  constructor (props) {
+    super(props);
+    
+    this.state = {
+      paginationTerms: {
+        itemsPerPage: props.itemsPerPage || 25,
+        limit: props.itemsPerPage || 25,
+        offset: 0,
+      }
+    };
+  }
+  
+  
+  setPaginationTerms = (paginationTerms) => {
+    this.setState({ paginationTerms });
+  };
+  
+  
+  render () {
+    const { paginate, data } = this.props;
+    const { itemsPerPage, offset } = this.state.paginationTerms;
+    const dataPage = paginate ? data.slice(offset, offset + itemsPerPage) : data;
+    
+    return (
+      <C.Datatable {...this.props}
+                   results={dataPage}
+                   count={dataPage.length}
+                   totalCount={data.length}
+                   showEdit={false}
+                   showNew={false}
+                   paginationTerms={paginate ? this.state.paginationTerms : undefined}
+                   setPaginationTerms={paginate ? this.setPaginationTerms : undefined}
+      />
+    );
+    
+  }
+  
+}
+
+DatatableFromArray.propTypes = {
+  data: PropTypes.array,
+  paginate: PropTypes.bool,
+  itemsPerPage: PropTypes.number,
+};
+
+
+DatatableFromArray.displayName = 'DatatableFromArray';
+
+
+registerComponent('DatatableFromArray', DatatableFromArray);

--- a/packages/vulcan-ui-material/lib/components/index.js
+++ b/packages/vulcan-ui-material/lib/components/index.js
@@ -6,6 +6,7 @@ import './accounts/AccountsForm';
 import './accounts/AccountsPasswordOrService';
 import './accounts/AccountsSocialButtons';
 
+import './bonus/DatatableFromArray';
 import './bonus/LoadMore';
 import './bonus/SearchInput';
 import './bonus/TooltipButton';


### PR DESCRIPTION
 * New `SearchInputProps` and `TableProps` props allow sending props to the `SearchInput` and `Table` components
 * New `wrapComponent` prop allows overriding the scroller that the `Table` is wrapped in by default
 * New `cellStyle` prop of column definitions accepts a function or object to add style to individual cells
 * Added default value for `paginationTerms`
 * New bonus component `DatatableFromArray` is a wrapper for `Datatable` that takes an array of objects and supports pagination