### PR TITLE
Validate document permissions bug fix

### DIFF
--- a/packages/vulcan-lib/lib/modules/validation.js
+++ b/packages/vulcan-lib/lib/modules/validation.js
@@ -28,7 +28,7 @@ const validateDocumentPermissions = (fullDocument, documentToValidate, schema, c
   const { Users, currentUser } = context;
   forEachDocumentField(documentToValidate, schema,
     ({ fieldName, fieldSchema, currentPath, isNested }) => {
-      if (isNested && (mode === 'create' ? !fieldSchema?.canCreate : !fieldSchema?.canUpdate)) return; // ignore nested without permission
+      if (isNested && (!fieldSchema || (mode === 'create' ? !fieldSchema.canCreate : !fieldSchema.canUpdate))) return; // ignore nested without permission
       if (!fieldSchema
         || (mode === 'create' ? !Users.canCreateField(currentUser, fieldSchema) : !Users.canUpdateField(currentUser, fieldSchema, fullDocument))
       ) {
@@ -38,7 +38,6 @@ const validateDocumentPermissions = (fullDocument, documentToValidate, schema, c
             name: `${currentPath}${fieldName}`
           },
         });
-        return;
       }
     });
   return validationErrors;

--- a/packages/vulcan-lib/lib/modules/validation.js
+++ b/packages/vulcan-lib/lib/modules/validation.js
@@ -28,7 +28,7 @@ const validateDocumentPermissions = (fullDocument, documentToValidate, schema, c
   const { Users, currentUser } = context;
   forEachDocumentField(documentToValidate, schema,
     ({ fieldName, fieldSchema, currentPath, isNested }) => {
-      if (isNested && (mode === 'create' ? !fieldSchema.canCreate : !fieldSchema.canUpdate)) return; // ignore nested without permission
+      if (isNested && (mode === 'create' ? !fieldSchema?.canCreate : !fieldSchema?.canUpdate)) return; // ignore nested without permission
       if (!fieldSchema
         || (mode === 'create' ? !Users.canCreateField(currentUser, fieldSchema) : !Users.canUpdateField(currentUser, fieldSchema, fullDocument))
       ) {
@@ -96,7 +96,7 @@ export const validateDocument = (document, collection, context, validationContex
 
   1. Check that the current user has permission to insert each field
   2. Run SimpleSchema validation step
-  
+
 */
 export const validateModifier = (modifier, data, document, collection, context, validationContextName = 'defaultContext') => {
   const schema = collection.simpleSchema()._schema;
@@ -226,7 +226,7 @@ export const validateDocumentNotUsed = (document, collection, context) => {
   3. Check field types
   4. Check for missing fields
   5. Run SimpleSchema validation step (for now)
-  
+
 */
 export const validateModifierNotUsed = (modifier, document, collection, context) => {
   const { Users, currentUser } = context;

--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -310,7 +310,7 @@ Users.canFilterDocument = (user, collection, fields, document) => {
 const restrictDocument = (document, schema, currentUser) => {
   let restrictedDocument = cloneDeep(document);
   forEachDocumentField(document, schema, ({ fieldName, fieldSchema, currentPath, isNested }) => {
-    if (isNested && fieldSchema && !fieldSchema.canRead) return; // ignore nested fields without permissions
+    if (isNested && (!fieldSchema || !fieldSchema.canRead)) return; // ignore nested fields without permissions
     if (!fieldSchema || !Users.canReadField(currentUser, fieldSchema, document)) {
       unset(restrictedDocument, `${currentPath}${fieldName}`);
     }


### PR DESCRIPTION
 * `validateDocumentPermissions` would throw an error when the document field was `isNested` but had no `fieldSchema`
 * This is the case for a nested schema that has a graphql-only field generated using `resolveAs`
 * This will be better handled once people start using apiSchema Fields