### PR TITLE
Feature/http only cookie

### DIFF
--- a/packages/vulcan-users/lib/server/mutations.js
+++ b/packages/vulcan-users/lib/server/mutations.js
@@ -105,6 +105,7 @@ const specificResolvers = {
         throw new Error('User already logged out');
       }
       const { userId } = context;
+      context.req.res.clearCookie('meteor_login_token');
       return await logout(userId);
     },
     async signup(root, args, context) {

--- a/packages/vulcan-users/lib/server/mutations.js
+++ b/packages/vulcan-users/lib/server/mutations.js
@@ -87,7 +87,18 @@ const specificResolvers = {
       if (!email) {
         throw new Error('Invalid email');
       }
-      return await authenticateWithPassword(email, password);
+      const authResult = await authenticateWithPassword(email, password);
+      // set an HTTP-only cookie so the user is authenticated
+      const { /*userId,*/ token } = authResult;
+      const tokenCookie = {
+        path: '/',
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'development' ? false : true,
+        // expires: //
+        //sameSite: ''
+      };
+      context.req.res.cookie('meteor_login_token', token, tokenCookie);
+      return authResult;
     },
     async logout(root, args, context) {
       if (!(context && context.userId)) {


### PR DESCRIPTION
Adds an HTTP-only cookie on the GraphQL login mutation (and clearCookie on logout).

This means we don't need browser magic to store the user token in the localStorage.

I leave this as a PR because I don't fully undestand the consequences of this yet, especially:
- what happens in production, especially when the API and the client don't live on the same URL
- what about password remembering, what happens when the browser is closed, should I need a max-age to the cookie

@yairtal @SachaG  since you've worked on authentication recently, any insight is welcome