### PR TITLE
Use Symbol.for for vulcan-accounts const STATES

### DIFF
--- a/packages/vulcan-accounts/imports/helpers.js
+++ b/packages/vulcan-accounts/imports/helpers.js
@@ -6,12 +6,12 @@ try {
 }
 export const loginButtonsSession = Accounts._loginButtonsSession;
 export const STATES = {
-  SIGN_IN: Symbol('SIGN_IN'),
-  SIGN_UP: Symbol('SIGN_UP'),
-  PROFILE: Symbol('PROFILE'),
-  PASSWORD_CHANGE: Symbol('PASSWORD_CHANGE'),
-  PASSWORD_RESET: Symbol('PASSWORD_RESET'),
-  ENROLL_ACCOUNT: Symbol('ENROLL_ACCOUNT')
+  SIGN_IN: Symbol.for('SIGN_IN'),
+  SIGN_UP: Symbol.for('SIGN_UP'),
+  PROFILE: Symbol.for('PROFILE'),
+  PASSWORD_CHANGE: Symbol.for('PASSWORD_CHANGE'),
+  PASSWORD_RESET: Symbol.for('PASSWORD_RESET'),
+  ENROLL_ACCOUNT: Symbol.for('ENROLL_ACCOUNT')
 };
 
 export function getLoginServices() {


### PR DESCRIPTION
Instead of `Symbol()`, `Symbol.for()` will allow global access to Symbols like `STATES.SIGN_IN` in the other files in a two-repo Vulcan install. This allows customization (i.e. `replaceComponent`) of the `AccountsStateSwitcher`, for example.

More info on `Symbol.for()` from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol: 
> the Symbol() function will not create a global symbol that is available in your whole codebase. To create symbols available across files ... use the method Symbol.for()...

On the other hand, if there is no use of the `STATES` const outside of this `helpers.js` file, I believe there is no harm in using the global Symbol registry anyway.