### PR TITLE
Add placeholder to the whitelist

### DIFF
--- a/packages/vulcan-lib/lib/modules/ui_utils.js
+++ b/packages/vulcan-lib/lib/modules/ui_utils.js
@@ -34,6 +34,6 @@ export const getHtmlInputProps = props => {
  * @returns Initial props + props specific to the HTML input in an inputProperties object
  */
 export const whitelistInputProps = props => {
-  const whitelist = ['name', 'path', 'options', 'label', 'onChange', 'onBlur', 'value', 'disabled'];
+  const whitelist = ['name', 'path', 'options', 'label', 'onChange', 'onBlur', 'value', 'disabled', 'placeholder'];
   return pick(props, whitelist);
 };


### PR DESCRIPTION
The placeholder from inputProperties gets removed when whitelistInputProps() is called in FormComponentInner.jsx, so placeholders get removed from smartform text inputs. This adds placeholder to the whitelist of supported fields so they are once again shown on Smartforms.