### PR TITLE
Minor Data Layer Fixes Oct 2020

### DIFF
--- a/packages/vulcan-lib/lib/modules/collections.js
+++ b/packages/vulcan-lib/lib/modules/collections.js
@@ -71,7 +71,7 @@ Mongo.Collection.prototype.attachSchema = function (schemaOrFields) {
 
 /**
  * @summary Add an additional field (or an array of fields) to a schema.
- * @param {Object|Object[]} field
+ * @param {Object|Object[]} fieldOrFieldArray
  */
 Mongo.Collection.prototype.addField = function (fieldOrFieldArray) {
   const collection = this;
@@ -85,7 +85,7 @@ Mongo.Collection.prototype.addField = function (fieldOrFieldArray) {
   });
 
   // add field schema to collection schema
-  collection.attachSchema(createSchema(merge(collection.options.schema, fieldSchema)));
+  collection.attachSchema(createSchema(merge(collection.simpleSchema()._schema, fieldSchema)));
 };
 
 /**

--- a/packages/vulcan-lib/lib/modules/validation.js
+++ b/packages/vulcan-lib/lib/modules/validation.js
@@ -111,7 +111,7 @@ export const validateModifier = (modifier, data, document, collection, context, 
 
   // 2. run SS validation
   const validationContext = collection.simpleSchema().namedContext(validationContextName);
-  validationContext.validate({ $set: set, $unset: unset }, { modifier: true });
+  validationContext.validate({ $set: set, $unset: unset }, { modifier: true, extendedCustomContext: { documentId: document._id } });
 
   if (!validationContext.isValid()) {
     const errors = validationContext.validationErrors();

--- a/packages/vulcan-lib/lib/server/default_resolvers.js
+++ b/packages/vulcan-lib/lib/server/default_resolvers.js
@@ -191,7 +191,7 @@ export function getDefaultResolvers(options) {
           } else {
             throwError({
               id: 'app.missing_document',
-              data: { documentId, oldSelector },
+              data: { documentId, oldSelector, collectionName },
             });
           }
         }

--- a/packages/vulcan-lib/lib/server/default_resolvers2.js
+++ b/packages/vulcan-lib/lib/server/default_resolvers2.js
@@ -160,7 +160,7 @@ export function getNewDefaultResolvers({ typeName, collectionName, options }) {
           } else {
             throwError({
               id: 'app.missing_document',
-              data: { documentId: _id, input },
+              data: { documentId: _id, input, collectionName },
             });
           }
         }


### PR DESCRIPTION
 * Updated JSDoc comments for `Mongo.Collection.prototype.addField()` and fixed a minor bug.
 * Updated `validateModifier()` to include `documentId` in the context of custom field validators. Validators can use it to make sure that a value is unique in the collection. Without the `documentId`, the validator can't tell if an existing document with a unique value is being updated or if a new document with a conflicting value is attempted to be inserted.
 * Updated default resolvers to include the collection name when throwing a `missing_document` error.