### PR TITLE
Material UI Minor Updates Oct 2020

### DIFF
--- a/packages/vulcan-ui-material/en_US.js
+++ b/packages/vulcan-ui-material/en_US.js
@@ -5,9 +5,16 @@ addStrings('en', {
 
   'search.search': 'Search',
   'search.clear': 'Clear search',
-  
+
+
   'modal.close': 'Close',
-  
+
+
+  'forms.phone_help': 'Call number',
+  'forms.email_help': 'Send email',
+  'forms.url_help': 'Visit site',
+
+
   'load_more.load_more': 'Load more',
   'load_more.loaded_count': 'Loaded {count} of {totalCount}',
   //'load_more.loaded_all': '{totalCount, plural, =0 {No items} one {One item} other {# items}}',

--- a/packages/vulcan-ui-material/history.md
+++ b/packages/vulcan-ui-material/history.md
@@ -1,9 +1,27 @@
-1.13.2_2 / 2020-01-20
+1.16.0_1 / 2020-10-24
 =====================
 
- * MuiSuggest: Removed `selectedOption` and `inputFormatted` from the component state
- * TooltipIntl: Fixed bug: `titleValues` prop was not implemented
-
+ * MuiSuggest
+   * Fixed how styles are applied for focused, disabled, and error states
+   * Enabled the styling of `menuItem`, `menuItemHighlight`, and `menuItemIcon` classes
+   * Renamed `muiIcon` class to `selectIcon`
+   * Fixed a bug when `disableSelectOnBlur` prop was passed
+   * Tweaked the behavior of `highlightFirstSuggestion()`
+   * Added support for `inputRef` prop
+ * MuiInput: Previously the field value was not updated until the user exited the input (`blur` event); now the value is updated as you type, enabling the form submit button sooner
+ * Various components: Changed the type of component props to `PropTypes.oneOfType([PropTypes.node, PropTypes.elementType])`
+ * Various components: Updated spacing to comply with linting rules
+ * ScrollTrigger: Refined functionality
+ * TooltipButton: Changed `buttonWrap` display to `inline-flex`
+ * Datatable: Added support for the `label` column prop where you can pass text, or a React element
+ * Component mixin: Updated list of fields in `cleanProps()`
+ * EndAdornment: Tweaked button spacing
+ * StartAdornment: Changed icon button to a `TooltipButton`
+ * Countries: Added `getRegionCode()` function
+ * FormSubmit: Tweaked button spacing
+ * ThemeStyles: Fixed minor bugs
+ * ModalTrigger: Now the trigger component is rendered using `instantiateComponent()`, the same as component props are rendered elsewhere
+ 
 1.16.0 / 2020-08-17
 ===================
 
@@ -40,6 +58,12 @@
    * Added default value for `paginationTerms`
    * New bonus component `DatatableFromArray` is a wrapper for `Datatable` that takes an array of objects and supports pagination
    
+1.13.2_2 / 2020-01-20
+=====================
+
+ * MuiSuggest: Removed `selectedOption` and `inputFormatted` from the component state
+ * TooltipIntl: Fixed bug: `titleValues` prop was not implemented
+
 1.13.2_1 / 2019-10-02
 =====================
 

--- a/packages/vulcan-ui-material/lib/components/bonus/ScrollTrigger.jsx
+++ b/packages/vulcan-ui-material/lib/components/bonus/ScrollTrigger.jsx
@@ -37,6 +37,11 @@ class ScrollTrigger extends Component {
     return supportsPassive;
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    this.checkStatus();
+    return false;
+  }
+
   componentDidMount () {
     this.addEventListeners();
   }
@@ -47,12 +52,12 @@ class ScrollTrigger extends Component {
 
   componentDidUpdate (prevProps, prevState, snapshot) {
     if (prevProps.scroller !== this.props.scroller) {
+      this.removeEventListeners();
       if (this.props.scroller) {
         this.addEventListeners();
-      } else {
-        this.removeEventListeners();
       }
     }
+    this.checkStatus();
   }
 
   addEventListeners () {

--- a/packages/vulcan-ui-material/lib/components/bonus/TooltipButton.jsx
+++ b/packages/vulcan-ui-material/lib/components/bonus/TooltipButton.jsx
@@ -25,12 +25,10 @@ const styles = theme => ({
 
   buttonWrap: {
     position: 'relative',
-    display: 'inline-block',
+    display: 'inline-flex',
   },
 
-  button: {
-    //zIndex: 2,
-  },
+  button: {},
 
   fab: {},
 

--- a/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
+++ b/packages/vulcan-ui-material/lib/components/core/Datatable.jsx
@@ -219,7 +219,7 @@ Datatable.propTypes = {
   options: PropTypes.object,
   columns: PropTypes.array,
   showEdit: PropTypes.bool,
-  editComponent: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  editComponent: PropTypes.oneOfType([PropTypes.node, PropTypes.elementType]),
   showNew: PropTypes.bool,
   showSearch: PropTypes.bool,
   emptyState: PropTypes.node,
@@ -235,7 +235,7 @@ Datatable.propTypes = {
   toggleSort: PropTypes.func,
   currentSort: PropTypes.object,
   paginate: PropTypes.bool,
-  wrapComponent: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  wrapComponent: PropTypes.oneOfType([PropTypes.node, PropTypes.elementType]),
   TableProps: PropTypes.object,
   SearchInputProps: PropTypes.object,
 };
@@ -475,9 +475,10 @@ const DatatableHeader = (
   const columnName = typeof column === 'string' ? column : column.name || column.label;
   let formattedLabel = '';
 
-  if (collection) {
+  if (column.label) {
+    formattedLabel = column.label;
+  } else if (collection) {
     const schema = collection.simpleSchema()._schema;
-
     /*
     use either:
 

--- a/packages/vulcan-ui-material/lib/components/forms/FormSubmit.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/FormSubmit.jsx
@@ -13,7 +13,8 @@ import classNames from 'classnames';
 const styles = theme => ({
   root: {
     textAlign: 'center',
-    marginTop: theme.spacing(4),
+    marginTop: theme.spacing(3),
+    marginBottom: theme.spacing(3),
   },
   button: {
     margin: theme.spacing(1),

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/EndAdornment.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/EndAdornment.jsx
@@ -12,7 +12,7 @@ import _omit from 'lodash/omit';
 
 
 export const styles = theme => ({
-  
+
   inputAdornment: {
     whiteSpace: 'nowrap',
     marginTop: '0 !important',
@@ -57,18 +57,15 @@ export const styles = theme => ({
       duration: theme.transitions.duration.short,
     }),
   },
-  
+
   urlButton: {
     width: 40,
     height: 40,
     fontSize: 20,
-    margin: -8,
-    marginRight: 0,
-    '&:last-child': {
-      margin: -8,
-    },
+    marginLeft: -4,
+    marginRight: -4,
   },
-  
+
 });
 
 
@@ -78,7 +75,7 @@ const EndAdornment = (props, context) => {
 
   if (!addonAfter && (!changeValue || hideClear || disabled)) return null;
   const hasValue = !!value || value === 0;
-  
+
   const clearButton = changeValue && !hideClear && !disabled &&
     <IconButton className={classNames('clear-button', classes.clearButton, hasValue && 'has-value')}
                 onClick={event => {
@@ -115,7 +112,7 @@ EndAdornment.propTypes = {
   changeValue: PropTypes.func,
   showMenuIndicator: PropTypes.bool,
   hideClear: PropTypes.bool,
-  addonAfter: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.func]),
+  addonAfter: PropTypes.oneOfType([PropTypes.node, PropTypes.elementType]),
 };
 
 EndAdornment.contextTypes = {

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiFormHelper.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiFormHelper.jsx
@@ -7,18 +7,18 @@ import classNames from 'classnames';
 
 
 export const styles = theme => ({
-  
+
   error: {
     color: theme.palette.error.main,
   },
-  
+
   formHelperText: {
     display: 'flex',
     '& :first-child': {
       flexGrow: 1,
     }
   },
-  
+
 });
 
 
@@ -34,31 +34,31 @@ const MuiFormHelper = (props) => {
     charsCount,
     max,
   } = props;
-  
+
   if (!help && !hasErrors && !showCharsRemaining) {
     return null;
   }
-  
+
   const errorMessage = hasErrors &&
     <Components.FormError error={errors[0]} />;
-  
+
   return (
     <FormHelperText className={classNames(className, classes.formHelperText)} error={hasErrors}>
-      
+
       <span>
         {
           hasErrors ? errorMessage : help
         }
       </span>
-      
+
       {
         showCharsRemaining &&
-        
+
         <span className={charsRemaining < 0 ? classes.error : null}>
           {charsCount} / {max}
         </span>
       }
-    
+
     </FormHelperText>
   );
 };
@@ -69,7 +69,7 @@ MuiFormHelper.propTypes = {
   classes: PropTypes.object.isRequired,
   value: PropTypes.any,
   changeValue: PropTypes.func,
-  addonAfter: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.func]),
+  addonAfter: PropTypes.oneOfType([PropTypes.node, PropTypes.elementType]),
 };
 
 

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiInput.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiInput.jsx
@@ -8,6 +8,7 @@ import MuiFormHelper from './MuiFormHelper';
 import Input from '@material-ui/core/Input';
 import StartAdornment, { hideStartAdornment } from './StartAdornment';
 import EndAdornment from './EndAdornment';
+import _debounce from 'lodash/debounce';
 import classNames from 'classnames';
 
 
@@ -21,7 +22,7 @@ export const styles = theme => ({
   },
 
   inputFocused: {
-    '& .clear-button.has-value': { opacity: 0.54 }
+    '& .clear-button.has-value': { opacity: 0.54 },
   },
 
   inputDisabled: {},
@@ -82,6 +83,13 @@ const MuiInput = createReactClass({
   },
 
   getInitialState: function () {
+    this.changeValue = _debounce((value) => {
+        if (!this.props.handleChange) return;
+        if (value !== this.props.value) {
+          this.props.handleChange(value);
+        }
+      }, 500);
+
     if (this.props.refFunction) {
       this.props.refFunction(this);
     }
@@ -93,6 +101,7 @@ const MuiInput = createReactClass({
 
   UNSAFE_componentWillReceiveProps: function (nextProps) {
     if (nextProps.value !== this.state.value) {
+      this.changeValue.flush();
       this.setState({ value: nextProps.value });
     }
   },
@@ -103,16 +112,15 @@ const MuiInput = createReactClass({
       value = this.props.scrubValue(value, this.props);
     }
     this.setState({ value });
-  },
 
-  changeValue: function (value) {
-    this.props.handleChange(value);
+    this.changeValue(value);
   },
 
   handleBlur: function (event) {
     const { value } = this.state;
 
     this.changeValue(value);
+    this.changeValue.flush();
   },
 
   render: function () {
@@ -142,21 +150,22 @@ const MuiInput = createReactClass({
   },
 
   renderElement: function (startAdornment, endAdornment) {
-    const { classes, disabled, autoFocus, formatValue, label, inputProps } = this.props;
+    const { classes, disabled, autoFocus, formatValue, label, multiline, rows, rowsMax, inputProps } = this.props;
     const value = formatValue ? formatValue(this.state.value) : this.state.value;
     const options = this.props.options || {};
 
     return (
       <Input
         ref={c => (this.element = c)}
-        {...this.cleanProps(this.props)}
         id={this.getId()}
         value={value || ''}
         label={label}
         onChange={this.handleChange}
         onBlur={this.handleBlur}
         disabled={disabled}
-        rows={options.rows || this.props.rows}
+        multiline={multiline}
+        rows={options.rows || rows}
+        rowsMax={options.rowsMax || rowsMax}
         autoFocus={options.autoFocus || autoFocus}
         startAdornment={startAdornment}
         endAdornment={endAdornment}

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiSelect.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiSelect.jsx
@@ -115,7 +115,7 @@ const MuiSelect = createReactClass({
         </MenuList>;
     };
 
-    const { options, classes } = this.props;
+    const { options = [], classes } = this.props;
 
     let groups = options.filter(function (item) {
       return item.group;
@@ -191,7 +191,7 @@ const MuiSelect = createReactClass({
                               input: classNames(classes.input, !value && classes.inputPlaceholder),
                             }}
               />}
-              classes={{ icon: classes.muiIcon }}
+              classes={{ icon: classes.selectIcon }}
       >
         {optionNodes}
       </Select>

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/StartAdornment.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/StartAdornment.jsx
@@ -1,10 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { instantiateComponent } from 'meteor/vulcan:core';
+import { Components as C, instantiateComponent } from 'meteor/vulcan:core';
 import { intlShape } from 'meteor/vulcan:i18n';
 import withStyles from '@material-ui/core/styles/withStyles';
 import InputAdornment from '@material-ui/core/InputAdornment';
-import IconButton from '@material-ui/core/IconButton';
 import WebIcon from 'mdi-material-ui/Web';
 import EmailIcon from 'mdi-material-ui/EmailOutline';
 import { styles } from './EndAdornment';
@@ -32,29 +31,29 @@ const StartAdornment = (props, context) => {
   const url = getUrl ? getUrl(value, props) : value;
   const socialIcon = type === 'social' ? props.addonBefore : undefined;
   const addonBefore = type === 'social' ? undefined : props.addonBefore;
+  const icon = type === 'email'
+    ?
+    <EmailIcon/>
+    :
+    socialIcon
+      ?
+      instantiateComponent(socialIcon)
+      :
+      <WebIcon/>;
 
   const urlButton = linkTypes.includes(type) &&
-    <IconButton className={classes.urlButton}
-                href={url}
-                target="_blank"
-                disabled={!value}
-                aria-label={intl.formatMessage({
-                  id: `forms.start_adornment_${type}_icon`,
-                })}
-    >
-      {
-        type === 'email'
-          ?
-          <EmailIcon/>
-          :
-          socialIcon
-            ?
-            instantiateComponent(socialIcon)
-            :
-            <WebIcon/>
-      }
-    </IconButton>;
-
+    <C.TooltipButton classes={{ button: classes.urlButton }}
+                     titleId={`forms.${type}_help`}
+                     type="icon"
+                     icon={icon}
+                     size="small"
+                     href={url}
+                     target="_blank"
+                     disabled={!value}
+                     aria-label={intl.formatMessage({
+                       id: `forms.start_adornment_${type}_icon`,
+                     })}
+    />;
 
   return (
     <InputAdornment classes={{ root: classes.inputAdornment }} position="start">
@@ -69,7 +68,7 @@ StartAdornment.propTypes = {
   classes: PropTypes.object.isRequired,
   value: PropTypes.any,
   type: PropTypes.string,
-  addonBefore: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.func]),
+  addonBefore: PropTypes.oneOfType([PropTypes.node, PropTypes.elementType]),
 };
 
 StartAdornment.contextTypes = {

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/mixins/component.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/mixins/component.jsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 export default {
 
   propTypes: {
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    label: PropTypes.oneOfType([PropTypes.node, PropTypes.elementType]),
     hideLabel: PropTypes.bool,
     layout: PropTypes.string,
     optional: PropTypes.bool,
@@ -142,7 +142,16 @@ export default {
       'validateOnSubmit',
       'validatePristine',
       'visibleItemIndex',
-    ];
+      'itemDatatype',
+      'limitToList',
+      'disableText',
+      'disableSelectOnBlur',
+      'showAllOptions',
+      'disableMatchParts',
+      'autoComplete',
+      'autoFocus',
+      'intlKeys',
+  ];
 
     return _omit(props, removedFields);
   },

--- a/packages/vulcan-ui-material/lib/components/forms/controls/countries.js
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/countries.js
@@ -306,7 +306,7 @@ export const countryInfo = {
       { value: 'WV', label: 'West Virginia' },
       { value: 'WI', label: 'Wisconsin' },
       { value: 'WY', label: 'Wyoming' },
-    ]
+    ],
   },
   CA: {
     regionLabel: 'Province',
@@ -370,11 +370,11 @@ export const getRegionLabel = (countryValue, regionValue) => {
   if (!countryInfo[countryValue] || !countryInfo[countryValue].regions) {
     return regionValue;
   }
-  
+
   const regions = countryInfo[countryValue].regions;
-  
+
   let region = regions.find(nextRegion => nextRegion.value === regionValue);
-  
+
   if (region) {
     return region.label;
   } else {
@@ -389,20 +389,26 @@ export const validateRegion = (countryValue, regionValue) => {
   if (!countryInfo[countryValue] || !countryInfo[countryValue].regions) {
     return regionValue;
   }
-  
+
   const regions = countryInfo[countryValue].regions;
-  
+
   let region = regions.find(nextRegion => nextRegion.value === regionValue);
-  
+
   if (region) {
     return regionValue;
   }
-  
+
   region = regions.find(nextRegion => nextRegion.label === regionValue);
-  
+
   if (region) {
     return region.value;
   } else {
     return false;
   }
+};
+
+
+export const getRegionCode = (countryValue, regionValue) => {
+  const regionCode = validateRegion(countryValue, regionValue);
+  return regionCode || regionValue;
 };

--- a/packages/vulcan-ui-material/lib/components/theme/ThemeStyles.jsx
+++ b/packages/vulcan-ui-material/lib/components/theme/ThemeStyles.jsx
@@ -13,7 +13,8 @@ import classNames from 'classnames';
 const describeTypography = (theme, className) => {
   const typography = className ? theme.typography[className] : theme.typography;
   const fontFamily = typography.fontFamily.split(',')[0];
-  return `${fontFamily} ${typography.fontWeight} ${typography.fontSize}px`;
+  const fontSize = `${typography.fontSize}${typeof typography.fontSize === 'number' ? 'px' : ''}`;
+  return `${fontFamily} ${typography.fontWeight} ${fontSize}`;
 };
 
 function getColorBlock(theme, classes, colorName, colorValue, colorTitle) {
@@ -38,7 +39,7 @@ function getColorBlock(theme, classes, colorName, colorValue, colorTitle) {
   };
 
   return (
-      <>
+      <div key={colorName+colorValue}>
         {
           colorValue.toString().match(/^(A100|light|contrastText)$/) &&
           <div className={classes.blockSpace}/>
@@ -50,7 +51,7 @@ function getColorBlock(theme, classes, colorName, colorValue, colorTitle) {
             <span className={classes.colorValue}>{bgColor.toUpperCase()}</span>
           </div>
         </li>
-      </>
+      </div>
   );
 }
 
@@ -146,7 +147,7 @@ const ThemeStyles = ({theme, classes}) => {
             <Typography variant="subtitle1" gutterBottom>
               Subtitle1: {describeTypography(theme, 'subtitle1')}
             </Typography>
-            <Typography variant="subtitle1" gutterBottom>
+            <Typography variant="subtitle2" gutterBottom>
               Subtitle2: {describeTypography(theme, 'subtitle2')}
             </Typography>
 

--- a/packages/vulcan-ui-material/lib/components/ui/ModalTrigger.jsx
+++ b/packages/vulcan-ui-material/lib/components/ui/ModalTrigger.jsx
@@ -22,14 +22,14 @@ const styles = theme => ({
 });
 
 class ModalTrigger extends PureComponent {
-  
-  constructor (props) {
+
+  constructor(props) {
     super(props);
-    
+
     this.state = { modalIsOpen: false };
   }
-  
-  componentDidMount () {
+
+  componentDidMount() {
     if (this.props.action) {
       this.props.action({
         openModal: this.openModal,
@@ -37,7 +37,7 @@ class ModalTrigger extends PureComponent {
       });
     }
   }
-  
+
   openModal = event => {
     if (event) {
       event.preventDefault();
@@ -48,7 +48,7 @@ class ModalTrigger extends PureComponent {
       this.props.openStateChanged(true);
     }
   };
-  
+
   closeModal = event => {
     if (event) {
       event.stopPropagation();
@@ -58,8 +58,8 @@ class ModalTrigger extends PureComponent {
       this.props.openStateChanged(false);
     }
   };
-  
-  render () {
+
+  render() {
     const {
       className,
       dialogClassName,
@@ -78,22 +78,23 @@ class ModalTrigger extends PureComponent {
       contentProps,
       classes,
     } = this.props;
-    
+
     if (dialogProperties) {
       deprecate('1.15.2', 'ModalTrigger’s "dialogProperties" prop has been renamed "dialogProps"');
     }
-    
+
     const intl = this.context.intl;
-    
+
     const label = labelId ? intl.formatMessage({ id: labelId }) : this.props.label;
     const title = titleId ? intl.formatMessage({ id: titleId }) : this.props.title;
-    
+
     const triggerComponent =
       (component || trigger)
         ?
-        <span onClick={this.openModal} className={classNames('modal-trigger', classes.root, className)}>
-          {component || trigger}
-        </span>
+        instantiateComponent(component || trigger, {
+          onClick: this.openModal,
+          className: classNames('modal-trigger', classes.root, className),
+        })
         :
         type === 'button'
           ?
@@ -108,7 +109,7 @@ class ModalTrigger extends PureComponent {
              onClick={this.openModal}>
             {label}
           </a>;
-    
+
     return (
       <>
         {triggerComponent}
@@ -138,7 +139,7 @@ class ModalTrigger extends PureComponent {
       </>
     );
   }
-  
+
 }
 
 ModalTrigger.propTypes = {
@@ -156,7 +157,7 @@ ModalTrigger.propTypes = {
   dialogOverflow: PropTypes.bool,
   showCloseButton: PropTypes.bool,
   dontWrapDialogContent: PropTypes.bool,
-  dialogProperties: PropTypes.object, // deprecated
+  dialogProperties: PropTypes.object, // deprecated — use dialogProps
   dialogProps: PropTypes.object,
   label: PropTypes.string,
   labelId: PropTypes.string,
@@ -167,7 +168,7 @@ ModalTrigger.propTypes = {
   type: PropTypes.oneOf(['link', 'button']),
   openStateChanged: PropTypes.func,
   children: PropTypes.node,
-  contentComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  contentComponent: PropTypes.oneOfType([PropTypes.node, PropTypes.elementType]),
   contentProps: PropTypes.object,
   classes: PropTypes.object,
 };

--- a/packages/vulcan-ui-material/package.js
+++ b/packages/vulcan-ui-material/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'vulcan:ui-material',
-  version: '1.16.0',
+  version: '1.16.0_1',
   summary: 'Replacement for Vulcan (http://vulcanjs.org/) components using material-ui',
   documentation: 'README.md',
 });

--- a/packages/vulcan-ui-material/readme.md
+++ b/packages/vulcan-ui-material/readme.md
@@ -1,4 +1,4 @@
-# vulcan:ui-material 1.16.0
+# vulcan:ui-material 1.16.0_1
 
 Package initially created by [Erik Dakoda](https://github.com/ErikDakoda) ([`erikdakoda:vulcan-material-ui`](https://github.com/ErikDakoda/vulcan-material-ui))
 
@@ -17,16 +17,14 @@ To add vulcan-material-ui to an existing Vulcan project, run the following in th
 meteor add vulcan:ui-material
 
 meteor npm install --save @material-ui/core@4.11.0
-meteor npm install --save @material-ui/icons
-meteor npm install --save @material-ui/styles
-meteor npm install --save react-jss@8.6.1
-meteor npm install --save mdi-material-ui
-meteor npm install --save react-autosuggest
-meteor npm install --save autosuggest-highlight
-meteor npm install --save react-isolated-scroll
-meteor npm install --save react-keyboard-event-handler
-#meteor npm install --save autosize-input
-meteor npm install --save moment-timezone
+meteor npm install --save @material-ui/icons@4.9.1
+meteor npm install --save @material-ui/styles@4.10.0
+meteor npm install --save react-jss@10.4.0
+meteor npm install --save mdi-material-ui@6.19.0
+meteor npm install --save react-autosuggest@10.0.2
+meteor npm install --save autosuggest-highlight@3.1.1
+meteor npm install --save react-isolated-scroll@0.1.1
+meteor npm install --save react-keyboard-event-handler@1.5.4
 ```
 
 This package does not depend on `vulcan:ui-boostrap`, so you can remove it.
@@ -146,19 +144,23 @@ You can pass a couple of extra options to form groups as well:
   };
 ```
 
+
 ## DataTable
 
 You can pass the DataTable component an `editComponent` property in addition to or instead of `showEdit`. Here is a simplified example:
 
-``` javascript
+``` jsx
 const AgendaJobActions = ({ collection, document }) => {
   const scheduleAgent = () => {
     Meteor.call('scheduleAgent', document.agentId);
   };
   
-  return <Components.TooltipIconButton titleId="executions.execute_now"
-                                       icon={<Components.ExecutionsIcon/>}
-                                       onClick={scheduleAgent}/>;
+  return (
+    <Components.TooltipIconButton 
+      titleId="executions.execute_now"
+      icon={<ExecutionsIcon/>}
+      onClick={scheduleAgent}
+    />;
 };
 
 AgendaJobActionsInner.propTypes = {
@@ -184,6 +186,25 @@ You can also control the spacing of the table cells using the `dense` property. 
 You can also use other string values, as long as you define a `utils` entry named the same + `Table`, for example `myCustomTable`. Check out the sample theme for examples.
 
 
+## DatatableFromArray
+
+This is a wrapper component for Datatable that enables pagination even if you pass the data as an array instead of a query.
+
+``` jsx
+<Components.DatatableFromArray
+  columns={[
+             { name: 'message', component: TextCell },
+             { name: 'type', component: TypeCell },
+             { name: 'properties', component: JsonCell, cellClass: classes.widerCell },
+           ]}
+  data={errorArray}
+  paginate={true}
+  itemsPerPage={10}
+  intlNamespace="shops.reports"
+/>
+```
+
+
 ## CountrySelect
 
 One of the bonus components is **CountrySelect**, a country autosuggest. For an example, see **CountrySelect**.
@@ -201,7 +222,7 @@ One of the bonus components is **CountrySelect**, a country autosuggest. For an 
 
 Countries are stored as their 2-letter country codes. I have included a helper function for displaying the country name:
 
-``` javascript
+``` jsx
 import Typography from '@material-ui/core/Typography';
 import { getCountryLabel } from 'meteor/erikdakoda:vulcan-material-ui';
 
@@ -230,9 +251,9 @@ In addition, the `options` that you pass to any select control have additional p
 | Property              | Type   | Description  |
 | --------------------- | ------ | ------------ |
 | `label`         | string           | The option's text label (standard) |
-| `value`         | string \| number | The options's value (standard) |
+| `value`         | string or number | The options's value (standard) |
 | `iconComponent` | node             | An icon to put to the left of the label (optional) |
-| `formatted`     | node \| func     | Instead of just an icon, you can pass a component for each options for (optional) |
+| `formatted`     | node or func     | Instead of just an icon, you can pass a component for each options for (optional) |
 | `onClick`       | func             | Instead of selecting the option, your onClick handler can do something else, like open an modal to edit the options (optional) |
 
 


### PR DESCRIPTION
 * MuiSuggest
   * Fixed how styles are applied for focused, disabled, and error states
   * Enabled the styling of `menuItem`, `menuItemHighlight`, and `menuItemIcon` classes
   * Renamed `muiIcon` class to `selectIcon`
   * Fixed a bug when `disableSelectOnBlur` prop was passed
   * Tweaked the behavior of `highlightFirstSuggestion()`
   * Added support for `inputRef` prop
 * MuiInput: Previously the field value was not updated until the user exited the input (`blur` event); now the value is updated as you type, enabling the form submit button sooner
 * Various components: Changed the type of component props to `PropTypes.oneOfType([PropTypes.node, PropTypes.elementType])`
 * Various components: Updated spacing to comply with linting rules
 * ScrollTrigger: Refined functionality
 * TooltipButton: Changed `buttonWrap` display to `inline-flex`
 * Datatable: Added support for the `label` column prop where you can pass text, or a React element
 * Component mixin: Updated list of fields in `cleanProps()`
 * EndAdornment: Tweaked button spacing
 * StartAdornment: Changed icon button to a `TooltipButton`
 * Countries: Added `getRegionCode()` function
 * FormSubmit: Tweaked button spacing
 * ThemeStyles: Fixed minor bugs
 * ModalTrigger: Now the trigger component is rendered using `instantiateComponent()`, the same as component props are rendered elsewhere