### PR TITLE
Multi HoC/Hook Returned Props

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/multi.js
+++ b/packages/vulcan-core/lib/modules/containers/multi.js
@@ -141,6 +141,7 @@ const buildResult = (options, { fragmentName, fragment, resolverName }, { setPag
   return {
     // see https://github.com/apollostack/apollo-client/blob/master/src/queries/store.ts#L28-L36
     // note: loading will propably change soon https://github.com/apollostack/apollo-client/issues/831
+    ...returnedProps,
     loading,
     loadingInitial,
     loadingMore,

--- a/packages/vulcan-core/lib/modules/containers/multi2.js
+++ b/packages/vulcan-core/lib/modules/containers/multi2.js
@@ -125,6 +125,7 @@ const buildResult = (
   return {
     // see https://github.com/apollostack/apollo-client/blob/master/src/queries/store.ts#L28-L36
     // note: loading will propably change soon https://github.com/apollostack/apollo-client/issues/831
+    ...returnedProps,
     loading,
     loadingInitial,
     loadingMore,


### PR DESCRIPTION
`withMulti`, `useMulti`, `withMulti2`, `useMulti2` should return all the props from Apollo Client's `useQuery`, including `startPolling`, `stopPolling`, etc.