### PR TITLE
update permissions for debug schemas

### DIFF
--- a/packages/vulcan-debug/lib/modules/callbacks/schema.js
+++ b/packages/vulcan-debug/lib/modules/callbacks/schema.js
@@ -1,68 +1,69 @@
 import { Callbacks } from 'meteor/vulcan:lib';
+import { readPermissions } from "../permissions";
 
 const schema = {
   name: {
     type: String,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
   iterator: {
     type: Object,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
   properties: {
     type: Array,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
   'properties.$': {
     type: Object,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
   // iterator: {
   //   label: 'Iterator',
   //   type: String,
-  //   canRead: ['admins'],
+  //   canRead: readPermissions,
   // },
 
   // options: {
   //   label: 'Options',
   //   type: Array,
-  //   canRead: ['admins'],
+  //   canRead: readPermissions,
   // },
 
   // 'options.$': {
   //   type: Object,
-  //   canRead: ['admins'],
+  //   canRead: readPermissions,
   // },
 
   runs: {
     type: String,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
   newSyntax: {
     label: 'New Syntax',
     type: Boolean,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
   returns: {
     label: 'Should Return',
     type: String,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
   description: {
     type: String,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
   hooks: {
     type: Array,
-    canRead: ['admins'],
+    canRead: readPermissions,
     resolveAs: {
       type: '[String]',
       resolver: callback => {

--- a/packages/vulcan-debug/lib/modules/emails/schema.js
+++ b/packages/vulcan-debug/lib/modules/emails/schema.js
@@ -1,23 +1,25 @@
+import { readPermissions } from "../permissions";
+
 const schema = {
 
   name: {
     type: String,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
   template: {
     type: String,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
   subject: {
     type: String,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
   testPath: {
     type: String,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
 };

--- a/packages/vulcan-debug/lib/modules/permissions.js
+++ b/packages/vulcan-debug/lib/modules/permissions.js
@@ -1,0 +1,1 @@
+export const readPermissions = ['guests', 'members'];

--- a/packages/vulcan-debug/lib/modules/settings/schema.js
+++ b/packages/vulcan-debug/lib/modules/settings/schema.js
@@ -1,33 +1,35 @@
+import { readPermissions } from "../permissions";
+
 const schema = {
 
   name: {
     label: 'Name',
     type: String,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
   value: {
     label: 'Value',
     type: Object,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
   defaultValue: {
     label: 'Default Value',
     type: Object,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
   isPublic: {
     label: 'Public',
     type: Boolean,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
   description: {
     label: 'Description',
     type: String,
-    canRead: ['admins'],
+    canRead: readPermissions,
   },
 
 };


### PR DESCRIPTION
Package: vulcan:debug
The previous permissions were `['admins']` which is problematic when you're not logged in. So now I've set it to `['guests', 'members']` (I was not sure that if you're logged, you're still part of the guests group). I also factorized it a little, putting all inside a single variable, located in a `permissions` file.
