### PR TITLE
i18n Plural Support

### DIFF
--- a/packages/vulcan-i18n/lib/modules/provider.js
+++ b/packages/vulcan-i18n/lib/modules/provider.js
@@ -3,7 +3,7 @@ import { getString } from 'meteor/vulcan:lib';
 import { intlShape } from './shape.js';
 
 export default class IntlProvider extends Component {
-  formatMessage = ({ id, defaultMessage }, values) => {
+  formatMessage = ({ id, defaultMessage }, values = null) => {
     const { messages, locale } = this.props;
     return getString({ id, defaultMessage, values, messages, locale });
   };


### PR DESCRIPTION
* Added support for pluralization in i18n strings using [ICU Message syntax used by react-intl](https://formatjs.io/docs/core-concepts/icu-syntax/#plural-format)
 * Changed the `values` parameter of `IntlProvider.formatMessage` optional