### PR TITLE
Material UI Minor Updates Nov 2020

### DIFF
--- a/packages/vulcan-ui-material/lib/components/forms/FormGroupDefault.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/FormGroupDefault.jsx
@@ -26,7 +26,7 @@ const styles = theme => ({
     paddingLeft: theme.spacing(0.5),
     marginTop: theme.spacing(5),
     marginBottom: theme.spacing(1),
-    color: theme.palette.primary[500],
+    color: theme.palette.primary.main,
   },
 
   collapsible: {

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/EndAdornment.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/EndAdornment.jsx
@@ -87,6 +87,7 @@ const EndAdornment = (props, context) => {
                 }}
                 tabIndex={-1}
                 aria-label={intl.formatMessage({ id: 'forms.delete_field' })}
+                disabled={!hasValue}
     >
       <CloseIcon/>
     </IconButton>;

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiCheckbox.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiCheckbox.jsx
@@ -1,6 +1,8 @@
 import { Components } from 'meteor/vulcan:lib';
 import React from 'react';
 import createReactClass from 'create-react-class';
+import StartAdornment, { hideStartAdornment } from './StartAdornment';
+import EndAdornment from './EndAdornment';
 import ComponentMixin from './mixins/component';
 import withStyles from '@material-ui/core/styles/withStyles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -18,6 +20,10 @@ export const styles = theme => ({
   inputFocused: {},
   
   inputDisabled: {},
+  
+  checkboxRoot: {},
+  
+  checkboxDisabled: {},
   
 });
 
@@ -43,9 +49,17 @@ const MuiCheckbox = createReactClass({
   },
   
   render: function () {
-    
-    const element = this.renderElement();
-    
+    const startAdornment = hideStartAdornment(this.props) ? null :
+      <StartAdornment {...this.props}
+                      classes={null}
+      />;
+    const endAdornment =
+      <EndAdornment {...this.props}
+                    classes={null}
+      />;
+  
+    const element = this.renderElement(startAdornment, endAdornment);
+  
     if (this.props.layout === 'elementOnly') {
       return element;
     }
@@ -58,13 +72,17 @@ const MuiCheckbox = createReactClass({
     );
   },
   
-  renderElement: function () {
-    const { classes } = this.props;
-    const { disabled, value, label } = this.props.inputProperties;
+  renderElement: function (startAdornment, endAdornment) {
+    const { classes, disabled, value, label } = this.props;
     
     return (
+      <>
+        {startAdornment}
       <FormControlLabel
-        className={classes.inputRoot}
+        classes={{
+          root: classes.inputRoot,
+          disabled: classes.inputDisabled,
+        }}
         control={
           <Checkbox
             ref={(c) => this.element = c}
@@ -73,10 +91,16 @@ const MuiCheckbox = createReactClass({
             checked={value === true}
             onChange={this.changeValue}
             disabled={disabled}
+            classes={{
+              root: classes.checkboxRoot,
+              disabled: classes.checkboxDisabled,
+            }}
           />
         }
         label={<>{label}<Components.RequiredIndicator optional={this.props.optional} value={value}/></>}
       />
+        {endAdornment}
+      </>
     );
   },
   

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiInput.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiInput.jsx
@@ -6,7 +6,7 @@ import ComponentMixin from './mixins/component';
 import MuiFormControl from './MuiFormControl';
 import MuiFormHelper from './MuiFormHelper';
 import Input from '@material-ui/core/Input';
-import StartAdornment, { hideStartAdornment } from './StartAdornment';
+import StartAdornment, {hideStartAdornment} from './StartAdornment';
 import EndAdornment from './EndAdornment';
 import _debounce from 'lodash/debounce';
 import classNames from 'classnames';
@@ -17,12 +17,12 @@ export const styles = theme => ({
   root: {},
 
   inputRoot: {
-    '& .clear-button.has-value': { opacity: 0 },
-    '&:hover .clear-button.has-value': { opacity: 0.54 },
+    '& .clear-button.has-value': {opacity: 0},
+    '&:hover .clear-button.has-value': {opacity: 0.54},
   },
 
   inputFocused: {
-    '& .clear-button.has-value': { opacity: 0.54 },
+    '& .clear-button.has-value': {opacity: 0.54},
   },
 
   inputDisabled: {},
@@ -83,12 +83,12 @@ const MuiInput = createReactClass({
   },
 
   getInitialState: function () {
-    this.changeValue = _debounce((value) => {
-        if (!this.props.handleChange) return;
-        if (value !== this.props.value) {
-          this.props.handleChange(value);
-        }
-      }, 500);
+    this.handleChangeDebounced = _debounce((value) => {
+      if (!this.props.handleChange) return;
+      if (value !== this.props.value) {
+        this.props.handleChange(value);
+      }
+    }, 500);
 
     if (this.props.refFunction) {
       this.props.refFunction(this);
@@ -99,41 +99,40 @@ const MuiInput = createReactClass({
     };
   },
 
-  UNSAFE_componentWillReceiveProps: function (nextProps) {
-    if (nextProps.value !== this.state.value) {
-      this.changeValue.flush();
-      this.setState({ value: nextProps.value });
+  componentDidUpdate(prevProps, prevState) {
+    if (this.props.value !== prevProps.value) {
+      this.handleChangeDebounced.cancel();
+      this.setState({ value: this.props.value });
     }
   },
 
-  handleChange: function (event) {
+  handleInputChange: function (event) {
     let value = event.target.value;
+    this.changeValue(value);
+  },
+
+  changeValue: function (value) {
     if (this.props.scrubValue) {
       value = this.props.scrubValue(value, this.props);
     }
     this.setState({ value });
 
-    this.changeValue(value);
-  },
-
-  handleBlur: function (event) {
-    const { value } = this.state;
-
-    this.changeValue(value);
-    this.changeValue.flush();
+    this.handleChangeDebounced(value);
   },
 
   render: function () {
     const startAdornment = hideStartAdornment(this.props) ? null :
-      <StartAdornment {...this.props}
-                      classes={null}
-                      changeValue={this.changeValue}
-      />;
+        <StartAdornment {...this.props}
+                        classes={null}
+                        value={this.state.value}
+                        changeValue={this.changeValue}
+        />;
     const endAdornment =
-      <EndAdornment {...this.props}
-                    classes={null}
-                    changeValue={this.changeValue}
-      />;
+        <EndAdornment {...this.props}
+                      classes={null}
+                      value={this.state.value}
+                      changeValue={this.changeValue}
+        />;
 
     let element = this.renderElement(startAdornment, endAdornment);
 
@@ -142,44 +141,44 @@ const MuiInput = createReactClass({
     }
 
     return (
-      <MuiFormControl {...this.getFormControlProperties()} htmlFor={this.getId()}>
-        {element}
-        <MuiFormHelper {...this.getFormHelperProperties()}/>
-      </MuiFormControl>
+        <MuiFormControl {...this.getFormControlProperties()}
+                        htmlFor={this.getId()}>
+          {element}
+          <MuiFormHelper {...this.getFormHelperProperties()}/>
+        </MuiFormControl>
     );
   },
 
   renderElement: function (startAdornment, endAdornment) {
-    const { classes, disabled, autoFocus, formatValue, label, multiline, rows, rowsMax, inputProps } = this.props;
+    const {classes, disabled, autoFocus, formatValue, label, multiline, rows, rowsMax, inputProps} = this.props;
     const value = formatValue ? formatValue(this.state.value) : this.state.value;
     const options = this.props.options || {};
 
     return (
-      <Input
-        ref={c => (this.element = c)}
-        id={this.getId()}
-        value={value || ''}
-        label={label}
-        onChange={this.handleChange}
-        onBlur={this.handleBlur}
-        disabled={disabled}
-        multiline={multiline}
-        rows={options.rows || rows}
-        rowsMax={options.rowsMax || rowsMax}
-        autoFocus={options.autoFocus || autoFocus}
-        startAdornment={startAdornment}
-        endAdornment={endAdornment}
-        placeholder={this.props.placeholder}
-        classes={{
-          root: classNames(classes.inputRoot, label === null && classes.inputNoLabel),
-          input: classes.inputInput,
-          focused: classes.inputFocused,
-          disabled: classes.inputDisabled,
-          multiline: classes.multiline,
-          inputMultiline: classes.inputMultiline,
-        }}
-        {...inputProps}
-      />
+        <Input
+            ref={c => (this.element = c)}
+            id={this.getId()}
+            value={value || ''}
+            label={label}
+            onChange={this.handleInputChange}
+            disabled={disabled}
+            multiline={multiline}
+            rows={options.rows || rows}
+            rowsMax={options.rowsMax || rowsMax}
+            autoFocus={options.autoFocus || autoFocus}
+            startAdornment={startAdornment}
+            endAdornment={endAdornment}
+            placeholder={this.props.placeholder}
+            classes={{
+              root: classNames(classes.inputRoot, label === null && classes.inputNoLabel),
+              input: classes.inputInput,
+              focused: classes.inputFocused,
+              disabled: classes.inputDisabled,
+              multiline: classes.multiline,
+              inputMultiline: classes.inputMultiline,
+            }}
+            {...inputProps}
+        />
     );
   },
 

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/SwitchBase.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/SwitchBase.jsx
@@ -28,7 +28,7 @@ export const styles = theme => ({
 });
 
 
-const MuiSwitch = createReactClass({
+const SwitchBase = createReactClass({
 
   mixins: [ComponentMixin],
 
@@ -107,4 +107,4 @@ const MuiSwitch = createReactClass({
 });
 
 
-export default withStyles(styles)(MuiSwitch);
+export default withStyles(styles)(SwitchBase);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Checkbox.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Checkbox.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import MuiSwitch from '../base-controls/MuiSwitch';
+import SwitchBase from '../base-controls/SwitchBase';
 import MuiCheckbox from '../base-controls/MuiCheckbox';
 import { registerComponent } from 'meteor/vulcan:core';
 
 const CheckboxComponent = ({ variant, refFunction, ...properties }) =>
-  variant == 'checkbox' ? <MuiCheckbox {...properties} ref={refFunction} /> : <MuiSwitch {...properties} ref={refFunction} />;
+  variant === 'checkbox' ?
+    <MuiCheckbox {...properties} ref={refFunction} /> :
+    <SwitchBase {...properties} ref={refFunction} />;
 
 registerComponent('FormComponentCheckbox', CheckboxComponent);


### PR DESCRIPTION
 * MuiInput: Improved the debounce functionality and fixed some edge cases
 * EndAdornment: Fixed bug: When the form control had an empty value the clear button would be hidden, but it was not disabled
 * MuiCheckbox: Added support for start and end adornment in the checkbox base control and added additional classes that can be overridden for cusomization
 * MuiSwitch: Renamed `MuiSwitch` component to `SwitchBase` because its name conflicted with the style sheet name of the core `Switch` component - we should rename all components in `vulcan:ui-material` that start with Mui