### PR TITLE
Form Component New Names

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -13,6 +13,7 @@ Please open an issue or a pull request if you feel this doc is incomplete.
 - `meteor update`
 - `meteor npm i --save string-similarity @apollo/client`
 - Migrate your code to Apollo client v3: https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/
+- Migrate the names of base form controls in `vulcan:ui-material` if import them into your code. See `Vulcan/packages/vulcan-ui-material/history.md`.
  
 ## From 1.15 to 1.16
 

--- a/packages/vulcan-ui-material/history.md
+++ b/packages/vulcan-ui-material/history.md
@@ -1,3 +1,27 @@
+1.16.0_2 / 2020-11-16
+=====================
+
+ * Base controls
+   * I have renamed components in `vulcan-ui-material/lib/components/forms/base-controls/` because their names conflict with the style sheet names (used for [Global theme overrides](https://material-ui.com/customization/components/#global-theme-override)) of some core MUI components - for example `MuiInput`.
+   * These components are not registered with `registerComponent`, only exported.
+   * This will be a breaking change for anyone who has built custom components based on these base controls using import - the file and component names have to be updated.
+   * The new names are:
+     * **/forms/helpers/**
+       * MuiFormControl => FormControlLayout
+       * MuiFormHelper => FormHelper
+       * MuiRequiredIndicator => RequiredIndicator
+     * **/forms/base-controls/**
+       * MuiCheckbox => FormCheckbox
+       * MuiCheckboxGroup => FormCheckboxGroup
+       * MuiInput => FormInput
+       * MuiPicker => FormPicker
+       * MuiRadioGroup => FormRadioGroup
+       * MuiSelect => FormSelect
+       * MuiSuggest => FormSuggest
+       * MuiSwitch => FormSwitch
+       * MuiText => FormText
+ * The sample **Theme styles** page now displays sample buttons in addition to typography and color palettes
+ 
 1.16.0_1 / 2020-10-24
 =====================
 

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/FormCheckbox.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/FormCheckbox.jsx
@@ -6,9 +6,9 @@ import EndAdornment from './EndAdornment';
 import ComponentMixin from './mixins/component';
 import withStyles from '@material-ui/core/styles/withStyles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Switch from '@material-ui/core/Switch';
-import MuiFormControl from './MuiFormControl';
-import MuiFormHelper from './MuiFormHelper';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormControlLayout from './FormControlLayout';
+import FormHelper from './FormHelper';
 
 
 export const styles = theme => ({
@@ -21,14 +21,14 @@ export const styles = theme => ({
 
   inputDisabled: {},
 
-  switchRoot: {},
+  checkboxRoot: {},
 
-  switchDisabled: {},
+  checkboxDisabled: {},
 
 });
 
 
-const SwitchBase = createReactClass({
+const FormCheckbox = createReactClass({
 
   mixins: [ComponentMixin],
 
@@ -65,10 +65,10 @@ const SwitchBase = createReactClass({
     }
 
     return (
-      <MuiFormControl {...this.getFormControlProperties()} hideLabel={true} htmlFor={this.getId()}>
+      <FormControlLayout {...this.getFormControlProperties()} hideLabel={true} htmlFor={this.getId()}>
         {element}
-        <MuiFormHelper {...this.getFormHelperProperties()}/>
-      </MuiFormControl>
+        <FormHelper {...this.getFormHelperProperties()}/>
+      </FormControlLayout>
     );
   },
 
@@ -78,27 +78,27 @@ const SwitchBase = createReactClass({
     return (
       <>
         {startAdornment}
-        <FormControlLabel
-          classes={{
-            root: classes.inputRoot,
-            disabled: classes.inputDisabled,
-          }}
-          control={
-            <Switch
-              classes={{
-                root: classes.switchRoot,
-                disabled: classes.switchDisabled,
-              }}
-              ref={(c) => this.element = c}
-              {...this.cleanSwitchProps(this.cleanProps(this.props))}
-              id={this.getId()}
-              checked={value === true}
-              onChange={this.changeValue}
-              disabled={disabled}
-            />
-          }
-          label={<>{label}<Components.RequiredIndicator optional={this.props.optional} value={value}/></>}
-        />
+      <FormControlLabel
+        classes={{
+          root: classes.inputRoot,
+          disabled: classes.inputDisabled,
+        }}
+        control={
+          <Checkbox
+            ref={(c) => this.element = c}
+            {...this.cleanSwitchProps(this.cleanProps(this.props))}
+            id={this.getId()}
+            checked={value === true}
+            onChange={this.changeValue}
+            disabled={disabled}
+            classes={{
+              root: classes.checkboxRoot,
+              disabled: classes.checkboxDisabled,
+            }}
+          />
+        }
+        label={<>{label}<Components.RequiredIndicator optional={this.props.optional} value={value}/></>}
+      />
         {endAdornment}
       </>
     );
@@ -107,4 +107,4 @@ const SwitchBase = createReactClass({
 });
 
 
-export default withStyles(styles)(SwitchBase);
+export default withStyles(styles)(FormCheckbox);

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/FormCheckboxGroup.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/FormCheckboxGroup.jsx
@@ -5,8 +5,8 @@ import ComponentMixin from './mixins/component';
 import withStyles from '@material-ui/core/styles/withStyles';
 import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import MuiFormControl from './MuiFormControl';
-import MuiFormHelper from './MuiFormHelper';
+import FormControlLayout from './FormControlLayout';
+import FormHelper from './FormHelper';
 import Checkbox from '@material-ui/core/Checkbox';
 import Switch from '@material-ui/core/Switch';
 import classNames from 'classnames';
@@ -126,7 +126,7 @@ const OtherComponent = ({ value: _values, path, updateCurrentValues }) => {
   );
 };
 
-const MuiCheckboxGroup = createReactClass({
+const FormCheckboxGroup = createReactClass({
   mixins: [ComponentMixin],
 
   propTypes: {
@@ -216,12 +216,12 @@ const MuiCheckboxGroup = createReactClass({
     }
 
     return (
-      <MuiFormControl {...this.getFormControlProperties()} fakeLabel={true}>
+      <FormControlLayout {...this.getFormControlProperties()} fakeLabel={true}>
         {this.renderElement()}
-        <MuiFormHelper {...this.getFormHelperProperties()} />
-      </MuiFormControl>
+        <FormHelper {...this.getFormHelperProperties()} />
+      </FormControlLayout>
     );
   },
 });
 
-export default withStyles(styles)(MuiCheckboxGroup);
+export default withStyles(styles)(FormCheckboxGroup);

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/FormControlLayout.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/FormControlLayout.jsx
@@ -8,7 +8,7 @@ import { Components, registerComponent } from 'meteor/vulcan:core';
 
 
 //noinspection JSUnusedGlobalSymbols
-const MuiFormControl = createReactClass({
+const FormControlLayout = createReactClass({
 
   propTypes: {
     label: PropTypes.node,
@@ -72,7 +72,7 @@ const MuiFormControl = createReactClass({
 });
 
 
-export default MuiFormControl;
+export default FormControlLayout;
 
 
-registerComponent('FormControl', MuiFormControl);
+registerComponent('FormControl', FormControlLayout);

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/FormHelper.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/FormHelper.jsx
@@ -22,7 +22,7 @@ export const styles = theme => ({
 });
 
 
-const MuiFormHelper = (props) => {
+const FormHelper = (props) => {
   const {
     className,
     classes,
@@ -64,7 +64,7 @@ const MuiFormHelper = (props) => {
 };
 
 
-MuiFormHelper.propTypes = {
+FormHelper.propTypes = {
   className: PropTypes.string,
   classes: PropTypes.object.isRequired,
   value: PropTypes.any,
@@ -73,4 +73,4 @@ MuiFormHelper.propTypes = {
 };
 
 
-export default withStyles(styles)(MuiFormHelper);
+export default withStyles(styles)(FormHelper);

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/FormInput.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/FormInput.jsx
@@ -33,7 +33,7 @@ export const styles = theme => ({
 
   inputInput: {},
 
-  multiline: {},
+  rootMultiline: {},
 
   inputMultiline: {},
 
@@ -174,7 +174,7 @@ const MuiInput = createReactClass({
               input: classes.inputInput,
               focused: classes.inputFocused,
               disabled: classes.inputDisabled,
-              multiline: classes.multiline,
+              multiline: classes.rootMultiline,
               inputMultiline: classes.inputMultiline,
             }}
             {...inputProps}

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/FormPicker.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/FormPicker.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import withStyles from '@material-ui/core/styles/withStyles';
 import ComponentMixin from './mixins/component';
-import MuiFormControl from './MuiFormControl';
-import MuiFormHelper from './MuiFormHelper';
+import FormControlLayout from './FormControlLayout';
+import FormHelper from './FormHelper';
 import TextField from '@material-ui/core/TextField';
 
 import moment from 'moment';
@@ -25,11 +25,11 @@ export const styles = theme => ({
 });
 
 //noinspection JSUnusedGlobalSymbols
-const MuiPicker = createReactClass({
+const FormPicker = createReactClass({
 
   mixins: [ComponentMixin],
 
-  displayName: 'MuiPicker',
+  displayName: 'FormPicker',
 
   propTypes: {
     type: PropTypes.oneOf([
@@ -64,7 +64,7 @@ const MuiPicker = createReactClass({
     const options = this.props.options || {};
 
     return (
-      <MuiFormControl {...this.getFormControlProperties()} htmlFor={this.getId()}>
+      <FormControlLayout {...this.getFormControlProperties()} htmlFor={this.getId()}>
         <TextField
             ref={c => (this.element = c)}
             {...this.cleanProps(this.props)}
@@ -76,11 +76,11 @@ const MuiPicker = createReactClass({
             placeholder={this.props.placeholder}
             classes={{ root: classes.inputRoot }}
         />
-        <MuiFormHelper {...this.getFormHelperProperties()}/>
-      </MuiFormControl>
+        <FormHelper {...this.getFormHelperProperties()}/>
+      </FormControlLayout>
     );
   }
 });
 
 
-export default withStyles(styles)(MuiPicker);
+export default withStyles(styles)(FormPicker);

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/FormRadioGroup.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/FormRadioGroup.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import ComponentMixin from './mixins/component';
 import withStyles from '@material-ui/core/styles/withStyles';
-import MuiFormControl from './MuiFormControl';
-import MuiFormHelper from './MuiFormHelper';
+import FormControlLayout from './FormControlLayout';
+import FormHelper from './FormHelper';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
@@ -14,7 +14,7 @@ import {
   addOtherMarker,
   isOtherValue,
   removeOtherMarker,
-} from './MuiCheckboxGroup';
+} from './FormCheckboxGroup';
 import isEmpty from 'lodash/isEmpty';
 import { Components } from 'meteor/vulcan:core';
 
@@ -202,7 +202,7 @@ const OtherComponent = ({value, path, updateCurrentValues, classes, key, disable
   );
 };
 
-const MuiRadioGroup = createReactClass({
+const FormRadioGroup = createReactClass({
   mixins: [ComponentMixin],
 
   propTypes: {
@@ -311,12 +311,12 @@ const MuiRadioGroup = createReactClass({
     }
 
     return (
-      <MuiFormControl {...this.getFormControlProperties()} fakeLabel={true}>
+      <FormControlLayout {...this.getFormControlProperties()} fakeLabel={true}>
         {this.renderElement()}
-        <MuiFormHelper {...this.getFormHelperProperties()} />
-      </MuiFormControl>
+        <FormHelper {...this.getFormHelperProperties()} />
+      </FormControlLayout>
     );
   },
 });
 
-export default withStyles(styles)(MuiRadioGroup);
+export default withStyles(styles)(FormRadioGroup);

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/FormSelect.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/FormSelect.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import ComponentMixin from './mixins/component';
-import MuiFormControl from './MuiFormControl';
-import MuiFormHelper from './MuiFormHelper';
+import FormControlLayout from './FormControlLayout';
+import FormHelper from './FormHelper';
 import Select from '@material-ui/core/Select';
 import Input from '@material-ui/core/Input';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -14,10 +14,10 @@ import StartAdornment, { hideStartAdornment } from './StartAdornment';
 import EndAdornment from './EndAdornment';
 import _isArray from 'lodash/isArray';
 import classNames from 'classnames';
-import { styles } from './MuiSuggest';
+import { styles } from './FormSuggest';
 
 
-const MuiSelect = createReactClass({
+const FormSelect = createReactClass({
 
   element: null,
 
@@ -85,10 +85,10 @@ const MuiSelect = createReactClass({
     }
 
     return (
-      <MuiFormControl{...this.getFormControlProperties()} htmlFor={this.getId()}>
+      <FormControlLayout{...this.getFormControlProperties()} htmlFor={this.getId()}>
         {this.renderElement()}
-        <MuiFormHelper {...this.getFormHelperProperties()}/>
-      </MuiFormControl>
+        <FormHelper {...this.getFormHelperProperties()}/>
+      </FormControlLayout>
     );
   },
 
@@ -200,4 +200,4 @@ const MuiSelect = createReactClass({
 });
 
 
-export default withStyles(styles)(MuiSelect);
+export default withStyles(styles)(FormSelect);

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/FormSuggest.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/FormSuggest.jsx
@@ -13,8 +13,8 @@ import parse from 'autosuggest-highlight/parse';
 import { registerComponent } from 'meteor/vulcan:core';
 import StartAdornment, { hideStartAdornment } from './StartAdornment';
 import EndAdornment from './EndAdornment';
-import MuiFormControl from './MuiFormControl';
-import MuiFormHelper from './MuiFormHelper';
+import FormControlLayout from './FormControlLayout';
+import FormHelper from './FormHelper';
 import _isEqual from 'lodash/isEqual';
 import classNames from 'classnames';
 import IsolatedScroll from 'react-isolated-scroll';
@@ -42,9 +42,9 @@ export const styles = theme => {
   const bottomLineColor = light ? 'rgba(0, 0, 0, 0.42)' : 'rgba(255, 255, 255, 0.7)';
 
   return {
-    
+
     root: {},
-    
+
     container: {
       flexGrow: 1,
       position: 'relative',
@@ -144,11 +144,17 @@ export const styles = theme => {
       paddingLeft: 0,
       fontSize: 17.15,
       cursor: 'pointer',
-      '&.Mui-disabled': {
+      '&$disabled': {
         pointerEvents: 'none',
       },
     },
-    
+
+    error: {},
+
+    disabled: {},
+
+    focused: {},
+
     underline: {
       '&:after': {
         borderBottom: `2px solid ${theme.palette.primary[light ? 'dark' : 'light']}`,
@@ -168,7 +174,7 @@ export const styles = theme => {
       '&:focus:after': {
         transform: 'scaleX(1)',
       },
-      '&.Mui-error:after': {
+      '&$error:after': {
         borderBottomColor: theme.palette.error.main,
         transform: 'scaleX(1)', // error is always underlined in red
       },
@@ -185,15 +191,19 @@ export const styles = theme => {
         }),
         pointerEvents: 'none', // Transparent to the hover style.
       },
-      '&:hover:not(.Mui-disabled):not(.Mui-focused):not(.Mui-error):before': {
+      '&:hover:not($disabled):not($focused):not($error):before': {
         borderBottom: `2px solid ${theme.palette.text.primary}`,
         // Reset on touch devices, it doesn't add specificity
         '@media (hover: none)': {
           borderBottom: `1px solid ${bottomLineColor}`,
         },
       },
-      '&.Mui-disabled:before': {
+      '&$disabled:before': {
         borderBottomStyle: 'dotted',
+        '@media print': {
+          borderBottomStyle: 'solid',
+          borderBottomWidth: 'thin',
+        },
       },
     },
 
@@ -218,17 +228,17 @@ export const styles = theme => {
     inputAdornment: {
       pointerEvents: 'none',
     },
-  
+
     menuItem: {},
-  
+
     menuItemHighlight: {},
-  
+
     menuItemIcon: {},
 
   };
 };
 
-const MuiSuggest = createReactClass({
+const FormSuggest = createReactClass({
   inputElement: null,
 
   mixins: [ComponentMixin],
@@ -333,7 +343,7 @@ const MuiSuggest = createReactClass({
     if (!this.props.disableSelectOnBlur) {
       const selectedOption = this.getSelectedOption();
       if (!selectedOption) return;
-      
+
       this.changeValue(selectedOption);
       const inputValue = this.getInputValue(this.props);
       this.setState({
@@ -421,13 +431,13 @@ const MuiSuggest = createReactClass({
     }
 
     return (
-      <MuiFormControl
+      <FormControlLayout
         {...this.getFormControlProperties()}
         shrinkLabel={inputFormatted && inputFormatted !== inputValue}
         htmlFor={this.getId()}>
         {element}
-        <MuiFormHelper {...this.getFormHelperProperties()} />
-      </MuiFormControl>
+        <FormHelper {...this.getFormHelperProperties()} />
+      </FormControlLayout>
     );
   },
 
@@ -493,6 +503,7 @@ const MuiSuggest = createReactClass({
       startAdornment,
       endAdornment,
       disabled,
+      errors,
       ...rest
     } = inputProps;
     const { hideLabel, inputRef } = this.props;
@@ -506,6 +517,8 @@ const MuiSuggest = createReactClass({
           className={classNames(
             classes.inputRoot,
             classes.underline,
+            disabled && classes.disabled,
+            errors?.length && classes.error,
             classes.formatted,
             hideLabel && classes.formattedNoLabel,
           )}>
@@ -630,5 +643,5 @@ const MuiSuggest = createReactClass({
 
 });
 
-export default withStyles(styles)(MuiSuggest);
-registerComponent('MuiSuggest', MuiSuggest, [withStyles, styles]);
+export default withStyles(styles)(FormSuggest);
+registerComponent('FormSuggest', FormSuggest, [withStyles, styles]);

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/FormSwitch.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/FormSwitch.jsx
@@ -6,48 +6,48 @@ import EndAdornment from './EndAdornment';
 import ComponentMixin from './mixins/component';
 import withStyles from '@material-ui/core/styles/withStyles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Checkbox from '@material-ui/core/Checkbox';
-import MuiFormControl from './MuiFormControl';
-import MuiFormHelper from './MuiFormHelper';
+import Switch from '@material-ui/core/Switch';
+import FormControlLayout from './FormControlLayout';
+import FormHelper from './FormHelper';
 
 
 export const styles = theme => ({
-  
+
   inputRoot: {
     height: 50,
   },
-  
+
   inputFocused: {},
-  
+
   inputDisabled: {},
-  
-  checkboxRoot: {},
-  
-  checkboxDisabled: {},
-  
+
+  switchRoot: {},
+
+  switchDisabled: {},
+
 });
 
 
-const MuiCheckbox = createReactClass({
-  
+const FormSwitch = createReactClass({
+
   mixins: [ComponentMixin],
-  
+
   getDefaultProps: function () {
     return {
       label: '',
       value: false
     };
   },
-  
+
   changeValue: function (event) {
     const target = event.target;
     const value = target.checked;
-    
+
     this.props.handleChange(value);
-    
+
     setTimeout(() => {document.activeElement.blur();});
   },
-  
+
   render: function () {
     const startAdornment = hideStartAdornment(this.props) ? null :
       <StartAdornment {...this.props}
@@ -57,54 +57,54 @@ const MuiCheckbox = createReactClass({
       <EndAdornment {...this.props}
                     classes={null}
       />;
-  
+
     const element = this.renderElement(startAdornment, endAdornment);
-  
+
     if (this.props.layout === 'elementOnly') {
       return element;
     }
-    
+
     return (
-      <MuiFormControl {...this.getFormControlProperties()} hideLabel={true} htmlFor={this.getId()}>
+      <FormControlLayout {...this.getFormControlProperties()} hideLabel={true} htmlFor={this.getId()}>
         {element}
-        <MuiFormHelper {...this.getFormHelperProperties()}/>
-      </MuiFormControl>
+        <FormHelper {...this.getFormHelperProperties()}/>
+      </FormControlLayout>
     );
   },
-  
+
   renderElement: function (startAdornment, endAdornment) {
     const { classes, disabled, value, label } = this.props;
-    
+
     return (
       <>
         {startAdornment}
-      <FormControlLabel
-        classes={{
-          root: classes.inputRoot,
-          disabled: classes.inputDisabled,
-        }}
-        control={
-          <Checkbox
-            ref={(c) => this.element = c}
-            {...this.cleanSwitchProps(this.cleanProps(this.props))}
-            id={this.getId()}
-            checked={value === true}
-            onChange={this.changeValue}
-            disabled={disabled}
-            classes={{
-              root: classes.checkboxRoot,
-              disabled: classes.checkboxDisabled,
-            }}
-          />
-        }
-        label={<>{label}<Components.RequiredIndicator optional={this.props.optional} value={value}/></>}
-      />
+        <FormControlLabel
+          classes={{
+            root: classes.inputRoot,
+            disabled: classes.inputDisabled,
+          }}
+          control={
+            <Switch
+              classes={{
+                root: classes.switchRoot,
+                disabled: classes.switchDisabled,
+              }}
+              ref={(c) => this.element = c}
+              {...this.cleanSwitchProps(this.cleanProps(this.props))}
+              id={this.getId()}
+              checked={value === true}
+              onChange={this.changeValue}
+              disabled={disabled}
+            />
+          }
+          label={<>{label}<Components.RequiredIndicator optional={this.props.optional} value={value}/></>}
+        />
         {endAdornment}
       </>
     );
   },
-  
+
 });
 
 
-export default withStyles(styles)(MuiCheckbox);
+export default withStyles(styles)(FormSwitch);

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/FormText.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/FormText.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import withStyles from '@material-ui/core/styles/withStyles';
 import ComponentMixin from './mixins/component';
-import MuiFormControl from './MuiFormControl';
-import MuiFormHelper from './MuiFormHelper';
+import FormControlLayout from './FormControlLayout';
+import FormHelper from './FormHelper';
 import Typography from '@material-ui/core/Typography';
 
 export const styles = theme => ({
@@ -19,12 +19,12 @@ export const styles = theme => ({
 });
 
 //noinspection JSUnusedGlobalSymbols
-const MuiText = createReactClass({
+const FormText = createReactClass({
   element: null,
 
   mixins: [ComponentMixin],
 
-  displayName: 'MuiText',
+  displayName: 'FormText',
 
   propTypes: {},
 
@@ -64,15 +64,15 @@ const MuiText = createReactClass({
     }
 
     return (
-      <MuiFormControl
+      <FormControlLayout
         {...this.getFormControlProperties()}
         shrinkLabel={true}
         htmlFor={this.getId()}>
         {element}
-        <MuiFormHelper {...this.getFormHelperProperties()} />
-      </MuiFormControl>
+        <FormHelper {...this.getFormHelperProperties()} />
+      </FormControlLayout>
     );
   },
 });
 
-export default withStyles(styles)(MuiText);
+export default withStyles(styles)(FormText);

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/RequiredIndicator.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/RequiredIndicator.jsx
@@ -6,22 +6,22 @@ import classNames from 'classnames';
 
 
 export const styles = theme => ({
-  
+
   root: {
     marginLeft: 4,
   },
-  
+
   missing: {
     color: theme.palette.error.main,
   },
-  
+
 });
 
 
-const MuiRequiredIndicator = (props) => {
+const RequiredIndicator = (props) => {
   const { classes, optional, value } = props;
   const className = classNames('required-indicator', 'optional-symbol', classes.root, !value && classes.missing);
-  
+
   return optional
     ?
     null
@@ -30,11 +30,11 @@ const MuiRequiredIndicator = (props) => {
 };
 
 
-MuiRequiredIndicator.propTypes = {
+RequiredIndicator.propTypes = {
   classes: PropTypes.object.isRequired,
   optional: PropTypes.bool,
   value: PropTypes.any,
 };
 
 
-registerComponent('RequiredIndicator', MuiRequiredIndicator, [withStyles, styles]);
+registerComponent('RequiredIndicator', RequiredIndicator, [withStyles, styles]);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Checkbox.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Checkbox.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import SwitchBase from '../base-controls/SwitchBase';
-import MuiCheckbox from '../base-controls/MuiCheckbox';
+import FormSwitch from '../base-controls/FormSwitch';
+import FormCheckbox from '../base-controls/FormCheckbox';
 import { registerComponent } from 'meteor/vulcan:core';
 
 const CheckboxComponent = ({ variant, refFunction, ...properties }) =>
   variant === 'checkbox' ?
-    <MuiCheckbox {...properties} ref={refFunction} /> :
-    <SwitchBase {...properties} ref={refFunction} />;
+    <FormCheckbox {...properties} ref={refFunction} /> :
+    <FormSwitch {...properties} ref={refFunction} />;
 
 registerComponent('FormComponentCheckbox', CheckboxComponent);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/CheckboxGroup.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/CheckboxGroup.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import MuiCheckboxGroup from '../base-controls/MuiCheckboxGroup';
+import FormCheckboxGroup from '../base-controls/FormCheckboxGroup';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
 const CheckboxGroupComponent = ({ refFunction, ...properties }) =>
-  <MuiCheckboxGroup {...properties} ref={refFunction}/>;
+  <FormCheckboxGroup {...properties} ref={refFunction}/>;
 
 
 registerComponent('FormComponentCheckboxGroup', CheckboxGroupComponent);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/CountrySelect.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/CountrySelect.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import MuiSuggest from '../base-controls/MuiSuggest';
+import FormSuggest from '../base-controls/FormSuggest';
 import { registerComponent } from 'meteor/vulcan:core';
 import { countries } from './countries';
 
 
 const CountrySelect = ({ refFunction, ...properties }) =>
-  <MuiSuggest {...properties} ref={refFunction} options={countries} limitToList={true}/>;
+  <FormSuggest {...properties} ref={refFunction} options={countries} limitToList={true}/>;
 
 
 registerComponent('CountrySelect', CountrySelect);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Date.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Date.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import MuiPicker from '../base-controls/MuiPicker';
+import FormPicker from '../base-controls/FormPicker';
 import { registerComponent } from 'meteor/vulcan:core';
 import withStyles from '@material-ui/core/styles/withStyles';
 
 
 export const styles = theme => ({
-  
+
   '@global': {
     'input[type=date]::-ms-clear, input[type=date]::-ms-reveal': {
       display: 'none',
@@ -20,17 +20,17 @@ export const styles = theme => ({
       display: 'none',
       '-webkit-appearance': 'none',
     },
-    
+
     'input[type="date"]::-webkit-inner-spin-button,input[type="date"]::-webkit-outer-spin-button': {
       '-webkit-appearance': 'none',
       margin: 0,
     },
   },
-  
+
 });
 
 const DateComponent = ({ refFunction, classes, ...properties }) =>
-  <MuiPicker {...properties} {...classes} ref={refFunction}/>;
+  <FormPicker {...properties} {...classes} ref={refFunction}/>;
 
 registerComponent('FormComponentDate', DateComponent, [withStyles, styles]);
 registerComponent('FormComponentDate2', DateComponent, [withStyles, styles]);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/DateTime.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/DateTime.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import MuiInput from '../base-controls/MuiInput';
+import FormInput from '../base-controls/FormInput';
 import { registerComponent } from 'meteor/vulcan:core';
 import withStyles from '@material-ui/core/styles/withStyles';
 
 
 export const styles = theme => ({
-  
+
   '@global': {
     'input[type=datetime]::-ms-clear, input[type=datetime]::-ms-reveal': {
       display: 'none',
@@ -20,18 +20,18 @@ export const styles = theme => ({
       display: 'none',
       '-webkit-appearance': 'none',
     },
-    
+
     'input[type="datetime"]::-webkit-inner-spin-button,input[type="datetime"]::-webkit-outer-spin-button': {
       '-webkit-appearance': 'none',
       margin: 0,
     },
   },
-  
+
 });
 
 
 const DateTimeComponent = ({ refFunction, classes, ...properties }) =>
-  <MuiInput {...properties} ref={refFunction} type="datetime-local"/>;
+  <FormInput {...properties} ref={refFunction} type="datetime-local"/>;
 
 
 registerComponent('FormComponentDateTime', DateTimeComponent, [withStyles, styles]);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Default.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Default.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import MuiInput from '../base-controls/MuiInput';
+import FormInput from '../base-controls/FormInput';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
 const Default = ({ refFunction, ...properties }) =>
-  <MuiInput {...properties} ref={refFunction}/>;
+  <FormInput {...properties} ref={refFunction}/>;
 
 
 registerComponent('FormComponentDefault', Default);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Email.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Email.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import MuiInput from '../base-controls/MuiInput';
+import FormInput from '../base-controls/FormInput';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
@@ -14,7 +14,7 @@ export const getUrl = function (value, props) {
 
 
 const EmailComponent = ({ refFunction, ...properties }) =>
-  <MuiInput {...properties} ref={refFunction} type="email" getUrl={getUrl}/>;
+  <FormInput {...properties} ref={refFunction} type="email" getUrl={getUrl}/>;
 
 
 registerComponent('FormComponentEmail', EmailComponent);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Number.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Number.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import MuiInput from '../base-controls/MuiInput';
+import FormInput from '../base-controls/FormInput';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
 const NumberComponent = ({ refFunction, ...properties }) =>
-  <MuiInput {...properties} ref={refFunction} type="number" />;
+  <FormInput {...properties} ref={refFunction} type="number" />;
 
 
 registerComponent('FormComponentNumber', NumberComponent);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Password.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Password.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import MuiInput from '../base-controls/MuiInput';
+import FormInput from '../base-controls/FormInput';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
 const Password = ({ refFunction, ...properties }) =>
-  <MuiInput {...properties} ref={refFunction} type='password'/>;
+  <FormInput {...properties} ref={refFunction} type='password'/>;
 
 
 registerComponent('FormComponentPassword', Password);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/PostalCode.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/PostalCode.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import MuiInput from '../base-controls/MuiInput';
+import FormInput from '../base-controls/FormInput';
 import { registerComponent } from 'meteor/vulcan:core';
 import { getCountryInfo } from './RegionSelect';
 
@@ -7,8 +7,8 @@ import { getCountryInfo } from './RegionSelect';
 const PostalCode = ({ classes, refFunction,  ...properties }) => {
   const currentCountryInfo = getCountryInfo(properties);
   const postalLabel = currentCountryInfo ? currentCountryInfo.postalLabel : 'Postal code';
-  
-  return <MuiInput {...properties} ref={refFunction} label={postalLabel}/>;
+
+  return <FormInput {...properties} ref={refFunction} label={postalLabel}/>;
 };
 
 

--- a/packages/vulcan-ui-material/lib/components/forms/controls/RadioGroup.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/RadioGroup.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import MuiRadioGroup from '../base-controls/MuiRadioGroup';
+import FormRadioGroup from '../base-controls/FormRadioGroup';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
 const RadioGroupComponent = ({ refFunction, ...properties }) => {
-  return <MuiRadioGroup {...properties} ref={refFunction}/>;
+  return <FormRadioGroup {...properties} ref={refFunction}/>;
 };
 
 

--- a/packages/vulcan-ui-material/lib/components/forms/controls/RegionSelect.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/RegionSelect.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import MuiSuggest from '../base-controls/MuiSuggest';
-import MuiInput from '../base-controls/MuiInput';
+import FormSuggest from '../base-controls/FormSuggest';
+import FormInput from '../base-controls/FormInput';
 import { registerComponent } from 'meteor/vulcan:core';
 import { countryInfo } from './countries';
 import _get from 'lodash/get';
@@ -19,11 +19,11 @@ const RegionSelect = ({ classes, refFunction, ...properties }) => {
   const currentCountryInfo = getCountryInfo(properties);
   const options = currentCountryInfo ? currentCountryInfo.regions : null;
   const regionLabel = currentCountryInfo ? currentCountryInfo.regionLabel : 'Region';
-  
+
   if (options) {
-    return <MuiSuggest {...properties} ref={refFunction} options={options} label={regionLabel}/>;
+    return <FormSuggest {...properties} ref={refFunction} options={options} label={regionLabel}/>;
   } else {
-    return <MuiInput {...properties} ref={refFunction} label={regionLabel}/>;
+    return <FormInput {...properties} ref={refFunction} label={regionLabel}/>;
   }
 };
 

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Select.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Select.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import MuiSelect from '../base-controls/MuiSelect';
+import FormSelect from '../base-controls/FormSelect';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
 const SelectComponent = ({ refFunction, ...properties }) => {
-  return <MuiSelect {...properties} ref={refFunction}/>;
+  return <FormSelect {...properties} ref={refFunction}/>;
 };
 
 

--- a/packages/vulcan-ui-material/lib/components/forms/controls/SelectMultiple.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/SelectMultiple.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import MuiSelect from '../base-controls/MuiSelect';
+import FormSelect from '../base-controls/FormSelect';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
 const SelectMultiple = ({ refFunction, ...properties }) => {
-  return <MuiSelect {...properties} multiple={true} ref={refFunction}/>;
+  return <FormSelect {...properties} multiple={true} ref={refFunction}/>;
 };
 
 

--- a/packages/vulcan-ui-material/lib/components/forms/controls/StaticText.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/StaticText.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import MuiText from '../base-controls/MuiText';
+import FormText from '../base-controls/FormText';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
 const StaticText = ({ refFunction, ...properties }) =>
-  <MuiText {...properties} ref={refFunction}/>;
+  <FormText {...properties} ref={refFunction}/>;
 
 
 registerComponent('FormComponentStaticText', StaticText);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Textarea.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Textarea.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import MuiInput from '../base-controls/MuiInput';
+import FormInput from '../base-controls/FormInput';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
 const TextareaComponent = ({ refFunction, inputProperties, ...properties }) =>
-  <MuiInput {...properties}
+  <FormInput {...properties}
             ref={refFunction}
             multiline={true}
             inputProperties={inputProperties}

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Time.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Time.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import MuiInput from '../base-controls/MuiInput';
+import FormInput from '../base-controls/FormInput';
 import { registerComponent } from 'meteor/vulcan:core';
 import withStyles from '@material-ui/core/styles/withStyles';
 
 
 export const styles = theme => ({
-  
+
   '@global': {
     'input[type=time]::-ms-clear, input[type=time]::-ms-reveal': {
       display: 'none',
@@ -20,18 +20,18 @@ export const styles = theme => ({
       display: 'none',
       '-webkit-appearance': 'none',
     },
-    
+
     'input[type="time"]::-webkit-inner-spin-button,input[type="time"]::-webkit-outer-spin-button': {
       '-webkit-appearance': 'none',
       margin: 0,
     },
   },
-  
+
 });
 
 
 const TimeComponent = ({ refFunction, classes, ...properties }) =>
-  <MuiInput {...properties} ref={refFunction} type="time"/>;
+  <FormInput {...properties} ref={refFunction} type="time"/>;
 
 
 registerComponent('FormComponentTime', TimeComponent, [withStyles, styles]);

--- a/packages/vulcan-ui-material/lib/components/forms/controls/Url.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/controls/Url.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import MuiInput from '../base-controls/MuiInput';
+import FormInput from '../base-controls/FormInput';
 import { registerComponent } from 'meteor/vulcan:core';
 
 
@@ -16,7 +16,7 @@ export const scrubValue = function (value, props) {
 
 
 const UrlComponent = ({ refFunction, ...properties }) =>
-  <MuiInput {...properties} ref={refFunction} scrubValue={scrubValue} type="url"/>;
+  <FormInput {...properties} ref={refFunction} scrubValue={scrubValue} type="url"/>;
 
 
 registerComponent('FormComponentUrl', UrlComponent);

--- a/packages/vulcan-ui-material/lib/components/index.js
+++ b/packages/vulcan-ui-material/lib/components/index.js
@@ -20,8 +20,8 @@ import './core/EditButton';
 import './core/Loading';
 import './core/NewButton';
 
-import './forms/base-controls/MuiRequiredIndicator';
-import './forms/base-controls/MuiFormControl';
+import './forms/base-controls/RequiredIndicator';
+import './forms/base-controls/FormControlLayout';
 
 import './forms/FormComponentInner';
 import './forms/FormErrors';

--- a/packages/vulcan-ui-material/lib/components/theme/ThemeStyles.jsx
+++ b/packages/vulcan-ui-material/lib/components/theme/ThemeStyles.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {registerComponent} from 'meteor/vulcan:core';
+import { registerComponent } from 'meteor/vulcan:core';
 import withTheme from '@material-ui/core/styles/withTheme';
 import withStyles from '@material-ui/core/styles/withStyles';
 import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import Divider from '@material-ui/core/Divider';
-import {getContrastRatio} from '@material-ui/core/styles/colorManipulator';
+import { getContrastRatio } from '@material-ui/core/styles/colorManipulator';
 import classNames from 'classnames';
+
 
 const describeTypography = (theme, className) => {
   const typography = className ? theme.typography[className] : theme.typography;
@@ -39,41 +41,46 @@ function getColorBlock(theme, classes, colorName, colorValue, colorTitle) {
   };
 
   return (
-      <div key={colorName+colorValue}>
-        {
-          colorValue.toString().match(/^(A100|light|contrastText)$/) &&
-          <div className={classes.blockSpace}/>
-        }
-        <li style={rowStyle} key={colorValue}>
-          {blockTitle}
-          <div className={classes.colorContainer}>
-            <span>{colorValue}</span>
-            <span className={classes.colorValue}>{bgColor.toUpperCase()}</span>
-          </div>
-        </li>
-      </div>
+    <div key={colorName + colorValue}>
+      {
+        colorValue.toString().match(/^(A100|light|contrastText)$/) &&
+        <div className={classes.blockSpace}/>
+      }
+      <li style={rowStyle} key={colorValue}>
+        {blockTitle}
+        <div className={classes.colorContainer}>
+          <span>{colorValue}</span>
+          <span className={classes.colorValue}>{bgColor.toUpperCase()}</span>
+        </div>
+      </li>
+    </div>
   );
 }
 
 function getColorGroup(options) {
-  const {theme, classes, color} = options;
+  const { theme, classes, color } = options;
   if (typeof theme.palette[color] !== 'object') return null;
 
   const cssColor = color.replace(' ', '').replace(color.charAt(0), color.charAt(0).toLowerCase());
   let colorsList = [];
-  colorsList = Object.keys(theme.palette[cssColor]).map(mainValue => getColorBlock(theme, classes, cssColor, mainValue));
+  colorsList =
+    Object.keys(theme.palette[cssColor]).map(mainValue => getColorBlock(theme, classes, cssColor, mainValue));
 
   return (
-      <ul className={classes.colorGroup} key={cssColor}>
-        {getColorBlock(theme, classes, cssColor, 500, true)}
-        <div className={classes.blockSpace}/>
-        {colorsList}
-      </ul>
+    <ul className={classes.colorGroup} key={cssColor}>
+      {getColorBlock(theme, classes, cssColor, 500, true)}
+      <div className={classes.blockSpace}/>
+      {colorsList}
+    </ul>
   );
 }
 
 const styles = theme => ({
-  root: {},
+  root: {
+    '& button + button': {
+      marginLeft: theme.spacing(2),
+    }
+  },
   paper: {
     padding: theme.spacing(3),
     marginTop: theme.spacing(3),
@@ -113,121 +120,146 @@ const styles = theme => ({
 const specialPalettes = ['common', 'text', 'action', 'grey'];
 
 const latin =
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur justo quam, ' +
-    'pellentesque ultrices ex a, aliquet porttitor ante. Donec tellus arcu, viverra ut lorem id, ' +
-    'ultrices ultricies enim. Donec enim metus, sollicitudin id lobortis id, iaculis ut arcu. ' +
-    'Maecenas sollicitudin congue nisi. Donec convallis, ipsum ac ultricies dignissim, orci ex ' +
-    'efficitur lectus, ac lacinia risus nunc at diam. Nam gravida bibendum lectus. Donec ' +
-    'scelerisque sem nec urna vestibulum vehicula.';
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur justo quam, ' +
+  'pellentesque ultrices ex a, aliquet porttitor ante. Donec tellus arcu, viverra ut lorem id, ' +
+  'ultrices ultricies enim. Donec enim metus, sollicitudin id lobortis id, iaculis ut arcu. ' +
+  'Maecenas sollicitudin congue nisi. Donec convallis, ipsum ac ultricies dignissim, orci ex ' +
+  'efficitur lectus, ac lacinia risus nunc at diam. Nam gravida bibendum lectus. Donec ' +
+  'scelerisque sem nec urna vestibulum vehicula.';
 
-const ThemeStyles = ({theme, classes}) => {
+const ThemeStyles = ({ theme, classes }) => {
   return (
-      <Grid container className={classNames('theme-styles', classes.root)}>
+    <Grid container className={classNames('theme-styles', classes.root)}>
 
-        <Grid item xs={12}>
-          <Typography
-              variant="h1">h1: {describeTypography(theme, 'h1')}</Typography>
-          <Typography
-              variant="h2">h2: {describeTypography(theme, 'h2')}</Typography>
-          <Typography
-              variant="h3">h3: {describeTypography(theme, 'h3')}</Typography>
-          <Typography
-              variant="h4">h4: {describeTypography(theme, 'h4')}</Typography>
-        </Grid>
-
-        <Grid item xs={12}>
-          <Paper className={classes.paper}>
-
-            <Typography variant="h5" gutterBottom>
-              h5: {describeTypography(theme, 'h5')}
-            </Typography>
-            <Typography variant="h6" gutterBottom>
-              h6: {describeTypography(theme, 'h6')}
-            </Typography>
-            <Typography variant="subtitle1" gutterBottom>
-              Subtitle1: {describeTypography(theme, 'subtitle1')}
-            </Typography>
-            <Typography variant="subtitle2" gutterBottom>
-              Subtitle2: {describeTypography(theme, 'subtitle2')}
-            </Typography>
-
-            <Divider className={classes.divider}/>
-
-            <Typography variant="body1" gutterBottom>
-              Body 1: {describeTypography(theme, 'body1')} - {latin}
-            </Typography>
-            <Typography variant="body1" gutterBottom>
-              {latin}
-            </Typography>
-
-            <Divider className={classes.divider}/>
-
-            <Typography variant="body2" gutterBottom>
-              Body 2: {describeTypography(theme, 'body2')} - {latin}
-            </Typography>
-            <Typography variant="body2" gutterBottom>
-              {latin}
-            </Typography>
-
-            <Divider className={classes.divider}/>
-
-            <Typography variant="button" gutterBottom>
-              Button - {describeTypography(theme)}
-            </Typography>
-
-            <Divider className={classes.divider}/>
-
-            <Typography variant="caption" gutterBottom>
-              Caption: {describeTypography(theme, 'caption')}
-            </Typography>
-
-            <Divider className={classes.divider}/>
-
-            <Typography variant="overline" gutterBottom>
-              Overline: {describeTypography(theme, 'overline')}
-            </Typography>
-
-            <Divider className={classes.divider}/>
-
-            <Typography gutterBottom>
-              Base: {describeTypography(theme)} - {latin}
-            </Typography>
-
-          </Paper>
-        </Grid>
-
-
-        {
-          Object.keys(theme.palette).map(color => {
-            if (specialPalettes.includes(color)) return null;
-
-            const colorGroup = getColorGroup({theme, classes, color});
-            if (!colorGroup) return null;
-
-            return (
-                <Grid item xs={12} sm={6} md={3}  key={color}>
-                  {colorGroup}
-                </Grid>
-            );
-          })
-        }
-
-        {
-          Object.keys(theme.palette).map(color => {
-            if (!specialPalettes.includes(color)) return null;
-
-            const colorGroup = getColorGroup({theme, classes, color});
-            if (!colorGroup) return null;
-
-            return (
-                <Grid item xs={12} sm={6} md={3}  key={color}>
-                  {colorGroup}
-                </Grid>
-            );
-          })
-        }
-
+      <Grid item xs={6}>
+        <Typography variant="h1">h1: {describeTypography(theme, 'h1')}</Typography>
+        <Typography variant="h2">h2: {describeTypography(theme, 'h2')}</Typography>
+        <Typography variant="h3">h3: {describeTypography(theme, 'h3')}</Typography>
+        <Typography variant="h4">h4: {describeTypography(theme, 'h4')}</Typography>
       </Grid>
+
+      <Grid item xs={12}>
+        <Paper className={classes.paper}>
+
+          <Grid container>
+
+            <Grid item xs={12} lg={6}>
+              <Typography variant="h5" gutterBottom>
+                h5: {describeTypography(theme, 'h5')}
+              </Typography>
+              <Typography variant="h6" gutterBottom>
+                h6: {describeTypography(theme, 'h6')}
+              </Typography>
+              <Typography variant="subtitle1" gutterBottom>
+                Subtitle1: {describeTypography(theme, 'subtitle1')}
+              </Typography>
+              <Typography variant="subtitle2" gutterBottom>
+                Subtitle2: {describeTypography(theme, 'subtitle2')}
+              </Typography>
+            </Grid>
+
+            <Grid item xs={12} lg={6}>
+              <p>
+                <Button variant="contained">Default</Button>
+                <Button variant="contained" color="primary">Primary</Button>
+                <Button variant="contained" color="secondary">Secondary</Button>
+                <Button variant="contained" disabled>Disabled</Button>
+              </p>
+
+              <p>
+                <Button>Default</Button>
+                <Button color="primary">Primary</Button>
+                <Button color="secondary">Secondary</Button>
+                <Button disabled>Disabled</Button>
+              </p>
+
+              <p>
+                <Button variant="outlined">Default</Button>
+                <Button variant="outlined" color="primary">Primary</Button>
+                <Button variant="outlined" color="secondary">Secondary</Button>
+                <Button variant="outlined" disabled>Disabled</Button>
+              </p>
+            </Grid>
+
+          </Grid>
+
+          <Divider className={classes.divider}/>
+
+          <Typography variant="body1" gutterBottom>
+            Body 1: {describeTypography(theme, 'body1')} - {latin}
+          </Typography>
+          <Typography variant="body1" gutterBottom>
+            {latin}
+          </Typography>
+
+          <Divider className={classes.divider}/>
+
+          <Typography variant="body2" gutterBottom>
+            Body 2: {describeTypography(theme, 'body2')} - {latin}
+          </Typography>
+          <Typography variant="body2" gutterBottom>
+            {latin}
+          </Typography>
+
+          <Divider className={classes.divider}/>
+
+          <Typography variant="button" gutterBottom>
+            Button - {describeTypography(theme)}
+          </Typography>
+
+          <Divider className={classes.divider}/>
+
+          <Typography variant="caption" gutterBottom>
+            Caption: {describeTypography(theme, 'caption')}
+          </Typography>
+
+          <Divider className={classes.divider}/>
+
+          <Typography variant="overline" gutterBottom>
+            Overline: {describeTypography(theme, 'overline')}
+          </Typography>
+
+          <Divider className={classes.divider}/>
+
+          <Typography gutterBottom>
+            Base: {describeTypography(theme)} - {latin}
+          </Typography>
+
+        </Paper>
+      </Grid>
+
+
+      {
+        Object.keys(theme.palette).map(color => {
+          if (specialPalettes.includes(color)) return null;
+
+          const colorGroup = getColorGroup({ theme, classes, color });
+          if (!colorGroup) return null;
+
+          return (
+            <Grid item xs={12} sm={6} md={3} key={color}>
+              {colorGroup}
+            </Grid>
+          );
+        })
+      }
+
+      {
+        Object.keys(theme.palette).map(color => {
+          if (!specialPalettes.includes(color)) return null;
+
+          const colorGroup = getColorGroup({ theme, classes, color });
+          if (!colorGroup) return null;
+
+          return (
+            <Grid item xs={12} sm={6} md={3} key={color}>
+              {colorGroup}
+            </Grid>
+          );
+        })
+      }
+
+    </Grid>
   );
 };
 

--- a/packages/vulcan-ui-material/lib/components/upload/UploadInner.jsx
+++ b/packages/vulcan-ui-material/lib/components/upload/UploadInner.jsx
@@ -4,9 +4,10 @@ import { Components, registerComponent, getComponent } from 'meteor/vulcan:lib';
 import Dropzone from 'react-dropzone';
 import withStyles from '@material-ui/core/styles/withStyles';
 import { FormattedMessage } from 'meteor/vulcan:i18n';
-import FormControl from '@material-ui/core/FormControl';
-import FormLabel from '@material-ui/core/FormLabel';
-import FormHelperText from '@material-ui/core/FormHelperText';
+import ComponentMixin from 'meteor/vulcan:ui-material/lib/components/forms/base-controls/mixins/component';
+import FormControlLayout from 'meteor/vulcan:ui-material/lib/components/forms/base-controls/FormControlLayout';
+import FormHelper from 'meteor/vulcan:ui-material/lib/components/forms/base-controls/FormHelper';
+import classNames from 'classnames';
 
 /*
 

--- a/packages/vulcan-ui-material/readme.md
+++ b/packages/vulcan-ui-material/readme.md
@@ -1,4 +1,4 @@
-# vulcan:ui-material 1.16.0_1
+# vulcan:ui-material 1.16.0_2
 
 Package initially created by [Erik Dakoda](https://github.com/ErikDakoda) ([`erikdakoda:vulcan-material-ui`](https://github.com/ErikDakoda/vulcan-material-ui))
 
@@ -231,9 +231,9 @@ import { getCountryLabel } from 'meteor/erikdakoda:vulcan-material-ui';
 </Typography>
 ```
 
-## MuiSuggest
+## FormSuggest
 
-**MuiSuggest** is a base control that you can use to build custom autosuggest controls. Refer to **CountrySelect** for an example.
+**FormSuggest** is a base control that you can use to build custom autosuggest controls. Refer to **CountrySelect** for an example.
 
 You can use the following additional props:
 
@@ -246,7 +246,7 @@ You can use the following additional props:
 | `disableMatchParts`   | bool   | Prevent highlighting of matched sub-strings |
 | `autoComplete`        | string | Autocomplete is turned off by default |
 
-In addition, the `options` that you pass to any select control have additional properties supported by **MuiSuggest**:
+In addition, the `options` that you pass to any select control have additional properties supported by **FormSuggest**:
 
 | Property              | Type   | Description  |
 | --------------------- | ------ | ------------ |


### PR DESCRIPTION
 * Base controls
   * I have renamed components in `vulcan-ui-material/lib/components/forms/base-controls/` because their names conflict with the style sheet names (used for [Global theme overrides](https://material-ui.com/customization/components/#global-theme-override)) of some core MUI components - for example `MuiInput`.
   * These components are not registered with `registerComponent`, only exported.
   * This will be a breaking change for anyone who has built custom components based on these base controls using import - the file and component names have to be updated.
   * The new names are:
     * **/forms/helpers/**
       * MuiFormControl => FormControlLayout
       * MuiFormHelper => FormHelper
       * MuiRequiredIndicator => RequiredIndicator
     * **/forms/base-controls/**
       * MuiCheckbox => FormCheckbox
       * MuiCheckboxGroup => FormCheckboxGroup
       * MuiInput => FormInput
       * MuiPicker => FormPicker
       * MuiRadioGroup => FormRadioGroup
       * MuiSelect => FormSelect
       * MuiSuggest => FormSuggest
       * MuiSwitch => FormSwitch
       * MuiText => FormText
 * The sample **Theme styles** page now displays sample buttons in addition to typography and color palettes