### PR TITLE
add to storybook plugin-proposal-optional-chaining to accept component.jsx

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -128,7 +128,8 @@ module.exports = ({ config }) => {
           presets: ['@babel/react', {
             plugins: [
               '@babel/plugin-proposal-class-properties',
-              '@babel/plugin-syntax-dynamic-import'
+              '@babel/plugin-syntax-dynamic-import',
+              '@babel/plugin-proposal-optional-chaining'
             ]
           }],
         }


### PR DESCRIPTION
The use of the optional chaining `?.` in `component.jsx` stops storybook working, I added the babel plugin to make it work

https://github.com/VulcanJS/Vulcan/blob/devel/packages/vulcan-ui-material/lib/components/forms/base-controls/mixins/component.jsx