### PR TITLE
add init callback to smartform

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -137,10 +137,11 @@ const getInitialStateFromProps = nextProps => {
 class SmartForm extends Component {
   constructor(props) {
     super(props);
-
+    const state = getInitialStateFromProps(props);
     this.state = {
-      ...getInitialStateFromProps(props),
+      ...state,
     };
+    if(props.initCallback) props.initCallback(state.currentDocument);
   }
 
   defaultValues = {};
@@ -651,7 +652,9 @@ class SmartForm extends Component {
   UNSAFE_componentWillReceiveProps(nextProps) {
     const needReset = !!RESET_PROPS.find(prop => !isEqual(this.props[prop], nextProps[prop]));
     if (needReset) {
-      this.setState(getInitialStateFromProps(nextProps));
+      const newState = getInitialStateFromProps(nextProps);
+      this.setState(newState);
+      if (nextProps.initCallback) nextProps.initCallback(newState.currentDocument);
     }
   }
 

--- a/packages/vulcan-forms/lib/components/propTypes.js
+++ b/packages/vulcan-forms/lib/components/propTypes.js
@@ -37,6 +37,7 @@ export const groupProps = {
 };
 
 export const callbackProps = {
+  initCallback: PropTypes.func,
   changeCallback: PropTypes.func,
   submitCallback: PropTypes.func,
   successCallback: PropTypes.func,


### PR DESCRIPTION
Smartform can now take an `initCallback` prop, similar to the `changeCallback` prop.
This initCallback runs on form init and on form "reset".
I'm doing a component that has a preview of the object currently edited, for that I need to get the form's current document. I realized that `changeCallback` did not run on init, so my preview was empty until i changed something to the form, triggering the change.