### PR TITLE
React Node Support in getString()

### DIFF
--- a/packages/vulcan-lib/test/index.js
+++ b/packages/vulcan-lib/test/index.js
@@ -1,8 +1,8 @@
 import './components.test.js';
-
-//import './schema_utils.test';
-import './handleOptions.test.js';
-import './utils.test.js';
-import './routes.test';
 import './documentValidation.test';
+import './handleOptions.test.js';
+import './intl.test.js';
 import './mongoParams.test';
+import './routes.test';
+//import './schema_utils.test';
+import './utils.test.js';

--- a/packages/vulcan-lib/test/intl.test.js
+++ b/packages/vulcan-lib/test/intl.test.js
@@ -1,6 +1,8 @@
+import React from 'react';
 import expect from 'expect';
-import { addStrings, Utils } from 'meteor/vulcan:core';
-import { formatLabel } from '../lib/modules/intl';
+import {addStrings, Strings, Utils} from 'meteor/vulcan:core';
+import {formatLabel, getString} from '../lib/modules/intl';
+import { shallow } from 'enzyme';
 
 // constants for formatLabel
 const fieldName = 'testFieldName';
@@ -43,35 +45,104 @@ addStrings('en', {
   [`${collectionName.toLowerCase()}.${fieldNameForCollection}`]: labelFromCollection,
 });
 
-describe('vulcan:lib/intl', function() {
-  
-  describe('formatLabel', function() {
+const intl = {
+  formatMessage: ({id, defaultMessage}, values = null) => {
+    return getString({id, defaultMessage, values, messages: Strings, locale: 'en'});
+  }
+}
 
-    it('return the fieldName when there is no matching string or label', function() {
-      const ENString = formatLabel({ fieldName: unknownFieldName, schema, collectionName });
+describe('vulcan:lib/intl', function () {
+
+  describe('formatLabel', function () {
+
+    it('return the fieldName when there is no matching string or label', function () {
+      const ENString = formatLabel({fieldName: unknownFieldName, schema, collectionName, intl});
       expect(ENString).toEqual(Utils.camelToSpaces(unknownFieldName));
     });
-    
-    it('return the matching schema label when there is no matching string', function() {
-      const ENString = formatLabel({ fieldName: fieldNameForSchema, schema, collectionName });
+
+    it('return the matching schema label when there is no matching string', function () {
+      const ENString = formatLabel({fieldName: fieldNameForSchema, schema, collectionName, intl});
       expect(ENString).toEqual(schema[fieldName].label);
     });
-    
-    it('return the label from a matched `fieldName`', function() {
-      const ENString = formatLabel({ fieldName, schema, collectionName });
+
+    it('return the label from a matched `fieldName`', function () {
+      const ENString = formatLabel({fieldName, schema, collectionName, intl});
       expect(ENString).toEqual(labelFromFieldName);
     });
-    
-    it('return the label from a matched `global.fieldName`', function() {
-      const ENString = formatLabel({ fieldName: fieldNameForGlobal, schema, collectionName });
+
+    it('return the label from a matched `global.fieldName`', function () {
+      const ENString = formatLabel({fieldName: fieldNameForGlobal, schema, collectionName, intl});
       expect(ENString).toEqual(labelFromGlobal);
     });
-    
-    it('return the label from a matched `collectionName.fieldName`', function() {
-      const ENString = formatLabel({ fieldName: fieldNameForCollection, schema, collectionName });
+
+    it('return the label from a matched `collectionName.fieldName`', function () {
+      const ENString = formatLabel({fieldName: fieldNameForCollection, schema, collectionName, intl});
       expect(ENString).toEqual(labelFromCollection);
     });
-    
+
   });
-  
+
+  describe('getString', function () {
+
+    it('returns a simple string', function () {
+      const id = 'simple';
+      const string = 'This is an intl string with no values';
+      const expected = string;
+      addStrings('en', {[id]: string});
+
+      const ENString = getString({id, messages: Strings, locale: 'en'});
+      expect(ENString).toEqual(expected);
+    });
+
+    it('substitutes string values passed', function () {
+      const id = 'withStringValue';
+      const string = 'This is an intl string with {type} values';
+      const values = {
+        type: 'string'
+      };
+      const expected = 'This is an intl string with string values';
+      addStrings('en', {[id]: string});
+
+      const ENString = getString({id, values, messages: Strings, locale: 'en'});
+      expect(ENString).toEqual(expected);
+    });
+
+    it('substitutes plural values passed', function () {
+      const id = 'withPluralValue';
+      const string = 'You have {itemCount, plural, =0 {no items} one {# item} other {# items}}.';
+      const expectedWithZero = 'You have no items.';
+      const expectedWithOne = 'You have 1 item.';
+      const expectedWithOther = 'You have 3 items.';
+      addStrings('en', {[id]: string});
+
+      const ENString1 = getString({id, values: { itemCount: 0 }, messages: Strings, locale: 'en'});
+      expect(ENString1).toEqual(expectedWithZero);
+
+      const ENString2 = getString({id, values: { itemCount: 1 }, messages: Strings, locale: 'en'});
+      expect(ENString2).toEqual(expectedWithOne);
+
+      const ENString3 = getString({id, values: { itemCount: 3 }, messages: Strings, locale: 'en'});
+      expect(ENString3).toEqual(expectedWithOther);
+    });
+
+    it('substitutes react node values passed', function () {
+      const id = 'withNodeValue';
+      const string = 'To learn more, see {link}';
+      const values = {
+        link: <a href="https://docs.vulcanjs.org/unit-testing.html" className="link">Vulcan Docs</a>,
+      };
+      const expected = ['To learn more, see ', values.link];
+      addStrings('en', {[id]: string});
+
+      const ENResult = getString({id, values, messages: Strings, locale: 'en'});
+      expect(Array.isArray(ENResult)).toBeTruthy();
+      expect(ENResult).toHaveLength(2);
+      expect(ENResult[0]).toEqual(expected[0]);
+
+      const wrapper = shallow(<span>{ENResult}</span>);
+      expect(wrapper.find('.link')).toHaveLength(1);
+    });
+
+  });
+
 });


### PR DESCRIPTION
 * In the values object you pass to `getString()` you can now use React nodes, in addition to simple strings, enabling the embedding of HTML tags, images, etc.
 * Activated unit tests for `vulcan:lib/intl/formatLabel`
 * Added unit tests for `vulcan:lib/intl/getString`