### PR TITLE
Feature RTL support in locale

### DIFF
--- a/packages/vulcan-core/lib/modules/components/App.jsx
+++ b/packages/vulcan-core/lib/modules/components/App.jsx
@@ -147,6 +147,8 @@ class App extends PureComponent {
     if (document && typeof document.getElementsByTagName === "function" && document.getElementsByTagName("html")) {
       const htmlTag = document.getElementsByTagName("html");
       if (htmlTag && htmlTag.length === 1) {
+        // change in locale didn't change the html lang as well, which is fixed by this PR
+        htmlTag[0].lang = localeId;
         if (localeObject?.rtl === true) {
           htmlTag[0].classList.add("rtl")
         } else {

--- a/packages/vulcan-core/lib/modules/components/App.jsx
+++ b/packages/vulcan-core/lib/modules/components/App.jsx
@@ -74,6 +74,7 @@ class App extends PureComponent {
     this.state = {
       locale: {
         id: locale.id,
+        rtl: locale.rtl ?? false,
         method: locale.method,
         loading: false,
         strings: merge({}, loadedStrings, bundledStrings),
@@ -137,12 +138,23 @@ class App extends PureComponent {
 
     // if this is a dynamic locale, fetch its data from the server
     if (localeObject.dynamic) {
-      this.setState({ locale: { ...this.state.locale, loading: true } });
+      this.setState({ locale: { ...this.state.locale, loading: true, rtl: localeObject?.rtl ?? false } });
       localeStrings = await this.loadLocaleStrings(localeId);
     } else {
       localeStrings = getStrings(localeId);
     }
-    this.setState({ locale: { ...this.state.locale, loading: false, id: localeId, strings: localeStrings } });
+    // before removing the loading we have to change the rtl class on HTML tag if it exists
+    if (document && typeof document.getElementsByTagName === "function" && document.getElementsByTagName("html")) {
+      const htmlTag = document.getElementsByTagName("html");
+      if (htmlTag && htmlTag.length === 1) {
+        if (localeObject?.rtl === true) {
+          htmlTag[0].classList.add("rtl")
+        } else {
+          htmlTag[0].classList.remove("rtl")
+        }
+      }
+    }
+    this.setState({ locale: { ...this.state.locale, loading: false, id: localeId, rtl: localeObject?.rtl ?? false, strings: localeStrings } });
 
     cookies.remove('locale', { path: '/' });
     cookies.set('locale', localeId, { path: '/' });

--- a/packages/vulcan-lib/lib/server/apollo-server/context.js
+++ b/packages/vulcan-lib/lib/server/apollo-server/context.js
@@ -19,6 +19,7 @@ import { GraphQLSchema } from '../graphql/index.js';
 import _merge from 'lodash/merge';
 import { getUser } from 'meteor/apollo';
 import { getHeaderLocale } from '../intl.js';
+import { getLocale } from '../../modules/intl.js';
 import { getSetting } from '../../modules/settings.js';
 import { WebApp } from 'meteor/webapp';
 
@@ -116,12 +117,17 @@ export const computeContextFromReq = (currentContext, customContextFromReq) => {
     }
 
     context.locale = getHeaderLocale(headers, context.currentUser && context.currentUser.locale);
+    const locale = getLocale(context.locale);
 
     // see https://forums.meteor.com/t/can-i-edit-html-tag-in-meteor/5867/7
     WebApp.addHtmlAttributeHook(function() {
-      return {
-        lang: context.locale,
+      let htmlAttributes = {
+        lang: context.locale
       };
+      if (locale?.rtl === true) {
+        htmlAttributes.class = 'rtl';
+      }
+      return htmlAttributes;
     });
 
     return context;


### PR DESCRIPTION
This is for the RTL Support the ticket I have created https://github.com/VulcanJS/Vulcan/issues/2669
Could you please check it carefully, as I don't have slightest idea about the impacts, but it's working fine on my local project for translations of StateOfJS ;) 
https://github.com/StateOfJS/state-of-js-graphql-results-api/issues/50
After checking the code, I had come to the conclusion that without this, the RTL support was not possible at all.
This is just the beginning and give the developer the opportunity by usage of RTL class in HTML to do custom CSS if needed ;) 