### PR TITLE
Query filters to mongo params

### DIFF
--- a/packages/vulcan-core/lib/modules/decorators/autocomplete.js
+++ b/packages/vulcan-core/lib/modules/decorators/autocomplete.js
@@ -1,4 +1,4 @@
-import { getCollectionByTypeName, isEmptyOrUndefined, fieldDynamicQueryTemplate, fieldStaticQueryTemplate, autocompleteQueryTemplate } from 'meteor/vulcan:core';
+import { getCollectionByTypeName, fieldDynamicQueryTemplate, autocompleteQueryTemplate } from 'meteor/vulcan:core';
 import get from 'lodash/get';
 
 const getQueryResolverName = field => {
@@ -27,7 +27,7 @@ export const makeAutocomplete = (field = {}, options = {}) => {
   if (!autocompletePropertyName) {
     throw new Error('makeAutocomplete decorator is missing an autocompletePropertyName option.');
   }
-  
+
   // if field stores an array, use multi autocomplete
   const isMultiple = multi || field.type === Array;
 

--- a/packages/vulcan-lib/lib/modules/utils.js
+++ b/packages/vulcan-lib/lib/modules/utils.js
@@ -579,7 +579,6 @@ Utils.getSchemaFieldAllowedValues = schemaFieldOptionsArray => {
  */
 Utils.getFieldType = field => get(field, 'type.definitions.0.type');
 
-
 /**
  * Convert an array of field names into a Mongo fields specifier
  * @param {Array} fieldsArray
@@ -593,10 +592,13 @@ Utils.arrayToFields = fieldsArray => {
   );
 };
 
-export const isEmptyOrUndefined = value =>
+Utils.isEmptyOrUndefined = value =>
   typeof value === 'undefined' ||
   value === null ||
   value === '' ||
-  (typeof value === 'object' && isEmpty(value) && !(value instanceof Date));
-
-Utils.isEmptyOrUndefined = isEmptyOrUndefined;
+  (
+    typeof value === 'object' &&
+    isEmpty(value) &&
+    !(value instanceof Date) &&
+    !(value instanceof RegExp)
+  );

--- a/packages/vulcan-lib/lib/modules/utils.js
+++ b/packages/vulcan-lib/lib/modules/utils.js
@@ -595,7 +595,7 @@ Utils.arrayToFields = fieldsArray => {
 Utils.isEmptyOrUndefined = value =>
   typeof value === 'undefined' ||
   value === null ||
-  value === '' ||
+  //value === '' ||
   (
     typeof value === 'object' &&
     isEmpty(value) &&

--- a/packages/vulcan-lib/lib/server/graphql/typedefs.js
+++ b/packages/vulcan-lib/lib/server/graphql/typedefs.js
@@ -4,7 +4,7 @@
 
 
 // schema generation
-const generateQueryType = (queries = []) => 
+const generateQueryType = (queries = []) =>
   queries.length === 0
   ? ''
   : `type Query {
@@ -23,7 +23,7 @@ ${queries
 }
   `;
 
-const generateMutationType = (mutations = []) => 
+const generateMutationType = (mutations = []) =>
   mutations.length === 0
   ? ''
   : `type Mutation {
@@ -52,26 +52,27 @@ scalar Date
 
 input String_Selector {
   _eq: String
-  #_gt: String
-  #_gte: String
-  #_ilike: String
+  _gt: String
+  _gte: String
   _in: [String!]
+  _nin: [String!]
   _is_null: Boolean
   _like: String
-  #_lt: String
-  #_lte: String
-  #_neq: String
+  _lt: String
+  _lte: String
+  _neq: String
+  #_ilike: String
   #_nilike: String
-  #_nin: [String!]
   #_nlike: String
-  #_nsimilar: String
   #_similar: String
+  #_nsimilar: String
 }
 
 input String_Array_Selector {
   _in: [String!]
+  _nin: [String!]
   _contains: String
-  # _contains_all: [String_Selector]
+  _contains_all: [String_Selector]
 }
 
 input Int_Selector {
@@ -79,16 +80,18 @@ input Int_Selector {
   _gt: Int
   _gte: Int
   _in: [Int!]
-  #_is_null: Boolean
+  _nin: [Int!]
+  _is_null: Boolean
   _lt: Int
   _lte: Int
-  #_neq: Int
-  #_nin: [Int!]
+  _neq: Int
 }
 
 input Int_Array_Selector {
-  contains: Int_Selector
-  # contains_all: [Int_Selector]
+  _in: [Int!]
+  _nin: [Int!]
+  _contains: Int_Selector
+  _contains_all: [Int_Selector]
 }
 
 input Float_Selector {
@@ -96,26 +99,27 @@ input Float_Selector {
   _gt: Float
   _gte: Float
   _in: [Float!]
-  #_is_null: Boolean
+  _nin: [Float!]
+  _is_null: Boolean
   _lt: Float
   _lte: Float
-  #_neq: Float
-  #_nin: [Float!]
+  _neq: Float
 }
 
 input Float_Array_Selector {
-  contains: Float_Selector
-  # contains_all: [Float_Selector]
+  _in: [Int!]
+  _nin: [Int!]
+  _contains: Float_Selector
+  _contains_all: [Float_Selector]
 }
 
 input Boolean_Selector {
   _eq: Boolean
-  #_neq: Boolean
+  _neq: Boolean
 }
 
 input Boolean_Array_Selector {
-  contains: Boolean_Selector
-  # contains_all: [Boolean_Selector]
+  _contains: Boolean_Selector
 }
 
 input Date_Selector {
@@ -123,16 +127,16 @@ input Date_Selector {
   _gt: Date
   _gte: Date
   _in: [Date!]
-  #_is_null: Boolean
+  _nin: [Date!]
+  _is_null: Boolean
   _lt: Date
   _lte: Date
-  #_neq: Date
-  #_nin: [Date!]
+  _neq: Date
 }
 
 input Date_Array_Selector {
-  contains: Date_Selector
-  # contains_all: [Date_Selector]
+  _contains: Date_Selector
+  _contains_all: [Date_Selector]
 }
 
 # column ordering options

--- a/packages/vulcan-lib/test/mongoParams.test.js
+++ b/packages/vulcan-lib/test/mongoParams.test.js
@@ -1,23 +1,18 @@
 import expect from 'expect';
-import { filterFunction } from '../lib/modules/mongoParams';
-import { createDummyCollection } from 'meteor/vulcan:test';
+import {filterFunction} from '../lib/modules/mongoParams';
+import {createDummyCollection, initServerTest} from 'meteor/vulcan:test';
 
 const test = it;
 
-describe('vulcan:lib/mongoParams', () => {
-  test('keep multiple filters', async () => {
-    const filter = {
-      _id: { _gte: 1, _lte: 5 },
-    };
-    const input = {
-      filter,
-    };
-    const expectedFilter = { _id: { $gte: 1, $lte: 5 } };
-    const mongoParams = await filterFunction(createDummyCollection({}), input);
-    expect(mongoParams.selector).toEqual(expectedFilter);
-  });
-  describe('boolean operators', () => {
-    const collection = createDummyCollection({
+const mayTheFourth = new Date('1977-05-04T22:00:00');
+const summerSolstice = new Date('1972-06-20T12:41:00');
+
+describe.only('vulcan:lib/mongoParams', function () {
+
+  let collection;
+
+  before(async function () {
+    collection = createDummyCollection({
       schema: {
         _id: {
           type: String,
@@ -27,22 +22,738 @@ describe('vulcan:lib/mongoParams', () => {
           type: String,
           canRead: ['admins'],
         },
-        length: {
+        age: {
+          type: Number,
+          canRead: ['admins'],
+        },
+        withTheForce: {
+          type: Boolean,
+          canRead: ['admins'],
+        },
+        birthday: {
+          type: Date,
+          canRead: ['admins'],
+        },
+        friends: {
+          type: Array,
+          canRead: ['admins'],
+        },
+        'friends.$': {
+          type: String,
+          canRead: ['admins'],
+        },
+        agesOfFriends: {
+          type: Array,
+          canRead: ['admins'],
+        },
+        'agesOfFriends.$': {
+          type: Number,
+          canRead: ['admins'],
+        },
+        scores: {
+          type: Array,
+          canRead: ['admins'],
+        },
+        'scores.$': {
+          type: Number,
+          canRead: ['admins'],
+        },
+        forcesOfFriends: {
+          type: Array,
+          canRead: ['admins'],
+        },
+        'forcesOfFriends.$': {
+          type: Number,
+          canRead: ['admins'],
+        },
+        birthdaysOfFriends: {
+          type: Array,
+          canRead: ['admins'],
+        },
+        'birthdaysOfFriends.$': {
           type: Number,
           canRead: ['admins'],
         },
       },
+      results: [{
+        _id: "1", name: 'Han', age: 140, withTheForce: false,
+        birthday: summerSolstice, friends: ['Leia', 'Luke'], scores: [1.1, 1.2],
+      }, {
+        _id: "2", name: 'Leia', age: 120, withTheForce: true,
+        birthday: mayTheFourth, friends: ['Luke'], scores: [1.1],
+      }, {
+        _id: "3", name: 'Luke', age: 100, withTheForce: true,
+        birthday: mayTheFourth, friends: ['Leia'], scores: [1.2],
+      }, {
+        _id: "4", name: 'Obi-Wan', age: null, withTheForce: true,
+        birthday: new Date('1496-05-04T22:00:00'),
+      },
+      ]
     });
-    test('handle _and at root', async () => {
+  })
+
+  describe('string selector', async function () {
+
+    test('string selector _eq', async function () {
+      const input = {
+        filter: {
+          name: {_eq: 'Han'},
+        }
+      };
+      const expectedFilter = {name: {$eq: 'Han'}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('string selector _gt', async function () {
+      const input = {
+        filter: {
+          name: {_gt: 'Han'},
+        }
+      };
+      const expectedFilter = {name: {$gt: 'Han'}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('string selector _gte', async function () {
+      const input = {
+        filter: {
+          name: {_gte: 'Han'},
+        }
+      };
+      const expectedFilter = {name: {$gte: 'Han'}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('string selector _in', async function () {
+      const input = {
+        filter: {
+          name: {_in: ['Luke', 'Han']},
+        }
+      };
+      const expectedFilter = {name: {$in: ['Luke', 'Han']}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('string selector _nin', async function () {
+      const input = {
+        filter: {
+          name: {_nin: ['Han', 'Leia']},
+        }
+      };
+      const expectedFilter = {name: {$nin: ['Han', 'Leia']}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('string selector _is_null', async function () {
+      const input = {
+        filter: {
+          name: {_is_null: true},
+        }
+      };
+      const expectedFilter = {name: {$exists: false}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('string selector _like', async function () {
+      const input = {
+        filter: {
+          name: {_like: '^e'},
+        }
+      };
+      const expectedFilter = {name: {$regex: '\\^e', $options: 'i'}};
+      const mongoParams = await filterFunction(collection, input);
+      console.log('mongoParams.selector', mongoParams.selector);
+      console.log('expectedFilter', expectedFilter);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('string selector _lt', async function () {
+      const input = {
+        filter: {
+          name: {_lt: 'Han'},
+        }
+      };
+      const expectedFilter = {name: {$lt: 'Han'}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('string selector _lte', async function () {
+      const input = {
+        filter: {
+          name: {_lte: 'Han'},
+        }
+      };
+      const expectedFilter = {name: {$lte: 'Han'}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('string selector _neq', async function () {
+      const input = {
+        filter: {
+          name: {_neq: 'Han'},
+        }
+      };
+      const expectedFilter = {name: {$ne: 'Han'}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+  });
+
+  describe('string array selector', async function () {
+
+    test('string array selector _in', async function () {
+      const input = {
+        filter: {
+          friends: {_in: ['Luke', 'Han']},
+        }
+      };
+      const expectedFilter = {friends: {$in: ['Luke', 'Han']}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('string array selector _nin', async function () {
+      const input = {
+        filter: {
+          friends: {_nin: ['Luke', 'Han']},
+        }
+      };
+      const expectedFilter = {friends: {$nin: ['Luke', 'Han']}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('string array selector _contains', async function () {
+      const input = {
+        filter: {
+          friends: {_contains: 'Han'},
+        }
+      };
+      const expectedFilter = {friends: {$elemMatch: {$eq: 'Han'}}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('string array selector _contains_all', async function () {
+      const input = {
+        filter: {
+          friends: {_contains_all: ['Leia', 'Luke']},
+        }
+      };
+      const expectedFilter = {friends: {$all: ['Leia', 'Luke']}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+  });
+
+  describe('int selector', async function () {
+
+    test('int selector _eq', async function () {
+      const input = {
+        filter: {
+          age: {_eq: 100},
+        }
+      };
+      const expectedFilter = {age: {$eq: 100}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('int selector _gt', async function () {
+      const input = {
+        filter: {
+          age: {_gt: 100},
+        }
+      };
+      const expectedFilter = {age: {$gt: 100}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('int selector _gte', async function () {
+      const input = {
+        filter: {
+          age: {_gte: 100},
+        }
+      };
+      const expectedFilter = {age: {$gte: 100}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('int selector _in', async function () {
+      const input = {
+        filter: {
+          age: {_in: [100, 120]},
+        }
+      };
+      const expectedFilter = {age: {$in: [100, 120]}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('int selector _nin', async function () {
+      const input = {
+        filter: {
+          age: {_nin: [100, 120]},
+        }
+      };
+      const expectedFilter = {age: {$nin: [100, 120]}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('int selector _is_null', async function () {
+      const input = {
+        filter: {
+          age: {_is_null: true},
+        }
+      };
+      const expectedFilter = {age: {$exists: false}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('int selector _lt', async function () {
+      const input = {
+        filter: {
+          age: {_lt: 120},
+        }
+      };
+      const expectedFilter = {age: {$lt: 120}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('int selector _lte', async function () {
+      const input = {
+        filter: {
+          age: {_lte: 120},
+        }
+      };
+      const expectedFilter = {age: {$lte: 120}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('int selector _neq', async function () {
+      const input = {
+        filter: {
+          age: {_neq: 120},
+        }
+      };
+      const expectedFilter = {age: {$ne: 120}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+  });
+
+  describe('int array selector', async function () {
+
+    test('int array selector _in', async function () {
+      const input = {
+        filter: {
+          agesOfFriends: {_in: [110, 120]},
+        }
+      };
+      const expectedFilter = {agesOfFriends: {$in: [110, 120]}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('int array selector _nin', async function () {
+      const input = {
+        filter: {
+          agesOfFriends: {_nin: [110, 120]},
+        }
+      };
+      const expectedFilter = {agesOfFriends: {$nin: [110, 120]}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('int array selector _contains', async function () {
+      const input = {
+        filter: {
+          agesOfFriends: {_contains: 110},
+        }
+      };
+      const expectedFilter = {agesOfFriends: {$elemMatch: {$eq: 110}}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('int array selector _contains_all', async function () {
+      const input = {
+        filter: {
+          agesOfFriends: {_contains_all: [110, 120]},
+        }
+      };
+      const expectedFilter = {agesOfFriends: {$all: [110, 120]}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+  });
+
+  describe('float selector', async function () {
+
+    test('float selector _eq', async function () {
+      const input = {
+        filter: {
+          age: {_eq: 100},
+        }
+      };
+      const expectedFilter = {age: {$eq: 100}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('float selector _gt', async function () {
+      const input = {
+        filter: {
+          age: {_gt: 100},
+        }
+      };
+      const expectedFilter = {age: {$gt: 100}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('float selector _gte', async function () {
+      const input = {
+        filter: {
+          age: {_gte: 100},
+        }
+      };
+      const expectedFilter = {age: {$gte: 100}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('float selector _in', async function () {
+      const input = {
+        filter: {
+          age: {_in: [100, 120]},
+        }
+      };
+      const expectedFilter = {age: {$in: [100, 120]}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('float selector _nin', async function () {
+      const input = {
+        filter: {
+          age: {_nin: [100, 120]},
+        }
+      };
+      const expectedFilter = {age: {$nin: [100, 120]}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('float selector _is_null', async function () {
+      const input = {
+        filter: {
+          age: {_is_null: true},
+        }
+      };
+      const expectedFilter = {age: {$exists: false}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('float selector _lt', async function () {
+      const input = {
+        filter: {
+          age: {_lt: 120},
+        }
+      };
+      const expectedFilter = {age: {$lt: 120}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('float selector _lte', async function () {
+      const input = {
+        filter: {
+          age: {_lte: 120},
+        }
+      };
+      const expectedFilter = {age: {$lte: 120}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('float selector _neq', async function () {
+      const input = {
+        filter: {
+          age: {_neq: 120},
+        }
+      };
+      const expectedFilter = {age: {$ne: 120}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+  });
+
+  describe('float array selector', async function () {
+
+    test('float array selector _in', async function () {
+      const input = {
+        filter: {
+          scores: {_in: [1.1, 1.2]},
+        }
+      };
+      const expectedFilter = {scores: {$in: [1.1, 1.2]}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('float array selector _nin', async function () {
+      const input = {
+        filter: {
+          scores: {_nin: [1.1, 1.2]},
+        }
+      };
+      const expectedFilter = {scores: {$nin: [1.1, 1.2]}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('float array selector _contains', async function () {
+      const input = {
+        filter: {
+          scores: {_contains: 1.1},
+        }
+      };
+      const expectedFilter = {scores: {$elemMatch: {$eq: 1.1}}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('float array selector _contains_all', async function () {
+      const input = {
+        filter: {
+          scores: {_contains_all: [1.1, 1.2]},
+        }
+      };
+      const expectedFilter = {scores: {$all: [1.1, 1.2]}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+  });
+
+  describe('boolean selector', async function () {
+
+    test('boolean selector _eq', async function () {
+      const input = {
+        filter: {
+          withTheForce: {_eq: true},
+        }
+      };
+      const expectedFilter = {withTheForce: {$eq: true}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('boolean selector _neq', async function () {
+      const input = {
+        filter: {
+          withTheForce: {_neq: true},
+        }
+      };
+      const expectedFilter = {withTheForce: {$ne: true}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+  });
+
+  describe('boolean array selector', async function () {
+
+    test('boolean array selector _contains', async function () {
+      const input = {
+        filter: {
+          forcesOfFriends: {_contains: true},
+        }
+      };
+      const expectedFilter = {forcesOfFriends: {$elemMatch: {$eq: true}}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+  });
+
+  describe('date selector', async function () {
+
+    test('date selector _eq', async function () {
+      const input = {
+        filter: {
+          birthday: {_eq: mayTheFourth},
+        }
+      };
+      const expectedFilter = {birthday: {$eq: mayTheFourth }};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('date selector _gt', async function () {
+      const input = {
+        filter: {
+          birthday: {_gt: mayTheFourth},
+        }
+      };
+      const expectedFilter = {birthday: {$gt: mayTheFourth}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('date selector _gte', async function () {
+      const input = {
+        filter: {
+          birthday: {_gte: mayTheFourth},
+        }
+      };
+      const expectedFilter = {birthday: {$gte: mayTheFourth}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('date selector _in', async function () {
+      const input = {
+        filter: {
+          birthday: {_in: [mayTheFourth, summerSolstice]},
+        }
+      };
+      const expectedFilter = {birthday: {$in: [mayTheFourth, summerSolstice]}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('date selector _nin', async function () {
+      const input = {
+        filter: {
+          birthday: {_nin: [mayTheFourth, summerSolstice]},
+        }
+      };
+      const expectedFilter = {birthday: {$nin: [mayTheFourth, summerSolstice]}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('date selector _is_null', async function () {
+      const input = {
+        filter: {
+          birthday: {_is_null: true},
+        }
+      };
+      const expectedFilter = {birthday: {$exists: false}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('date selector _lt', async function () {
+      const input = {
+        filter: {
+          birthday: {_lt: mayTheFourth},
+        }
+      };
+      const expectedFilter = {birthday: {$lt: mayTheFourth}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('date selector _lte', async function () {
+      const input = {
+        filter: {
+          birthday: {_lte: mayTheFourth},
+        }
+      };
+      const expectedFilter = {birthday: {$lte: mayTheFourth}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('date selector _neq', async function () {
+      const input = {
+        filter: {
+          birthday: {_neq: mayTheFourth},
+        }
+      };
+      const expectedFilter = {birthday: {$ne: mayTheFourth}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+  });
+
+  describe('date array selector', async function () {
+
+    test('date array selector _contains', async function () {
+      const input = {
+        filter: {
+          birthdaysOfFriends: {_contains: mayTheFourth},
+        }
+      };
+      const expectedFilter = {birthdaysOfFriends: {$elemMatch: {$eq: mayTheFourth}}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+    test('date array selector _contains_all', async function () {
+      const input = {
+        filter: {
+          birthdaysOfFriends: {_contains_all: ['Leia', 'Luke']},
+        }
+      };
+      const expectedFilter = {birthdaysOfFriends: {$all: ['Leia', 'Luke']}};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
+  });
+
+  describe('complex selectors', () => {
+
+    test('handle multiple filters', async () => {
       const filter = {
-        _and: [{ name: { _gte: 'A' } }, { length: { _lte: 2 } }],
+        _id: {_gte: 1, _lte: 5},
       };
       const input = {
         filter,
       };
-      const expectedFilter = { $and: [{ name: { $gte: 'A' } }, { length: { $lte: 2 } }] };
+      const expectedFilter = {_id: {$gte: 1, $lte: 5}};
       const mongoParams = await filterFunction(collection, input);
       expect(mongoParams.selector).toEqual(expectedFilter);
     });
+
+    test('handle _and at root', async () => {
+      const filter = {
+        _and: [{name: {_gte: 'A'}}, {age: {_lte: 2}}],
+      };
+      const input = {
+        filter,
+      };
+      const expectedFilter = {$and: [{name: {$gte: 'A'}}, {age: {$lte: 2}}]};
+      const mongoParams = await filterFunction(collection, input);
+      expect(mongoParams.selector).toEqual(expectedFilter);
+    });
+
   });
+
 });

--- a/packages/vulcan-lib/test/mongoParams.test.js
+++ b/packages/vulcan-lib/test/mongoParams.test.js
@@ -74,6 +74,30 @@ describe.only('vulcan:lib/mongoParams', function () {
           type: Number,
           canRead: ['admins'],
         },
+        scores: {
+          type: Array,
+          canRead: ['admins'],
+        },
+        'scores.$': {
+          type: Number,
+          canRead: ['admins'],
+        },
+        forcesOfFriends: {
+          type: Array,
+          canRead: ['admins'],
+        },
+        'forcesOfFriends.$': {
+          type: Number,
+          canRead: ['admins'],
+        },
+        birthdaysOfFriends: {
+          type: Array,
+          canRead: ['admins'],
+        },
+        'birthdaysOfFriends.$': {
+          type: Number,
+          canRead: ['admins'],
+        },
       },
       results: [{
         _id: "1", name: 'Han', age: 140, withTheForce: false,

--- a/packages/vulcan-lib/test/utils.test.js
+++ b/packages/vulcan-lib/test/utils.test.js
@@ -155,7 +155,7 @@ describe('vulcan:lib/utils', function () {
       expect(result).toEqual(false);
     })
 
-    it('reports empty for empty string values', () => {
+    it('reports not empty for string values of zero length', () => {
       const result = Utils.isEmptyOrUndefined('');
       expect(result).toEqual(true);
     })

--- a/packages/vulcan-lib/test/utils.test.js
+++ b/packages/vulcan-lib/test/utils.test.js
@@ -1,6 +1,6 @@
-import { Utils } from '../lib/modules/utils';
+import {Utils} from '../lib/modules/utils';
 import expect from 'expect';
-import { createDummyCollection } from "meteor/vulcan:test"
+import {createDummyCollection} from "meteor/vulcan:test"
 import SimpleSchema from "simpl-schema"
 
 // prepare Jest migration
@@ -9,7 +9,7 @@ const test = it
 describe('vulcan:lib/utils', function () {
 
   const collection = {
-    findOne: function ({ slug }) {
+    findOne: function ({slug}) {
       switch (slug) {
         case 'duplicate-name':
           return {
@@ -41,48 +41,52 @@ describe('vulcan:lib/utils', function () {
     }
   };
 
-  it('returns the same slug when there are no conflicts', function () {
-    const slug = 'unique-name';
-    const unusedSlug = Utils.getUnusedSlug(collection, slug);
+  describe('Utils.getUnusedSlug()', async function () {
 
-    expect(unusedSlug).toEqual(slug);
+    it('returns the same slug when there are no conflicts', function () {
+      const slug = 'unique-name';
+      const unusedSlug = Utils.getUnusedSlug(collection, slug);
+
+      expect(unusedSlug).toEqual(slug);
+    });
+
+    it('appends integer to slug when there is a conflict', function () {
+      const slug = 'duplicate-name';
+      const unusedSlug = Utils.getUnusedSlug(collection, slug);
+
+      expect(unusedSlug).toEqual(slug + '-1');
+    });
+
+    it('appends incremented integer to slug when there is a conflict', function () {
+      const slug = 'triplicate-name';
+      const unusedSlug = Utils.getUnusedSlug(collection, slug);
+
+      expect(unusedSlug).toEqual(slug + '-2');
+    });
+
+    it('returns the same slug when the conflict has the same _id', function () {
+      // This tests the case where a document is renamed, but its slug remains the same
+      // For example 'RENAMED NAME' is changed to 'Renamed name'; the slug should not increment
+      const slug = 'renamed-name';
+      const documentId = 'renamed-name';
+      const unusedSlug = Utils.getUnusedSlug(collection, slug, documentId);
+
+      expect(unusedSlug).toEqual(slug);
+    });
+
+    it('appends integer to slug when the conflict has the same _id, but it’s not passed to getUnusedSlug', function () {
+      // This tests the case where a document is renamed, but its slug remains the same
+      // For example 'RENAMED NAME' is changed to 'Renamed name'; the slug should not increment
+      const slug = 'renamed-name';
+      const unusedSlug = Utils.getUnusedSlug(collection, slug);
+
+      expect(unusedSlug).toEqual(slug + '-1');
+    });
+
   });
 
-  it('appends integer to slug when there is a conflict', function () {
-    const slug = 'duplicate-name';
-    const unusedSlug = Utils.getUnusedSlug(collection, slug);
+  describe("Utils.convertDates()", () => {
 
-    expect(unusedSlug).toEqual(slug + '-1');
-  });
-
-  it('appends incremented integer to slug when there is a conflict', function () {
-    const slug = 'triplicate-name';
-    const unusedSlug = Utils.getUnusedSlug(collection, slug);
-
-    expect(unusedSlug).toEqual(slug + '-2');
-  });
-
-  it('returns the same slug when the conflict has the same _id', function () {
-    // This tests the case where a document is renamed, but its slug remains the same
-    // For example 'RENAMED NAME' is changed to 'Renamed name'; the slug should not increment
-    const slug = 'renamed-name';
-    const documentId = 'renamed-name';
-    const unusedSlug = Utils.getUnusedSlug(collection, slug, documentId);
-
-    expect(unusedSlug).toEqual(slug);
-  });
-
-  it('appends integer to slug when the conflict has the same _id, but it’s not passed to getUnusedSlug', function () {
-    // This tests the case where a document is renamed, but its slug remains the same
-    // For example 'RENAMED NAME' is changed to 'Renamed name'; the slug should not increment
-    const slug = 'renamed-name';
-    const unusedSlug = Utils.getUnusedSlug(collection, slug);
-
-    expect(unusedSlug).toEqual(slug + '-1');
-  });
-
-
-  describe("convertDates", () => {
     it("convert date string to object", () => {
       const Dummies = createDummyCollection({
         schema: {
@@ -92,9 +96,10 @@ describe('vulcan:lib/utils', function () {
         }
       })
       const now = new Date()
-      const res = Utils.convertDates(Dummies, { begin: now.toISOString() })
+      const res = Utils.convertDates(Dummies, {begin: now.toISOString()})
       expect(res.begin).toBeInstanceOf(Date)
     })
+
     it("convert date string in nested objects", () => {
       const Dummies = createDummyCollection({
         schema: {
@@ -108,10 +113,10 @@ describe('vulcan:lib/utils', function () {
         }
       })
       const now = new Date()
-      const res = Utils.convertDates(Dummies, { nested: { begin: now.toISOString() } })
+      const res = Utils.convertDates(Dummies, {nested: {begin: now.toISOString()}})
       expect(res.nested.begin).toBeInstanceOf(Date)
-
     })
+
     it("convert date string in arrays of nested objects", () => {
       const Dummies = createDummyCollection({
         schema: {
@@ -128,15 +133,90 @@ describe('vulcan:lib/utils', function () {
         }
       })
       const now = new Date()
-      const res = Utils.convertDates(Dummies, { array: [{ begin: now.toISOString() }] })
+      const res = Utils.convertDates(Dummies, {array: [{begin: now.toISOString()}]})
       expect(res.array[0].begin).toBeInstanceOf(Date)
     })
+
   })
 
-  describe('pluralize', () => {
+  describe('Utils.pluralize()', () => {
+
     test('force a plural for words where plural = singular', () => {
       const peoples = Utils.pluralize("people")
       expect(peoples).toEqual("peoples")
     })
+
   })
+
+  describe('Utils.isEmptyOrUndefined()', () => {
+
+    it('reports not empty for non-empty string values', () => {
+      const result = Utils.isEmptyOrUndefined('abc');
+      expect(result).toEqual(false);
+    })
+
+    it('reports empty for empty string values', () => {
+      const result = Utils.isEmptyOrUndefined('');
+      expect(result).toEqual(true);
+    })
+
+    it('reports not empty for number values', () => {
+      const result = Utils.isEmptyOrUndefined(1);
+      expect(result).toEqual(false);
+    })
+
+    it('reports not empty for the number zero', () => {
+      const result = Utils.isEmptyOrUndefined(1);
+      expect(result).toEqual(false);
+    })
+
+    it('reports empty for undefined values', () => {
+      let value;
+      const result = Utils.isEmptyOrUndefined(value);
+      expect(result).toEqual(true);
+    })
+
+    it('reports empty for null values', () => {
+      const value = null;
+      const result = Utils.isEmptyOrUndefined(value);
+      expect(result).toEqual(true);
+    })
+
+    it('reports not empty for non-empty objects', () => {
+      const result = Utils.isEmptyOrUndefined({ key: 'abc' });
+      expect(result).toEqual(false);
+    })
+
+    it('reports empty for empty objects', () => {
+      const result = Utils.isEmptyOrUndefined({});
+      expect(result).toEqual(true);
+    })
+
+    it('reports not empty for dates', () => {
+      const result = Utils.isEmptyOrUndefined(new Date());
+      expect(result).toEqual(false);
+    })
+
+    it('reports not empty for empty dates', () => {
+      const result = Utils.isEmptyOrUndefined(new Date(0));
+      expect(result).toEqual(false);
+    })
+
+    it('reports not empty for non-empty arrays', () => {
+      const result = Utils.isEmptyOrUndefined(['abc']);
+      expect(result).toEqual(false);
+    })
+
+    it('reports empty for empty arrays', () => {
+      const result = Utils.isEmptyOrUndefined([]);
+      expect(result).toEqual(true);
+    })
+
+    it('reports not empty for regular expressions', () => {
+      const result = Utils.isEmptyOrUndefined(/^e/);
+      expect(result).toEqual(false);
+    })
+
+  })
+
 });


### PR DESCRIPTION
 * Enabled (uncommented) various query filter options in `String_Selector`, `String_Array_Selector`, `Int_Selector`, `Int_Array_Selector`, `Float_Selector`, `Float_Array_Selector`, `Boolean_Selector`, `Boolean_Array_Selector`, `Date_Selector`, `Date_Array_Selector`
 * Added unit tests for vulcan:lib/mongoParams