### PR TITLE
pass initial input to multi2 loadMoreInc

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/multi2.js
+++ b/packages/vulcan-core/lib/modules/containers/multi2.js
@@ -104,7 +104,8 @@ const buildResult = (
   options,
   { fragmentName, fragment, resolverName },
   { setPaginationInput, paginationInput, initialPaginationInput },
-  returnedProps
+  returnedProps,
+  queryOptions,
 ) => {
   //console.log('returnedProps', returnedProps);
   const { refetch, networkStatus, error, fetchMore, data, graphQLErrors } = returnedProps;
@@ -121,6 +122,8 @@ const buildResult = (
     // eslint-disable-next-line no-console
     console.log(error);
   }
+
+  const initialInput = queryOptions?.variables?.input || {}
 
   return {
     // see https://github.com/apollostack/apollo-client/blob/master/src/queries/store.ts#L28-L36
@@ -142,6 +145,8 @@ const buildResult = (
     loadMore(providedInput) {
       // if new terms are provided by presentational component use them, else default to incrementing current limit once
       const newInput = providedInput || {
+        // TODO : test if initialInput is necessary for loadMore function
+        // ...initialInput,
         ...paginationInput,
         limit: results.length + initialPaginationInput.limit,
       };
@@ -155,6 +160,7 @@ const buildResult = (
       // get terms passed as argument or else just default to incrementing the offset
 
       const newInput = providedInput || {
+        ...initialInput,
         ...paginationInput,
         offset: results.length,
       };
@@ -216,7 +222,8 @@ export const useMulti = (options, props = {}) => {
     options,
     { fragment, fragmentName, resolverName },
     { setPaginationInput, paginationInput, initialPaginationInput },
-    queryRes
+    queryRes,
+    queryOptions
   );
 
   return result;


### PR DESCRIPTION
**Describe the bug**
Maybe this should go in the new feature request
If I use useMulti2 with an input and then click sur loadMoreInc, the initial input is ignored
eg, I look up for the movies with a {rating : {_eq : 5}}
In the first time I will see only 5/5 movies, but when I click sur loadMoreInc, I will get any kind of film

**To Reproduce**
Steps to reproduce the behavior:
1. Go to any useMulti2 using an input
2. Click on loadMoreInc
4. The input is ignored

**Expected behavior**
I think it should keep the existing input