### PR TITLE
Flash messages in reactive state

### DIFF
--- a/packages/vulcan-core/lib/modules/components/AccessControl.jsx
+++ b/packages/vulcan-core/lib/modules/components/AccessControl.jsx
@@ -3,7 +3,7 @@ import { Components, registerComponent } from 'meteor/vulcan:lib';
 import { useCurrentUser } from '../containers/currentUser';
 import Users from 'meteor/vulcan:users';
 import { useHistory } from 'react-router-dom';
-import withMessages from '../containers/withMessages';
+import { withMessages } from '../containers/withMessages';
 import { intlShape } from 'meteor/vulcan:i18n';
 
 const AccessControl = ({ currentRoute, children, flash }, { intl }) => {

--- a/packages/vulcan-core/lib/modules/components/App.jsx
+++ b/packages/vulcan-core/lib/modules/components/App.jsx
@@ -1,15 +1,4 @@
-import {
-  Components,
-  registerComponent,
-  getSetting,
-  Strings,
-  runCallbacks,
-  detectLocale,
-  hasIntlFields,
-  Routes,
-  getLocale,
-  getStrings,
-} from 'meteor/vulcan:lib';
+import { Components, registerComponent, Strings, runCallbacks, hasIntlFields, Routes, getLocale, getStrings } from 'meteor/vulcan:lib';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { IntlProvider, intlShape, IntlContext } from 'meteor/vulcan:i18n';
@@ -22,7 +11,6 @@ import { withCookies } from 'react-cookie';
 import moment from 'moment';
 import { Switch, Route } from 'react-router-dom';
 import { withRouter } from 'react-router';
-import MessageContext from '../messages.js';
 import get from 'lodash/get';
 import merge from 'lodash/merge';
 
@@ -79,47 +67,10 @@ class App extends PureComponent {
         loading: false,
         strings: merge({}, loadedStrings, bundledStrings),
       },
-      messages: [],
     };
 
     moment.locale(locale.id);
   }
-
-  /*
-
-  Clear messages on route change
-  See https://stackoverflow.com/a/45373907/649299
-
-  */
-  UNSAFE_componentWillMount() {
-    this.unlisten = this.props.history.listen((location, action) => {
-      this.clear();
-    });
-  }
-
-  componentWillUnmount() {
-    this.unlisten();
-  }
-
-  /* 
-  
-  Show a flash message
-  
-  */
-  flash = message => {
-    this.setState({
-      messages: [...this.state.messages, message],
-    });
-  };
-
-  /*
-
-  Clear all flash messages
-
-  */
-  clear = () => {
-    this.setState({ messages: [] });
-  };
 
   componentDidMount = async () => {
     runCallbacks('app.mounted', this.props);
@@ -165,7 +116,10 @@ class App extends PureComponent {
     cookies.set('locale', localeId, { path: '/' });
     // if user is logged in, change their `locale` profile property
     if (currentUser) {
-      await updateUser({ selector: { documentId: currentUser._id }, data: { locale: localeId } });
+      await updateUser({
+        selector: { documentId: currentUser._id },
+        data: { locale: localeId },
+      });
     }
     moment.locale(localeId);
     if (hasIntlFields) {
@@ -177,7 +131,7 @@ class App extends PureComponent {
 
   Load a locale by triggering the refetch() method passed down by
   withLocalData HoC
-  
+
   */
   loadLocaleStrings = async localeId => {
     const result = await this.props.locale.refetch({ localeId });
@@ -193,7 +147,7 @@ class App extends PureComponent {
     };
   }
 
-  UNSAFE_componentWillUpdate(nextProps) {
+  componentDidUpdate(nextProps) {
     const currentUser = this.props.currentUser;
     const nextUser = nextProps.currentUser;
     if (nextUser && (!currentUser || currentUser._id !== nextUser._id)) {
@@ -203,8 +157,6 @@ class App extends PureComponent {
 
   render() {
     const routeNames = Object.keys(Routes);
-    const { flash } = this;
-    const { messages } = this.state;
     const localeId = this.state.locale.id;
     //const LayoutComponent = currentRoute.layoutName ? Components[currentRoute.layoutName] : Components.Layout;
 
@@ -218,35 +170,33 @@ class App extends PureComponent {
     return (
       <IntlProvider {...intlObject}>
         <IntlContext.Provider value={intlObject}>
-          <MessageContext.Provider value={{ messages, flash }}>
-            <Components.ScrollToTop />
-            <div className={`locale-${localeId}`}>
-              <Components.HeadTags />
-              {this.props.currentUserLoading ? (
-                <div className="app-initial-loading">
-                  <Components.Loading />
-                </div>
-              ) : routeNames.length ? (
-                <Switch>
-                  {routeNames.map(key => (
-                    // NOTE: if we want the exact props to be taken into account
-                    // we have to pass it to the RouteWithLayout, not the underlying Route,
-                    // because it is the direct child of Switch
-                    <RouteWithLayout exact currentRoute={Routes[key]} siteData={this.props.siteData} key={key} {...Routes[key]} />
-                  ))}
-                  <RouteWithLayout siteData={this.props.siteData} currentRoute={{ name: '404' }} component={Components.Error404} />
-                  {/* <Route component={Components.Error404} />  */}
-                </Switch>
-              ) : (
-                <Components.Welcome />
-              )}
-              {this.state.locale.loading && (
-                <div className="app-secondary-loading">
-                  <Components.Loading />
-                </div>
-              )}
-            </div>
-          </MessageContext.Provider>
+          <Components.ScrollToTop />
+          <div className={`locale-${localeId}`}>
+            <Components.HeadTags />
+            {this.props.currentUserLoading ? (
+              <div className="app-initial-loading">
+                <Components.Loading />
+              </div>
+            ) : routeNames.length ? (
+              <Switch>
+                {routeNames.map(key => (
+                  // NOTE: if we want the exact props to be taken into account
+                  // we have to pass it to the RouteWithLayout, not the underlying Route,
+                  // because it is the direct child of Switch
+                  <RouteWithLayout exact currentRoute={Routes[key]} siteData={this.props.siteData} key={key} {...Routes[key]} />
+                ))}
+                <RouteWithLayout siteData={this.props.siteData} currentRoute={{ name: '404' }} component={Components.Error404} />
+                {/* <Route component={Components.Error404} />  */}
+              </Switch>
+            ) : (
+              <Components.Welcome />
+            )}
+            {this.state.locale.loading && (
+              <div className="app-secondary-loading">
+                <Components.Loading />
+              </div>
+            )}
+          </div>
         </IntlContext.Provider>
       </IntlProvider>
     );

--- a/packages/vulcan-core/lib/modules/components/Flash.jsx
+++ b/packages/vulcan-core/lib/modules/components/Flash.jsx
@@ -1,62 +1,28 @@
-import { Components, registerComponent } from 'meteor/vulcan:lib';
-import withMessages from '../containers/withMessages.js';
-import React, { PureComponent } from 'react';
+import {Components, registerComponent} from 'meteor/vulcan:lib';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { intlShape } from 'meteor/vulcan:i18n';
+import {intlShape} from 'meteor/vulcan:i18n';
 
-class Flash extends PureComponent {
-  constructor() {
-    super();
-    this.dismissFlash = this.dismissFlash.bind(this);
-  }
+const Flash = (props) => {
+  const {message, type} = props.message;
 
-  // TODO: reenable if still useful, otherwise delete
-  // componentDidMount() {
-  //   this.props.markAsSeen && this.props.markAsSeen(this.props.message._id);
-  // }
-
-  dismissFlash(e) {
+  const dismissFlash = (e) => {
     e.preventDefault();
-    this.props.clear(this.props.message._id);
-  }
-
-  getProperties = () => {
-    const errorObject = this.props.message;
-    if (typeof errorObject === 'string') {
-      // if error is a string, use it as message
-      return {
-        message: errorObject,
-        type: 'error'
-      };
-    } else {
-      // else return full error object after internationalizing message
-      const { id, message, properties } = errorObject;
-      const translatedMessage = this.context.intl.formatMessage(
-        { id, defaultMessage: message },
-        properties
-      );
-      return {
-        ...errorObject,
-        message: translatedMessage
-      };
-    }
+    props.dismissFlash(props.message._id);
   };
 
-  render() {
-
-    const { message, type = 'danger' } = this.getProperties();
-    const flashType = type === 'error' ? 'danger' : type; // if flashType is "error", use "danger" instead
-
-    return (
-      <Components.Alert className="flash-message" variant={flashType} onClose={this.dismissFlash}>
-        <span dangerouslySetInnerHTML={{ __html: message }} />
+  return (
+      <Components.Alert className="flash-message"
+                        variant={type}
+                        onClose={dismissFlash}>
+        <span dangerouslySetInnerHTML={{__html: message}}/>
       </Components.Alert>
-    );
-  }
-}
+  );
+};
 
 Flash.propTypes = {
-  message: PropTypes.oneOfType([PropTypes.object.isRequired, PropTypes.string.isRequired])
+  message: PropTypes.object.isRequired,
+  dismissFlash: PropTypes.func.isRequired,
 };
 
 Flash.contextTypes = {
@@ -65,21 +31,4 @@ Flash.contextTypes = {
 
 registerComponent('Flash', Flash);
 
-const FlashMessages = ({messages, className, ...flashActions}) => {
-  return (
-    <div className={`flash-messages ${className}`}>
-      {messages
-        // .filter(message => message.show)
-        .map((message, i) => <Components.Flash key={i} message={message} {...flashActions} />)}
-    </div>
-  );
-};
-
-FlashMessages.displayName = 'FlashMessages';
-FlashMessages.propTypes = {
-  messages: PropTypes.array.isRequired
-};
-
-registerComponent('FlashMessages', FlashMessages, withMessages);
-
-export default withMessages(FlashMessages);
+export default Flash;

--- a/packages/vulcan-core/lib/modules/components/FlashMessages.jsx
+++ b/packages/vulcan-core/lib/modules/components/FlashMessages.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Components, registerComponent } from 'meteor/vulcan:lib';
+import { intlShape } from 'meteor/vulcan:i18n';
+import { useMessages } from '../containers/withMessages.js';
+import { useReactiveVar } from '@apollo/client';
+
+const FlashMessages = ({ className }, context) => {
+  const { messagesState, ...flashActions } = useMessages();
+  const messages = useReactiveVar(messagesState.reactiveVar).messages;
+
+  return (
+    <div className={`flash-messages ${className}`}>
+      {
+        messages.map((message, i) =>
+          <Components.Flash key={i} message={message} {...flashActions} />)
+      }
+    </div>
+  );
+};
+
+FlashMessages.propTypes = {
+  className: PropTypes.string,
+};
+FlashMessages.contextTypes = {
+  intl: intlShape.isRequired,
+};
+FlashMessages.displayName = 'FlashMessages';
+
+registerComponent('FlashMessages', FlashMessages);
+
+export default FlashMessages;

--- a/packages/vulcan-core/lib/modules/containers/withAccess.js
+++ b/packages/vulcan-core/lib/modules/containers/withAccess.js
@@ -3,7 +3,7 @@ import { Components } from 'meteor/vulcan:lib';
 import withCurrentUser from './currentUser';
 import { withRouter } from 'react-router';
 import Users from 'meteor/vulcan:users';
-import withMessages from './withMessages.js';
+import { withMessages } from './withMessages.js';
 
 /**
  * withAccess - description

--- a/packages/vulcan-core/lib/modules/containers/withMessages.js
+++ b/packages/vulcan-core/lib/modules/containers/withMessages.js
@@ -1,24 +1,108 @@
 /*
 
-HoC that provides access to flash messages stored in context
+Hook and HoC that provides access to flash messages stored in reactive state
 
 */
 import React from 'react';
-import MessageContext from '../messages.js';
+import {
+  createReactiveState,
+  Random,
+} from 'meteor/vulcan:lib';
+import { intlShape, useIntl } from 'meteor/vulcan:i18n';
 
-const withMessages = WrappedComponent => {
+const messagesSchema = {
+  messages: {
+    type: Array,
+    arrayItem: {
+      type: Object,
+      blackbox: true,
+    },
+    defaultValue: [],
+  },
+};
+
+const messagesState = createReactiveState({stateKey: 'messagesState', schema: messagesSchema});
+
+const normalizeMessage = (messageObject, intl) => {
+  if (typeof messageObject === 'string') {
+    // if error is a string, use it as message
+    return {
+      message: messageObject,
+      type: 'error',
+    };
+  } else {
+    // else return full error object after internationalizing message
+    const { id = 'error', type, message, properties } = messageObject;
+    const translatedMessage = intl.formatMessage(
+      { id, defaultMessage: message },
+      properties,
+    );
+
+    const transformedType = type === 'error' ? 'danger' :
+      !['danger', 'success', 'warning'].includes(type) ? 'info' :
+        type;
+
+    return {
+      ...messageObject,
+      message: translatedMessage,
+      type: transformedType,
+      _id: Random.id(),
+    };
+  }
+};
+
+export const useMessages = (intl) => {
+  intl = intl || useIntl();
+
+  const messagesProps = {
+
+    messagesState,
+
+    messages: messagesState().messages,
+
+    flash: (message) => {
+      message = normalizeMessage(message, intl);
+      messagesState({ messages: { $push: [message] } });
+    },
+
+    dismissFlash: (_id) => {
+      // mark message as dismissed
+      const messages = messagesState().messages;
+      const message = messages.find(message => message._id === _id);
+      if (message) {
+        message.dismissed = true;
+      }
+
+      // if all messages are dismissed, empty the messages array
+      const hasUnDismissed = messages.find(message => !message.dismissed);
+      if (!hasUnDismissed) {
+        messagesState({ messages: [] });
+      }
+    },
+
+    dismissAllFlash: () => {
+      messagesState({ messages: [] });
+    },
+
+  };
+
+  return messagesProps;
+};
+
+export const withMessages = WrappedComponent => {
   class MessagesComponent extends React.Component {
     render() {
-      return (
-        <MessageContext.Consumer>
-          {messageProps => <WrappedComponent {...this.props} {...messageProps} />}
-        </MessageContext.Consumer>
-      );
+      const intl = this.context.intl;
+      const messagesProps = useMessages(intl);
+      return <WrappedComponent {...this.props} {...messagesProps} />;
     }
   }
+
+  MessagesComponent.contextTypes = {
+    intl: intlShape
+  };
+
   MessagesComponent.displayName = `withMessages(${WrappedComponent.displayName})`;
 
   return MessagesComponent;
 };
-
-export default withMessages;

--- a/packages/vulcan-core/lib/modules/index.js
+++ b/packages/vulcan-core/lib/modules/index.js
@@ -13,6 +13,7 @@ export { default as Dummy } from './components/Dummy.jsx';
 export { default as DynamicLoading } from './components/DynamicLoading.jsx';
 export { default as Error404 } from './components/Error404.jsx';
 export { default as Flash } from './components/Flash.jsx';
+export { default as FlashMessages } from './components/FlashMessages.jsx';
 export { default as HeadTags } from './components/HeadTags.jsx';
 export { default as HelloWorld } from './components/HelloWorld.jsx';
 export { default as Icon } from './components/Icon.jsx';
@@ -24,10 +25,10 @@ export { default as ScrollToTop } from './components/ScrollToTop.jsx';
 export { default as ShowIf } from './components/ShowIf.jsx';
 export { default as Welcome } from './components/Welcome.jsx';
 export { default as VerticalMenuLayout } from './components/VerticalMenuLayout/VerticalMenuLayout.jsx';
-export * from './components/PaginatedList';
+export * from './components/PaginatedList/index';
 
 export { default as withAccess } from './containers/withAccess.js';
-export { default as withMessages } from './containers/withMessages.js';
+export { withMessages, useMessages } from './containers/withMessages.js';
 export { withMulti, useMulti } from './containers/multi.js';
 export { withMulti2, useMulti2 } from './containers/multi2.js';
 export { withSingle, useSingle } from './containers/single.js';
@@ -46,9 +47,7 @@ export { withSiteData, useSiteData } from './containers/siteData.js';
 
 export * from './decorators';
 
-export { default as withComponents } from './containers/withComponents';
-
-export { default as MessageContext } from './messages.js';
+export { default as withComponents } from './containers/withComponents.js';
 
 // OpenCRUD backwards compatibility
 export { default as withNew } from './containers/create.js';
@@ -57,4 +56,4 @@ export { default as withRemove } from './containers/delete.js';
 export { default as withList } from './containers/multi.js';
 export { default as withDocument } from './containers/single.js';
 
-export * from './menu';
+export * from './menu.js';

--- a/packages/vulcan-core/lib/modules/messages.js
+++ b/packages/vulcan-core/lib/modules/messages.js
@@ -1,5 +1,0 @@
-import React from 'react';
-
-const MessageContext = React.createContext();
-
-export default MessageContext;

--- a/packages/vulcan-i18n/lib/modules/context.js
+++ b/packages/vulcan-i18n/lib/modules/context.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 const IntlContext = React.createContext({
   locale: '',

--- a/packages/vulcan-i18n/lib/modules/index.js
+++ b/packages/vulcan-i18n/lib/modules/index.js
@@ -6,3 +6,4 @@ export { default as FormattedMessage } from './message.js';
 export { intlShape } from './shape.js';
 export { default as IntlProvider } from './provider.js';
 export { default as IntlContext } from './context.js';
+export { default as useIntl } from './useIntl.js';

--- a/packages/vulcan-i18n/lib/modules/useIntl.js
+++ b/packages/vulcan-i18n/lib/modules/useIntl.js
@@ -1,0 +1,7 @@
+import React, {useContext} from 'react';
+import IntlContext from './context';
+
+export default function useIntl() {
+  const intl = useContext(IntlContext);
+  return intl;
+}

--- a/packages/vulcan-lib/lib/client/apollo-client/links/error.js
+++ b/packages/vulcan-lib/lib/client/apollo-client/links/error.js
@@ -10,7 +10,7 @@ const errorLink = onError(error => {
     });
   if (networkError) {
     // eslint-disable-next-line no-console
-    console.log(`[Network error]: ${networkError}`);
+    console.log(`[${networkError.statusCode} ${networkError.response?.statusText}]: ${networkError.message}`);
   }
 });
 

--- a/packages/vulcan-ui-material/lib/components/core/Flash.jsx
+++ b/packages/vulcan-ui-material/lib/components/core/Flash.jsx
@@ -1,0 +1,116 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Utils, replaceComponent, registerSetting, getSetting } from 'meteor/vulcan:core';
+import { intlShape } from 'meteor/vulcan:i18n';
+import makeStyles from '@material-ui/core/styles/makeStyles';
+import Snackbar from '@material-ui/core/Snackbar';
+import Alert from '@material-ui/lab/Alert';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from 'mdi-material-ui/Close';
+import Slide from '@material-ui/core/Slide';
+import DOMPurify from 'dompurify';
+
+
+registerSetting('flash.infoHideSeconds', 5, 'Seconds to display flash info messages');
+registerSetting('flash.errorHideSeconds', 15, 'Seconds to display flash error messages');
+
+
+const styles = theme => ({
+
+  root: {
+    maxWidth: 600,
+    transition: theme.transitions.create(['opacity'], {
+      duration: theme.transitions.duration.short,
+    }),
+    opacity: theme.opacity.darker,
+    '&:hover': {
+      opacity: 1,
+    },
+    '& code': {
+      fontSize: '0.9rem',
+    },
+  },
+
+  alert: {
+    lineHeight: 1.3,
+  },
+
+  infoAlert: {
+    backgroundColor: theme.palette.grey[800],
+  },
+
+});
+
+const useStyles = makeStyles(styles);
+
+
+const Flash = (props, context) => {
+  const [isOpen, setIsOpen] = useState(true);
+  const classes = useStyles(props);
+  const intl = context.intl;
+  const { message, type, _id } = props.message;
+  const infoOrError = ['info', 'success'].includes(type) ? 'info' : 'error';
+  const hideDuration = getSetting(`flash.${infoOrError}HideSeconds`) * 1000;
+
+  const handleClose = (event, reason) => {
+    if (reason === 'clickaway') return;
+
+      setIsOpen(false);
+      setTimeout(() => { props.dismissFlash(props.message._id); }, 500);
+  };
+
+  return (
+    <Snackbar key={message.content}
+              anchorOrigin={{
+                vertical: 'bottom',
+                horizontal: 'left',
+              }}
+              open={isOpen}
+              TransitionComponent={Slide}
+              classes={{ root: classes.root }}
+              autoHideDuration={hideDuration}
+              onClose={handleClose}
+              ContentProps={{
+                'aria-describedby': _id,
+              }}
+              action={[
+                <IconButton key="close"
+                            aria-label={intl.formatMessage({ id: 'global.close' })}
+                            color="inherit"
+                            onClick={handleClose}
+                >
+                  <CloseIcon/>
+                </IconButton>,
+              ]}
+    >
+      <Alert onClose={handleClose}
+             severity={type}
+             variant="filled"
+             classes={{
+               root: classes.alert,
+               filledInfo: classes.infoAlert,
+             }}
+      >
+        <span id={_id} dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(message) }}/>
+      </Alert>
+    </Snackbar>
+  );
+};
+
+
+Flash.propTypes = {
+  message: PropTypes.object.isRequired,
+  dismissFlash: PropTypes.func.isRequired,
+};
+
+
+Flash.contextTypes = {
+  intl: intlShape.isRequired,
+};
+
+
+Flash.displayName = 'Flash';
+
+
+replaceComponent('Flash', Flash);
+export default Flash;

--- a/packages/vulcan-ui-material/lib/components/index.js
+++ b/packages/vulcan-ui-material/lib/components/index.js
@@ -17,6 +17,7 @@ import './core/Avatar';
 import './core/Card';
 import './core/Datatable';
 import './core/EditButton';
+import './core/Flash';
 import './core/Loading';
 import './core/NewButton';
 


### PR DESCRIPTION
 * An adaptation of Vulcan's flash message system, but using reactive state instead of React context
 * Updated `withMessages` to use reactive state
 * Added new `useMessages` hook
 * Added new `useIntl` hook
 * Separated `FlashMessages` component into its own file
 * Updated `Flash` component to use reactive state
 * Moved `getProperties()` from the Flash component to `normalizeMessage()` in withMessages
 * Added new Material UI implementation of the `Flash` component
 * Removed `messages` from the state of the `App` component, `MessageContext` from the component tree, and the methods `UNSAFE_componentWillMount`, `componentWillUnmount`, `flash`, and `clear`
 * Removed `messages.js`, which only defined `MessageContext`
 * Updated `error.js` to report the http status of network errors thrown by Apollo