### PR TITLE
SmartForm minor bug fixes Jan 2020

### DIFF
--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -375,7 +375,6 @@ class SmartForm extends Component {
     // intialize properties
     let field = {
       ..._.pick(fieldSchema, formProperties),
-      document: this.state.initialDocument,
       name: fieldName,
       datatype: fieldSchema.type,
       layout: this.props.layout,
@@ -401,6 +400,7 @@ class SmartForm extends Component {
     // }
 
     const document = this.getDocument();
+    field.document = document;
 
     // internationalize field options labels
     if (field.options && Array.isArray(field.options)) {

--- a/packages/vulcan-forms/lib/components/Form.jsx
+++ b/packages/vulcan-forms/lib/components/Form.jsx
@@ -1022,7 +1022,7 @@ class SmartForm extends Component {
         const meta = this.props[`create${this.props.typeName}Meta`];
         // in new versions of Apollo Client errors are no longer thrown/caught
         // but can instead be provided as props by the useMutation hook
-        if (meta.error) {
+        if (meta?.error) {
           this.mutationErrorCallback(document, meta.error);
         } else {
           this.newMutationSuccessCallback(result);

--- a/packages/vulcan-forms/lib/components/FormComponent.jsx
+++ b/packages/vulcan-forms/lib/components/FormComponent.jsx
@@ -32,7 +32,7 @@ class FormComponent extends Component {
     }
     const path = getPath(props);
     const intlOrRegularValue = get(document, path);
-    const value = typeof intlOrRegularValue === 'object' ? intlOrRegularValue.value : intlOrRegularValue;
+    const value = (intlOrRegularValue && typeof intlOrRegularValue === 'object') ? intlOrRegularValue.value : intlOrRegularValue;
     return getCharacterCounts(value, max);
   }
 

--- a/packages/vulcan-lib/lib/modules/intl.js
+++ b/packages/vulcan-lib/lib/modules/intl.js
@@ -37,7 +37,7 @@ export const getString = ({ id, values, defaultMessage, messages, locale }) => {
     message = defaultMessage;
   }
 
-  if (values && typeof values === 'object') {
+  if (values && typeof values === 'object' && typeof message === 'string') {
     message = pluralizeString(message, values);
     message = substituteStringValues(message, values);
   }

--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/FormInput.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/FormInput.jsx
@@ -88,7 +88,7 @@ const FormInput = createReactClass({
       if (value !== this.props.value) {
         this.props.handleChange(value);
       }
-    }, 500);
+    }, 500, { leading: true });
 
     if (this.props.refFunction) {
       this.props.refFunction(this);


### PR DESCRIPTION
 * Fixed bug: `SmartForm.initField()` set each field's `document` property to the initial document, instead of the current document, resulting in bugs like [Nested Schema document update not working](https://github.com/VulcanJS/Vulcan/issues/2686)
 * Fixed bug: `FormComponent.getDerivedStateFromProps()` would fail when `intlOrRegularValue` was null (because `typeof null === 'object'`); it's possible that this should not normally occur, but it has occurred in my codebase because of Invariant Violation errors thrown by Apollo, likely because we have not upgraded to Apollo Client 3 cache
 * Fixed bug: Material UI Number input would not behave correctly when the user entered "0." quickly (the period would disappear)
 * Fixed bug: Creating a new document with SmartForm would fail when no Apollo errors occurred (`meta` prop was missing)
 * Fixed bug: `getString()` in `intl.js` would fail if the defaultMessage passed was not a string