### PR TITLE
add graphql.context callback

### DIFF
--- a/packages/vulcan-lib/lib/server/apollo-server/context.js
+++ b/packages/vulcan-lib/lib/server/apollo-server/context.js
@@ -132,6 +132,8 @@ export const computeContextFromReq = (currentContext, customContextFromReq) => {
       return htmlAttributes;
     });
 
+    context = await runCallbacks({ name: 'graphql.context', iterator: context });
+
     return context;
   };
 


### PR DESCRIPTION
Simply add a server-side callback called `graphql.context` that lets us iterate and modify the context passed to resolvers. It will run once per request, at graphql context initialization.