### PR TITLE
Unify Server and Client ThemeProviders and pass apolloClient as prop

### DIFF
--- a/packages/vulcan-ui-material/history.md
+++ b/packages/vulcan-ui-material/history.md
@@ -1,3 +1,8 @@
+1.16.0_3 / 2021-02-16
+=====================
+
+ * Theme provider now uses Components.ThemeProvider on the server side, similar to client side, in order to enable theming overrides in SSR.
+
 1.16.0_2 / 2020-11-16
 =====================
 

--- a/packages/vulcan-ui-material/lib/client/wrapWithMuiTheme.jsx
+++ b/packages/vulcan-ui-material/lib/client/wrapWithMuiTheme.jsx
@@ -1,24 +1,8 @@
 import React from 'react';
-import { addCallback, registerComponent, Components } from 'meteor/vulcan:core';
-import { ThemeProvider } from '@material-ui/core/styles';
-import { getCurrentTheme } from '../modules/themes';
-import JssCleanup from '../components/theme/JssCleanup';
+import { addCallback, Components } from 'meteor/vulcan:core';
 
-class AppThemeProvider extends React.Component {
-  render() {
-    const theme = getCurrentTheme();
-    return (
-      <ThemeProvider theme={theme}>
-        <JssCleanup>{this.props.children}</JssCleanup>
-      </ThemeProvider>
-    );
-  }
-}
-
-registerComponent('ThemeProvider', AppThemeProvider);
-
-function wrapWithMuiTheme(app) {
-  return <Components.ThemeProvider>{app}</Components.ThemeProvider>;
+function wrapWithMuiTheme(app, { apolloClient }) {
+  return <Components.ThemeProvider apolloClient={apolloClient}>{app}</Components.ThemeProvider>;
 }
 
 addCallback('router.client.wrapper', wrapWithMuiTheme);

--- a/packages/vulcan-ui-material/lib/components/index.js
+++ b/packages/vulcan-ui-material/lib/components/index.js
@@ -55,6 +55,7 @@ import './forms/controls/TimeRdt';
 export * from './forms/controls/Url';
 
 import './theme/ThemeStyles';
+import './theme/ThemeProvider';
 
 import './ui/Alert';
 import './ui/Button';

--- a/packages/vulcan-ui-material/lib/components/theme/ThemeProvider.jsx
+++ b/packages/vulcan-ui-material/lib/components/theme/ThemeProvider.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { registerComponent } from 'meteor/vulcan:core';
+import { getCurrentTheme } from '../../modules/';
+import { ThemeProvider } from '@material-ui/core/styles';
+import JssCleanup from './JssCleanup';
+
+const AppThemeProvider = ({ children }) => {
+  const theme = getCurrentTheme();
+  return (
+    <ThemeProvider theme={theme}>
+      <JssCleanup>{children}</JssCleanup>
+    </ThemeProvider>
+  );
+};
+
+registerComponent('ThemeProvider', AppThemeProvider);

--- a/packages/vulcan-ui-material/lib/server/wrapWithMuiTheme.jsx
+++ b/packages/vulcan-ui-material/lib/server/wrapWithMuiTheme.jsx
@@ -1,33 +1,24 @@
 import React from 'react';
-import { addCallback } from 'meteor/vulcan:core';
-import {
-  ServerStyleSheets,
-  ThemeProvider,
-} from '@material-ui/core/styles';
-import { getCurrentTheme } from '../modules/themes';
-import JssCleanup from '../components/theme/JssCleanup';
+import { addCallback, Components } from 'meteor/vulcan:core';
+import { ServerStyleSheets } from '@material-ui/core/styles';
 
-function wrapWithMuiTheme(app, { context }) {
+function wrapWithMuiTheme(app, { context, apolloClient }) {
   // will spawn a StylesProvider automatically during render
   // replaces the manual setup of JSSProvider
   // @see https://github.com/mui-org/material-ui/blob/master/packages/material-ui-styles/src/ServerStyleSheets/ServerStyleSheets.js
   const sheets = new ServerStyleSheets({ disableGeneration: true });
   context.sheetsRegistry = sheets;
 
-  const theme = getCurrentTheme();
-
   return sheets.collect(
-    <ThemeProvider theme={theme}>
-      <JssCleanup>{app}</JssCleanup>
-    </ThemeProvider>
+    <Components.ThemeProvider apolloClient={apolloClient} context={context}>
+      {app}
+    </Components.ThemeProvider>
   );
 }
 
-function wrapWithMuiStyleGenerator(app, { context }) {
+function wrapWithMuiStyleGenerator(app, { context, apolloClient }) {
   const sheets = new ServerStyleSheets();
   context.sheetsRegistry = sheets;
-
-  const theme = getCurrentTheme();
 
   // NOTE: The sheets.collect API does not allow to pass a seed
   // do we still need to force a specific seed?
@@ -36,9 +27,9 @@ function wrapWithMuiStyleGenerator(app, { context }) {
   //const generateClassName = createGenerateClassName({ seed: '' });
 
   return sheets.collect(
-    <ThemeProvider theme={theme}>
-      <JssCleanup>{app}</JssCleanup>
-    </ThemeProvider>
+    <Components.ThemeProvider apolloClient={apolloClient} context={context}>
+      {app}
+    </Components.ThemeProvider>
   );
 }
 

--- a/packages/vulcan-ui-material/package.js
+++ b/packages/vulcan-ui-material/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'vulcan:ui-material',
-  version: '1.16.0_2',
+  version: '1.16.0_3',
   summary: 'Replacement for Vulcan (http://vulcanjs.org/) components using material-ui',
   documentation: 'README.md',
 });


### PR DESCRIPTION
Also pass context on serverside.

The Client version of wrapWithMuiTheme was using Components.ThemeProvider while the server version was using the default ThemeProvider, so you could overwrite it client-side but not server-side. 
I introduced this three years ago in a [PR to ErikDakoda's package](https://github.com/ErikDakoda/vulcan-material-ui/pull/30)).

Now both the server and the client ThemeProvider uses the Components system, so they can be overwritten. The implementation for the default ThemeProvider was the same on client and server, so I implemented it directly in the `components/theme` folder which is common to both server and client environments.
Also, I add the `apolloClient` prop that lets you query data right inside the ThemeProvider to be able to have a dynamic theme depending on a graphql query. We need it because the ThemeProvider is higher than the ApolloClientProvider in the react tree, so a `useQuery` would not have the context for it.

Here is an example of dynamic ThemeProvider:

```jsx
const CustomThemeProvider = ({ children, apolloClient }) => {
  const { data } = useQuery(currentThemeQuery, { client: apolloClient });
  const primaryColor = data?.currentTheme?.primaryColor || DEFAULT_PRIMARY_COLOR;
  const secondaryColor = data?.currentTheme?.secondaryColor || DEFAULT_SECONDARY_COLOR;

  const memoizedTheme = useMemo(() => {
    return createTheme({ primaryColor, secondaryColor });
  }, [primaryColor, secondaryColor]);

  return (
    <ThemeProvider theme={memoizedTheme}>
      <JssCleanup>{children}</JssCleanup>
    </ThemeProvider>
  );
};
```
