### PR TITLE
Aggregation

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/create.js
+++ b/packages/vulcan-core/lib/modules/containers/create.js
@@ -1,9 +1,9 @@
 /*
 
 Generic mutation wrapper to insert a new document in a collection and update
-a related query on the client with the new item and a new total item count. 
+a related query on the client with the new item and a new total item count.
 
-Sample mutation: 
+Sample mutation:
 
   mutation createMovie($data: CreateMovieData) {
     createMovie(data: $data) {
@@ -16,14 +16,14 @@ Sample mutation:
     }
   }
 
-Arguments: 
+Arguments:
 
   - data: the document to insert
 
 Child Props:
 
   - createMovie({ data })
-    
+
 */
 
 import React from 'react';
@@ -55,7 +55,7 @@ export const multiQueryUpdater = ({
   const multiResolverName = collection.options.multiResolverName;
   // update multi queries
   const multiQuery = buildMultiQuery({ typeName, fragmentName, fragment });
-  const newDoc = data[resolverName].data;
+  const newDoc = data[resolverName]?.data;
   // get all the resolvers that match
   const variablesList = getVariablesListFromCache(cache, multiResolverName);
   variablesList.forEach(async variables => {

--- a/packages/vulcan-lib/lib/modules/graphql/defaultFragment.js
+++ b/packages/vulcan-lib/lib/modules/graphql/defaultFragment.js
@@ -2,80 +2,83 @@
  * Generates the default fragment for a collection
  * = a fragment containing all fields
  */
-import { getFragmentFieldNames } from '../schema_utils';
+import { getFragmentFieldNames, createSchema } from '../schema_utils';
 import { isBlackbox } from '../simpleSchema_utils';
+import { registerFragment } from '../fragments.js';
+
 
 const intlSuffix = '_intl';
 
 // get fragment for a whole object (root schema or nested schema of an object or an array)
-const getObjectFragment = ({
-    schema,
-    fragmentName,
-    options
+export const getObjectFragment = ({
+  schema,
+  fragmentName,
+  options,
 }) => {
-    const fieldNames = getFragmentFieldNames({ schema, options });
-    const childFragments = fieldNames.length && fieldNames.map(fieldName => getFieldFragment({
-        schema,
-        fieldName,
-        options,
-        getObjectFragment: getObjectFragment
-    }))
-        // remove empty values
-        .filter(f => !!f);
-    if (childFragments.length) {
-        return `${fragmentName} { ${childFragments.join('\n')} }`;
-    }
-    return null;
+  const fieldNames = getFragmentFieldNames({ schema, options });
+  const childFragments = fieldNames.length && fieldNames.map(fieldName => getFieldFragment({
+    schema,
+    fieldName,
+    options,
+    getObjectFragment: getObjectFragment,
+  }))
+  // remove empty values
+  .filter(f => !!f);
+  if (childFragments.length) {
+    return `${fragmentName} { ${childFragments.join('\n')} }`;
+  }
+  return null;
 };
 
 // get fragment for a specific field (either the field name or a nested fragment)
 export const getFieldFragment = ({
-    schema,
-    fieldName,
-    options,
-    getObjectFragment = getObjectFragment // a callback to call on nested schema
+  schema,
+  fieldName,
+  options,
+  getObjectFragment = getObjectFragment, // a callback to call on nested schema
 }) => {
-    // intl
-    if (fieldName.slice(-5) === intlSuffix) {
-        return `${fieldName}{ locale value }`;
-    }
-    if (fieldName === '_id') return fieldName;
-    const field = schema[fieldName];
+  // intl
+  if (fieldName.slice(-5) === intlSuffix) {
+    return `${fieldName}{ locale value }`;
+  }
+  if (fieldName === '_id') return fieldName;
+  const field = schema[fieldName];
 
-    const fieldType = field.type.singleType;
-    const fieldTypeName =
-        typeof fieldType === 'object' ? 'Object' : typeof fieldType === 'function' ? fieldType.name : fieldType;
+  const fieldType = field.type.singleType;
+  const fieldTypeName =
+    typeof fieldType === 'object' ? 'Object' : typeof fieldType === 'function' ? fieldType.name : fieldType;
 
-    switch (fieldTypeName) {
-        case 'Object':
-            if (!isBlackbox(field) && fieldType._schema) {
-                return getObjectFragment({
-                    fragmentName: fieldName,
-                    schema: fieldType._schema,
-                    options
-                }) || null;
-            }
-            return fieldName;
-        case 'Array':
-            const arrayItemFieldName = `${fieldName}.$`;
-            const arrayItemField = schema[arrayItemFieldName];
-            // note: make sure field has an associated array item field
-            if (arrayItemField) {
-                // child will either be native value or a an object (first case)
-                const arrayItemFieldType = arrayItemField.type.singleType;
-                if (!isBlackbox(field) && arrayItemFieldType._schema) {
-                    return getObjectFragment({
-                        fragmentName: fieldName,
-                        schema: arrayItemFieldType._schema,
-                        options
-                    }) || null;
-                }
-            }
-            return fieldName;
-        default:
-            return fieldName; // fragment = fieldName
-    }
+  switch (fieldTypeName) {
+    case 'Object':
+      if (!isBlackbox(field) && fieldType._schema) {
+        return getObjectFragment({
+          fragmentName: fieldName,
+          schema: fieldType._schema,
+          options,
+        }) || null;
+      }
+      return fieldName;
+    case 'Array':
+      const arrayItemFieldName = `${fieldName}.$`;
+      const arrayItemField = schema[arrayItemFieldName];
+      // note: make sure field has an associated array item field
+      if (arrayItemField) {
+        // child will either be native value or a an object (first case)
+        const arrayItemFieldType = arrayItemField.type.singleType;
+        if (!isBlackbox(field) && arrayItemFieldType._schema) {
+          return getObjectFragment({
+            fragmentName: fieldName,
+            schema: arrayItemFieldType._schema,
+            options,
+          }) || null;
+        }
+      }
+      return fieldName;
+    default:
+      return fieldName; // fragment = fieldName
+  }
 };
+
 
 /*
 
@@ -83,12 +86,42 @@ Create default "dumb" gql fragment object for a given collection
 
 */
 export const getDefaultFragmentText = (collection, options = { onlyViewable: true }) => {
-    const schema = collection.simpleSchema()._schema;
-    return getObjectFragment({
-        schema,
-        fragmentName: `fragment ${collection.options.collectionName}DefaultFragment on ${collection.typeName}`,
-        options
-    }) || null;
+  const schema = collection.simpleSchema()._schema;
+  return getObjectFragment({
+    schema,
+    fragmentName: `fragment ${collection.options.collectionName}DefaultFragment on ${collection.typeName}`,
+    options,
+  }) || null;
 };
 
 export default getDefaultFragmentText;
+
+
+/**
+ * Generates and registers a default fragment for a typeName registered using `registerCustomQuery()`
+ * @param {string} typeName The GraphQL Type registered using `registerCustomQuery()`
+ * @param {Object|SimpleSchema} [schema] Schema definition object to convert to a fragment
+ * @param {String} [fragmentName] The fragment's name; if omitted `${typeName}DefaultFragment` will be used
+ * @param {[String]} [defaultCanRead] Fields in the schema without `canRead` will be assigned these read permissions
+ * @param {Object} options Options sent to `getObjectFragment()`
+ */
+export const registerCustomDefaultFragment = function ({
+                                                         typeName,
+                                                         schema,
+                                                         fragmentName,
+                                                         defaultCanRead,
+                                                         options = { onlyViewable: true },
+                                                       }) {
+  const simpleSchema = createSchema(schema, undefined, undefined, defaultCanRead);
+  schema = simpleSchema._schema;
+
+  fragmentName = fragmentName || `${typeName}DefaultFragment`;
+
+  const defaultFragment = getObjectFragment({
+    schema,
+    fragmentName: `fragment ${fragmentName} on ${typeName}`,
+    options,
+  });
+
+  if (defaultFragment) registerFragment(defaultFragment);
+};

--- a/packages/vulcan-lib/lib/modules/graphql_templates/types.js
+++ b/packages/vulcan-lib/lib/modules/graphql_templates/types.js
@@ -46,7 +46,7 @@ type Movie{
 */
 export const mainTypeTemplate = ({ typeName, description, interfaces, fields }) =>
   `${description ? `# ${description}` : ''}
-type ${typeName} ${interfaces.length ? `implements ${interfaces.join(', ')} ` : ''}{
+type ${typeName} ${interfaces?.length ? `implements ${interfaces.join(', ')} ` : ''}{
 ${convertToGraphQL(fields, '  ')}
 }
 `;

--- a/packages/vulcan-lib/lib/server/graphql/index.js
+++ b/packages/vulcan-lib/lib/server/graphql/index.js
@@ -1,2 +1,4 @@
 export * from './graphql';
+export * from './registerCustomQuery';
+export * from './schemaFields';
 export * from './typedefs';

--- a/packages/vulcan-lib/lib/server/graphql/registerCustomQuery.js
+++ b/packages/vulcan-lib/lib/server/graphql/registerCustomQuery.js
@@ -1,0 +1,102 @@
+import { createSchema } from '../../modules/schema_utils.js';
+import { getSetting } from '../../modules/settings.js';
+import { debug, debugGroup, debugGroupEnd } from '../../modules/debug.js';
+import { addGraphQLQuery, addGraphQLResolvers, GraphQLSchema } from './graphql.js';
+import { getSchemaFields } from './schemaFields';
+import {
+  multiInputType,
+  multiOutputType,
+  multiQueryType,
+  mainTypeTemplate,
+  multiInputTemplate,
+  multiOutputTemplate,
+  fieldFilterInputTemplate,
+  fieldSortInputTemplate,
+} from '../../modules/graphql_templates/index.js';
+
+
+/**
+ * Registers a custom Q
+ * @param typeName
+ * @param description
+ * @param resolver
+ * @param filterable
+ * @param defaultCanRead
+ * @param schema
+ * @param graphQLType
+ * @return {{totalCount, results}}
+ */
+export const registerCustomQuery = function ({ typeName,
+                                                  description,
+                                                  resolver,
+                                                  filterable,
+                                                  defaultCanRead,
+                                                  schema,
+                                                  graphQLType = null }) {
+  if (!schema && !graphQLType) {
+    throw new Error(`When registering ${typeName}, ` +
+      `you must pass either schema or graphQLType to registerCustomQuery()`);
+  }
+
+  const aggregate = {
+
+    name: typeName,
+
+    description,
+
+    async resolver(root, args, context, info) {
+      const { input = {} } = args;
+      const { enableCache = false } = input;
+      const { cacheControl } = info;
+
+      debug('');
+      debugGroup(`------------- start \x1b[35m${typeName}\x1b[0m resolver -------------`);
+      debug(`Input: ${JSON.stringify(input)}`);
+
+      if (cacheControl && enableCache) {
+        const maxAge = getSetting('graphQL.cacheMaxAge');
+        cacheControl.setCacheHint({ maxAge });
+      }
+
+      const { results, totalCount } = await resolver(root, args, context, info);
+
+      debug(`\x1b[33m=> ${results.length} of ${totalCount} documents returned\x1b[0m`);
+      debugGroupEnd();
+      debug(`------------- end \x1b[35m${typeName}\x1b[0m resolver -------------`);
+      debug('');
+
+      // return results
+      return { results, totalCount };
+    },
+
+  };
+
+  if (schema) {
+    const simpleSchema = createSchema(schema, undefined, undefined, defaultCanRead);
+    schema = simpleSchema._schema;
+    const schemaFields = getSchemaFields(schema, typeName);
+    graphQLType = graphQLType || mainTypeTemplate({
+      typeName,
+      fields: schemaFields.fields.readable,
+      description,
+    });
+  }
+
+  const graphQLSchemas = [];
+  graphQLSchemas.push(graphQLType);
+  graphQLSchemas.push(fieldFilterInputTemplate({ typeName, fields: filterable }));
+  graphQLSchemas.push(fieldSortInputTemplate({ typeName, fields: filterable }));
+  graphQLSchemas.push(multiInputTemplate({ typeName }));
+  graphQLSchemas.push(multiOutputTemplate({ typeName }));
+
+  const graphQLSchema = graphQLSchemas.join('\n');
+  GraphQLSchema.addSchema(graphQLSchema);
+
+  addGraphQLQuery(`${multiQueryType(typeName)}(input: ${multiInputType(typeName)}): ${multiOutputType(typeName)}`);
+  addGraphQLResolvers({
+    Query: {
+      [multiQueryType(typeName)]: aggregate.resolver.bind(aggregate),
+    },
+  });
+
+};


### PR DESCRIPTION
 * This PR enables you to query data on the server with a schema that does not match a database collection - for example an aggregation or an array of objects
 * PR for the documentation is [here](https://github.com/VulcanJS/vulcan-docs/pull/169)
 * Added new function `registerCustomQuery()`, to add a custom GraphQL type generated from a schema object and a resolver to query the data
 * Added new function `registerCustomDefaultFragment()`, to generate a default fragment from the same schema
 * Updated `multi2` to be compatible with custom queries - you can now specify a `typeName` instead of a `collection`
 * Updated `createSchema()` to support [SimpleSchema Shorthand Definitions](https://github.com/aldeed/simpl-schema#shorthand-definitions)
 * Added `defaultCanRead` parameter to `createSchema()`